### PR TITLE
Add documentation on how the CI/CD works

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ sequenceDiagram
     participant GH as elife-xpub (github)
     participant DH as docker-hub
     participant JK as Jenkins
-    participant WEB as demo--xpub (website)
+    participant WEB as elife-xpub--demo
 
     activate GL
     Note over GL: Build

--- a/README.md
+++ b/README.md
@@ -43,3 +43,36 @@ docker-compose up
 ```
 
 Visit the web interface at [http://localhost:3000].
+
+Build
+=====
+
+The following [sequence-diagram](https://mermaidjs.github.io/sequenceDiagram.html) shows how the building of this project is triggered from `xpub-elife` to the deployment on the [demo website](https://demo--xpub.elifesciences.org/login)
+
+```mermaid
+sequenceDiagram
+    participant GL as xpub-elife (gitlab)
+    participant GH as elife-xpub (github)
+    participant DH as docker-hub
+    participant JK as Jenkins
+    participant WEB as demo--xpub (website)
+
+    activate GL
+    Note over GL: Build
+    GL ->> DH: docker-push
+    deactivate GL
+    DH ->> JK: hook
+
+    activate JK
+    Note over JK: dependencies-elife-xpub-update-xpub
+    JK ->> GH: update container version
+    deactivate JK
+
+    GH ->> JK: hook
+
+    activate JK
+    Note over JK: test-elife-xpub
+    JK ->> WEB: deploy
+    deactivate JK
+
+```


### PR DESCRIPTION
This does not render on github but should do so in a markdown preview in Atom or similar.