### PR TITLE
fix(ci): update docker host for kubernetes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
   DOCKER_DRIVER: overlay2
-  DOCKER_HOST: tcp://docker:2375/
+  DOCKER_HOST: tcp://localhost:2375/
   IMAGE_ORG: xpub
   IMAGE_NAME: xpub-elife
   BASE_DOMAIN: gateway.xpub.semioticsquares.com


### PR DESCRIPTION
will hopefully fix:

```
error during connect: Get http://docker:2375/v1.37/version: dial tcp: lookup docker on 100.64.0.10:53: no such host
```