### PR TITLE
fix(ci): change PG_HOST for k8s

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ test:
   script:
     - cd ${HOME}
     # specify host here else it confuses the linked postgres image
-    - PGHOST=postgres npm test
+    - PGHOST=localhost npm test
 
 test:e2e:
   image: $IMAGE_ORG/$IMAGE_NAME:$CI_COMMIT_SHA
@@ -75,7 +75,7 @@ test:e2e:
   script:
     - cd ${HOME}
     # specify host here else it confuses the linked postgres image
-    - PGHOST=postgres npm run test:e2e
+    - PGHOST=localhost npm run test:e2e
 
 push:latest:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ test:
   script:
     - cd ${HOME}
     # specify host here else it confuses the linked postgres image
-    - PGHOST=localhost npm test
+    - PGHOSTADDR=127.0.0.1 npm test
 
 test:e2e:
   image: $IMAGE_ORG/$IMAGE_NAME:$CI_COMMIT_SHA
@@ -75,7 +75,8 @@ test:e2e:
   script:
     - cd ${HOME}
     # specify host here else it confuses the linked postgres image
-    - PGHOST=localhost npm run test:e2e
+    - export PGHOSTADDR=127.0.0.1
+    - npm run test:e2e
 
 push:latest:
   image: docker:latest


### PR DESCRIPTION
ugh: https://gitlab.com/gitlab-org/gitlab-runner/issues/2229

will hopefully fix:

```
Submission › createSubmission › adds new manuscript to the db for current user with stage INITIAL

    getaddrinfo ENOTFOUND postgres postgres:5432
```