### PR TITLE
fix(dropzone-molecule): fix react-dropzone warning about accepted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react": "^16.2.0",
     "react-apollo": "^2.1.2",
     "react-dom": "^16.2.0",
-    "react-dropzone": "^4.2.9",
+    "react-dropzone": "^4.2.11",
     "react-hot-loader": "^4.1.2",
     "react-router-dom": "^4.2.2",
     "recompose": "^0.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8653,9 +8653,9 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-dropzone@^4.2.9:
-  version "4.2.9"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-4.2.9.tgz#98156ce4d4cb018f7c5099eeb2eaff6dc21836fd"
+react-dropzone@^4.2.11:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-4.2.11.tgz#c20ff6a62634c5803bed5f292ef1bd4b3e1f90c3"
   dependencies:
     attr-accept "^1.0.3"
     prop-types "^15.5.7"


### PR DESCRIPTION
#### Background

Second page of submission was giving a warning like this

```
Warning: Failed prop type: Invalid prop `accept` of type `array` supplied to `Dropzone`, expected `string`.
```

The `accept` prop from react-dropzone doesn't accept an array of strings, but apparently it works with a string of comma separated values: https://github.com/react-dropzone/react-dropzone/pull/142

#### How has this been tested?

Reloaded page 2 of submission, no more warnings. Also, I uploaded a docx, pdf and png files and it accepted the first 2 but not the last one.