### PR TITLE
Enable debug logging for development builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN yarn install --frozen-lockfile \
     && yarn cache clean \
     && rm -rf /npm-packages-offline-cache
 
-COPY app.js .babelrc .eslintignore .eslintrc .prettierrc .stylelintignore .stylelintrc ./
+COPY .babelrc .eslintignore .eslintrc .prettierrc .stylelintignore .stylelintrc ./
 
 COPY app app
 COPY config config

--- a/Dockerfile-development
+++ b/Dockerfile-development
@@ -2,7 +2,7 @@ FROM xpub/xpub:base
 
 WORKDIR ${HOME}
 
-COPY package.json yarn.lock app.js .babelrc .eslintignore .eslintrc .prettierrc .stylelintignore .stylelintrc ./
+COPY package.json yarn.lock .babelrc .eslintignore .eslintrc .prettierrc .stylelintignore .stylelintrc ./
 COPY static static
 COPY webpack webpack
 COPY config config

--- a/app.js
+++ b/app.js
@@ -1,7 +1,0 @@
-const logger = require('@pubsweet/logger')
-const startServer = require('pubsweet-server')
-
-startServer().catch(err => {
-  logger.error('FATAL ERROR, SHUTTING DOWN:', err)
-  process.exit(1)
-})

--- a/config/development.js
+++ b/config/development.js
@@ -1,4 +1,7 @@
 const { deferConfig } = require('config/defer')
+const winston = require('winston')
+
+winston.level = 'debug'
 
 module.exports = {
   'pubsweet-server': {

--- a/server/submission/resolvers.js
+++ b/server/submission/resolvers.js
@@ -1,6 +1,7 @@
 const lodash = require('lodash')
 const config = require('config')
 const User = require('pubsweet-server/src/models/User')
+const logger = require('@pubsweet/logger')
 const request = require('request-promise-native')
 const { promisify } = require('util')
 const xml2js = require('xml2js')
@@ -65,7 +66,7 @@ const resolvers = {
       const newManuscript = lodash.merge({}, manuscript, data)
       const newManuscriptDb = db.manuscriptGqlToDb(newManuscript, ctx.user)
       await db.update(newManuscriptDb, data.id)
-
+      logger.debug(`Updated Submission ${data.id} by user ${ctx.user}`)
       return newManuscript
     },
 


### PR DESCRIPTION
#### Background

Enables debug logging when running in development. Also removed "app.js" as its not used.

#### Any relevant tickets
None

#### How has this been tested?
Yes, locally ran test and built the docker containers