### PR TITLE
fix: use key to force remount of formik component on each page

### DIFF
--- a/app/components/submission/ReviewerSuggestions/ReviewerSuggestionsSchema.js
+++ b/app/components/submission/ReviewerSuggestions/ReviewerSuggestionsSchema.js
@@ -21,7 +21,7 @@ const suggestedReviewerValidator = () =>
       email: yup
         .string()
         .email('Must be a valid email')
-        .required(),
+        .required('Email is required'),
     }),
   )
 


### PR DESCRIPTION
#### Background

Moving from individual form instances to a single form instance for the whole submission form had the side effect of persisting field "touched" status across steps in the wizard. This manifested itself as a bug which caused validation errors for all fields to be displayed as soon as any field was blurred. 

See #188 

#### How has this been tested?

Locally, manually.