### PR TITLE
ci: enable test coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     ]
   },
   "jest": {
+    "collectCoverage": true,
     "projects": [
       "<rootDir>/client",
       "<rootDir>/app",


### PR DESCRIPTION
#### Background

Jest previously had a bug relating to coverage reporting when using the projects feature. This appears to have been resolved.

This enables coverage reporting in Jest. The config in Gitlab CI has been update to parse the reported coverage figure. It remains to be seen how to get this displayed on the GitHub PR. 

#### How has this been tested?

This PR is the test.