### PR TITLE
195 subject area dropdown tests

### DIFF
--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -66,10 +66,6 @@ describe('SubjectAreaDropdown component', () => {
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
       expect(wrapper.find('MultiValue')).toHaveLength(2)
       expect(wrapper.find('ValueContainer').html()).toContain('Cancer Biology')
-
-      // selectWrapper.props().onInputChange('E')
-      // selectInput.simulate('change')
-      // expect(wrapper.contains('Menu')).toBe(false)
     })
 
     it('selecting 2 options disables further selection', () => {

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -20,11 +20,9 @@ const MyDropdown = (
 describe('SubjectAreaDropdown component', () => {
   it('renders label & select', () => {
     const wrapper = shallow(MyDropdown).dive() // dive is necessary because SubjectAreaDropdown is wrapped by withTheme
-    expect(wrapper.contains('My label')).toBe(true)
-    expect(wrapper.find('[inputId="subject-area-select"]').exists()).toEqual(
-      true,
-    )
-    expect(wrapper.contains('No more than two subject areas')).toBe(false)
+    expect(wrapper.html()).toContain('My label')
+    expect(wrapper.find('[inputId="subject-area-select"]').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('No more than two subject areas')
   })
 
   describe('Integration with react-select', () => {
@@ -46,7 +44,7 @@ describe('SubjectAreaDropdown component', () => {
 
     it('focusing causes the dropdown to open & display every option', () => {
       typeSubjectArea('') // typing nothing into the field seems to be the only way to programmatically focus react-select)
-      expect(wrapper.find('Menu').exists()).toEqual(true)
+      expect(wrapper.find('Menu').exists()).toBe(true)
       expect(wrapper.find('Option')).toHaveLength(17)
     })
 
@@ -54,13 +52,11 @@ describe('SubjectAreaDropdown component', () => {
       typeSubjectArea('b')
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
       expect(onChange.mock.calls).toHaveLength(1)
-      expect(wrapper.find('Menu').exists()).toEqual(false)
+      expect(wrapper.find('Menu').exists()).toBe(false)
       expect(wrapper.find('MultiValue')).toHaveLength(1) // MultiValue = a "tag" (i.e. selected option) in react-select
-      expect(
-        wrapper
-          .find('MultiValue')
-          .contains('Biochemistry and Chemical Biology'),
-      ).toBe(true)
+      expect(wrapper.find('ValueContainer').html()).toContain(
+        'Biochemistry and Chemical Biology',
+      )
     })
 
     it('2 options can be selected from the dropdown', () => {
@@ -69,7 +65,7 @@ describe('SubjectAreaDropdown component', () => {
       typeSubjectArea('c')
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
       expect(wrapper.find('MultiValue')).toHaveLength(2)
-      expect(wrapper.find('MultiValue').contains('Cancer Biology')).toBe(true)
+      expect(wrapper.find('ValueContainer').html()).toContain('Cancer Biology')
 
       // selectWrapper.props().onInputChange('E')
       // selectInput.simulate('change')
@@ -81,7 +77,7 @@ describe('SubjectAreaDropdown component', () => {
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
       typeSubjectArea('c')
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
-      expect(wrapper.contains('DropdownIndicator')).toBe(false)
+      expect(wrapper.text()).not.toContain('DropdownIndicator')
     })
 
     it('selection/deselection of 2 items triggers success message to show/hide', () => {
@@ -89,12 +85,12 @@ describe('SubjectAreaDropdown component', () => {
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
       typeSubjectArea('c')
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
-      expect(wrapper.contains('No more than two subject areas')).toBe(true)
+      expect(wrapper.text()).toContain('No more than two subject areas')
 
       const crossOnFirstTag = wrapper.find('MultiValueRemove').at(0)
       crossOnFirstTag.simulate('click')
       expect(wrapper.find('MultiValue')).toHaveLength(1)
-      expect(wrapper.contains('No more than two subject areas')).toBe(false)
+      expect(wrapper.text()).not.toContain('No more than two subject areas')
     })
 
     it('typing filters list of options based on first letter(s)', () => {

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -19,7 +19,8 @@ const MyDropdown = (
 
 describe('SubjectAreaDropdown component', () => {
   it('renders label & select', () => {
-    const wrapper = shallow(MyDropdown).dive() // dive is necessary because SubjectAreaDropdown is wrapped by withTheme
+    // dive is necessary because SubjectAreaDropdown is wrapped by withTheme
+    const wrapper = shallow(MyDropdown).dive()
     expect(wrapper.html()).toContain('My label')
     expect(wrapper.find('[inputId="subject-area-select"]').exists()).toBe(true)
     expect(wrapper.text()).not.toContain('No more than two subject areas')
@@ -43,7 +44,8 @@ describe('SubjectAreaDropdown component', () => {
     }
 
     it('focusing causes the dropdown to open & display every option', () => {
-      typeSubjectArea('') // typing nothing into the field seems to be the only way to programmatically focus react-select)
+      // typing nothing into the field seems to be the only way to programmatically focus react-select)
+      typeSubjectArea('')
       expect(wrapper.find('Menu').exists()).toBe(true)
       expect(wrapper.find('Option')).toHaveLength(17)
     })
@@ -53,7 +55,8 @@ describe('SubjectAreaDropdown component', () => {
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
       expect(onChange.mock.calls).toHaveLength(1)
       expect(wrapper.find('Menu').exists()).toBe(false)
-      expect(wrapper.find('MultiValue')).toHaveLength(1) // MultiValue = a "tag" (i.e. selected option) in react-select
+      // MultiValue = a "tag" (i.e. selected option) in react-select
+      expect(wrapper.find('MultiValue')).toHaveLength(1)
       expect(wrapper.find('ValueContainer').html()).toContain(
         'Biochemistry and Chemical Biology',
       )

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -4,15 +4,15 @@ import theme from '@elifesciences/elife-theme'
 
 import SubjectAreaDropdown from './SubjectAreaDropdown'
 
-const onChange = jest.fn()
-const onBlur = jest.fn()
+const handleChange = jest.fn()
+const handleBlur = jest.fn()
 
 const MyDropdown = (
   <SubjectAreaDropdown
     label="My label"
     name="My name"
-    onBlur={onBlur}
-    onChange={onChange}
+    onBlur={handleBlur}
+    onChange={handleChange}
     savedValues={[]}
     theme={theme}
   />
@@ -55,7 +55,7 @@ describe('SubjectAreaDropdown component', () => {
     it('an option can be selected from the dropdown', () => {
       typeSubjectArea('b')
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
-      expect(onChange.mock.calls).toHaveLength(1)
+      expect(handleChange.mock.calls).toHaveLength(1)
       // MultiValue = a "tag" (i.e. selected option) in react-select
       expect(wrapper.find('MultiValue')).toHaveLength(1)
       expect(wrapper.find('ValueContainer').html()).toContain(

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -5,12 +5,13 @@ import theme from '@elifesciences/elife-theme'
 import SubjectAreaDropdown from './SubjectAreaDropdown'
 
 const onChange = jest.fn()
+const onBlur = jest.fn()
 
 const MyDropdown = (
   <SubjectAreaDropdown
     label="My label"
     name="My name"
-    onBlur={jest.fn()}
+    onBlur={onBlur}
     onChange={onChange}
     savedValues={[]}
     theme={theme}

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-import theme from '@pubsweet/elife-theme'
+import theme from '@elifesciences/elife-theme'
 
 import SubjectAreaDropdown from './SubjectAreaDropdown'
 

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import theme from '@pubsweet/elife-theme'
 
 import SubjectAreaDropdown from './SubjectAreaDropdown'
@@ -18,8 +18,103 @@ const MyDropdown = (
 )
 
 describe('SubjectAreaDropdown component', () => {
-  it('renders default form', () => {
+  it('renders label & select', () => {
     const wrapper = shallow(MyDropdown).dive() // dive is necessary because SubjectAreaDropdown is wrapped by withTheme
     expect(wrapper.contains('My label')).toBe(true)
+    expect(wrapper.find('[inputId="subject-area-select"]').exists()).toEqual(
+      true,
+    )
+    expect(wrapper.contains('No more than two subject areas')).toBe(false)
+  })
+
+  describe('Integration with react-select', () => {
+    let wrapper, selectWrapper, selectInput
+
+    beforeEach(() => {
+      wrapper = mount(MyDropdown)
+      selectWrapper = wrapper.find('Select')
+      selectInput = selectWrapper.find('input')
+    })
+
+    const typeSubjectArea = letters => {
+      // We need 2 steps to programmatically simulate typing in a letter
+      // 1. Add a letter to the value of the input field (does not cause the dropdown to appear by itself)
+      selectWrapper.props().onInputChange(letters)
+      // 2. Open the dropdown
+      selectInput.simulate('change')
+    }
+
+    it('focusing causes the dropdown to open & display every option', () => {
+      typeSubjectArea('') // typing nothing into the field seems to be the only way to programmatically focus react-select)
+      expect(wrapper.find('Menu').exists()).toEqual(true)
+      expect(wrapper.find('Option')).toHaveLength(17)
+    })
+
+    it('an option can be selected from the dropdown', () => {
+      typeSubjectArea('b')
+      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
+      expect(onChange.mock.calls).toHaveLength(1)
+      expect(wrapper.find('Menu').exists()).toEqual(false)
+      expect(wrapper.find('MultiValue')).toHaveLength(1) // MultiValue = a "tag" (i.e. selected option) in react-select
+      expect(
+        wrapper
+          .find('MultiValue')
+          .contains('Biochemistry and Chemical Biology'),
+      ).toBe(true)
+    })
+
+    it('2 options can be selected from the dropdown', () => {
+      typeSubjectArea('b')
+      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
+      typeSubjectArea('c')
+      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
+      expect(wrapper.find('MultiValue')).toHaveLength(2)
+      expect(wrapper.find('MultiValue').contains('Cancer Biology')).toBe(true)
+
+      // selectWrapper.props().onInputChange('E')
+      // selectInput.simulate('change')
+      // expect(wrapper.contains('Menu')).toBe(false)
+    })
+
+    it('selecting 2 options disables further selection', () => {
+      typeSubjectArea('b')
+      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
+      typeSubjectArea('c')
+      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
+      expect(wrapper.contains('DropdownIndicator')).toBe(false)
+    })
+
+    it('selection/deselection of 2 items triggers success message to show/hide', () => {
+      typeSubjectArea('b')
+      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
+      typeSubjectArea('c')
+      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
+      expect(wrapper.contains('No more than two subject areas')).toBe(true)
+
+      const crossOnFirstTag = wrapper.find('MultiValueRemove').at(0)
+      crossOnFirstTag.simulate('click')
+      expect(wrapper.find('MultiValue')).toHaveLength(1)
+      expect(wrapper.contains('No more than two subject areas')).toBe(false)
+    })
+
+    it('typing filters list of options based on first letter(s)', () => {
+      typeSubjectArea('c')
+      const totalStartingWithC = wrapper.find('Option').length
+      expect(totalStartingWithC).toBeLessThan(17)
+      wrapper.find('Option').forEach(option => {
+        const optionText = option.childAt(0).text()
+        const wordStartsWithC = new RegExp(/^[cC]\w+/)
+        expect(optionText).toMatch(wordStartsWithC)
+      })
+
+      typeSubjectArea('ce')
+      const totalStartingWithCe = wrapper.find('Option').length
+      expect(totalStartingWithCe).toBeLessThan(totalStartingWithC)
+      wrapper.find('Option').forEach(option => {
+        const optionText = option.childAt(0).text()
+        const wordStartsWithCe = new RegExp(/^[ceCe]\w+/)
+        expect(optionText).toMatch(wordStartsWithCe)
+      })
+    })
   })
 })

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -95,20 +95,16 @@ describe('SubjectAreaDropdown component', () => {
 
     it('typing filters list of options based on first letter(s)', () => {
       typeSubjectArea('c')
-      const totalStartingWithC = wrapper.find('Option').length
-      expect(totalStartingWithC).toBeLessThan(17)
       wrapper.find('Option').forEach(option => {
         const optionText = option.childAt(0).text()
-        const wordStartsWithC = new RegExp(/^[cC]\w+/)
+        const wordStartsWithC = new RegExp(/^c/i)
         expect(optionText).toMatch(wordStartsWithC)
       })
 
       typeSubjectArea('ce')
-      const totalStartingWithCe = wrapper.find('Option').length
-      expect(totalStartingWithCe).toBeLessThan(totalStartingWithC)
       wrapper.find('Option').forEach(option => {
         const optionText = option.childAt(0).text()
-        const wordStartsWithCe = new RegExp(/^[ceCe]\w+/)
+        const wordStartsWithCe = new RegExp(/^ce/i)
         expect(optionText).toMatch(wordStartsWithCe)
       })
     })

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -56,7 +56,6 @@ describe('SubjectAreaDropdown component', () => {
       typeSubjectArea('b')
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
       expect(onChange.mock.calls).toHaveLength(1)
-      expect(wrapper.find('Menu').exists()).toBe(false)
       // MultiValue = a "tag" (i.e. selected option) in react-select
       expect(wrapper.find('MultiValue')).toHaveLength(1)
       expect(wrapper.find('ValueContainer').html()).toContain(
@@ -64,13 +63,11 @@ describe('SubjectAreaDropdown component', () => {
       )
     })
 
-    it('2 options can be selected from the dropdown', () => {
+    it('when an option is chosen, the menu closes', () => {
       typeSubjectArea('b')
-      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
-      typeSubjectArea('c')
-      selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
-      expect(wrapper.find('MultiValue')).toHaveLength(2)
-      expect(wrapper.find('ValueContainer').html()).toContain('Cancer Biology')
+      selectInput.simulate('keyDown', { keyCode: 13, key: 'Enter' })
+      expect(wrapper.find('Menu').exists()).toBe(false)
+      expect(wrapper.find('MultiValue')).toHaveLength(1)
     })
 
     it('selecting 2 options disables further selection', () => {

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import theme from '@pubsweet/elife-theme'
+
+import SubjectAreaDropdown from './SubjectAreaDropdown'
+
+const onChange = jest.fn()
+
+const MyDropdown = (
+  <SubjectAreaDropdown
+    label="My label"
+    name="My name"
+    onBlur={jest.fn()}
+    onChange={onChange}
+    savedValues={[]}
+    theme={theme}
+  />
+)
+
+describe('SubjectAreaDropdown component', () => {
+  it('renders default form', () => {
+    const wrapper = shallow(MyDropdown).dive() // dive is necessary because SubjectAreaDropdown is wrapped by withTheme
+    expect(wrapper.contains('My label')).toBe(true)
+  })
+})

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -70,7 +70,7 @@ describe('SubjectAreaDropdown component', () => {
       expect(wrapper.find('MultiValue')).toHaveLength(1)
     })
 
-    it('selecting 2 options disables further selection', () => {
+    it('dropdown indicator disappears when 2 options are selected', () => {
       typeSubjectArea('b')
       selectInput.simulate('keyDown', { keyCode: 9, key: 'Tab' })
       typeSubjectArea('c')

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.test.js
@@ -31,6 +31,7 @@ describe('SubjectAreaDropdown component', () => {
     let wrapper, selectWrapper, selectInput
 
     beforeEach(() => {
+      jest.clearAllMocks()
       wrapper = mount(MyDropdown)
       selectWrapper = wrapper.find('Select')
       selectInput = selectWrapper.find('input')


### PR DESCRIPTION
####  What does this PR do?
- simplest possible unit test - checking whether a few elements appear on the page when shallow rendered
- integration tests (SubjectAreaDropdown + component from react-select library)

Fixes #195 

#### Not tested
Validation messages - responsibility of `ValidatedField` component & overall page component

Struggling with `react-select` + enzyme. Cannot simulate click behaviour, which makes it difficult to test the following:
- When 2 options are selected -> disables the dropdown
- Given that 2 options are selected, when 1 option is deleted, then the dropdown is re-enabled