### PR TITLE
fix: don't wipe the main database when running the end-to-end tests

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -2,6 +2,7 @@ const { deferConfig } = require('config/defer')
 
 module.exports = {
   'pubsweet-server': {
+    db: { database: 'test' },
     port: 4000,
     baseUrl: deferConfig(
       cfg => `http://localhost:${cfg['pubsweet-server'].port}`,

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,8 +1,11 @@
 # Testing
 
+The tests require a running PostgreSQL instance with a database called `test`.
+
 ## Unit Tests
 
 From the root folder, run the following:
+
 ```
 npm run test
 ```
@@ -10,6 +13,7 @@ npm run test
 ## End-to-End Tests
 
 From the root folder, run the following:
+
 ```
 npm run test:e2e
 ```


### PR DESCRIPTION
#### Background

The end-to-end tests previously connected to the default database. They are configured to clear the database before running the tests which resulted in the main Postgres database being deleted on each test run. This is potentially very bad.

#### How has this been tested?

Manually, locally.