### PR TITLE
Replace vertical grid units with space

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -10,16 +10,6 @@ import theme from '@elifesciences/elife-theme'
 import Routes from './routes'
 import * as AuthorDetailsSchema from './components/submission/AuthorDetails/AuthorDetailsSchema'
 
-const pixelGridUnit = parseInt(theme.gridUnit, 10)
-theme.space = [
-  0,
-  pixelGridUnit / 4,
-  pixelGridUnit / 2,
-  pixelGridUnit,
-  pixelGridUnit * 2,
-  pixelGridUnit * 4,
-]
-
 const history = createHistory()
 const store = configureStore(history, {})
 

--- a/client/elife-theme/src/index.js
+++ b/client/elife-theme/src/index.js
@@ -1,6 +1,8 @@
 /* eslint-disable import/extensions */
 import './fonts/index.css'
 
+const gridUnit = 6
+
 export default {
   /* Colors */
   colorPrimary: '#0288d1',
@@ -40,7 +42,17 @@ export default {
   fontLineHeight6: '16px',
 
   /* Spacing */
-  gridUnit: '6px',
+  gridUnit: `${gridUnit}px`,
+  space: [
+    0,
+    gridUnit,
+    gridUnit * 2,
+    gridUnit * 4,
+    gridUnit * 6,
+    gridUnit * 8,
+    gridUnit * 12,
+    gridUnit * 20,
+  ],
 
   /* Border */
   borderRadius: '3px',

--- a/client/elife-theme/src/index.js
+++ b/client/elife-theme/src/index.js
@@ -41,13 +41,6 @@ export default {
 
   /* Spacing */
   gridUnit: '6px',
-  verticalXxl: 'gridUnit' * 20,
-  verticalXl: 'gridUnit' * 12,
-  verticalL: 'gridUnit' * 8,
-  verticalM: 'gridUnit' * 6,
-  verticalS: 'gridUnit' * 4,
-  verticalXs: 'gridUnit' * 2,
-  verticalXxs: 'gridUnit',
 
   /* Border */
   borderRadius: '3px',


### PR DESCRIPTION
#### What does this PR do?r
- replace them variables `verticalXxs`...`verticalXxl` with `space`
- remove `theme.space` from `app.js`, since it now already exists in the theme

#### Any relevant tickets
Fixes #236 