### PR TITLE
style(SubjectAreaDropdown): sub components of react-select to conform to new elife theme

### DIFF
--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -131,6 +131,14 @@ class SubjectAreaDropdown extends React.Component {
             : this.props.theme.colorText,
         padding: `${gridUnitValue * 2}px`,
       }),
+      control: (base, { isFocused }) => ({
+        ...base,
+        borderRadius: this.props.theme.borderRadius,
+        borderWidth: this.props.theme.borderWidth,
+        borderStyle: this.props.theme.borderStyle,
+        boxShadow: this.props.theme.boxShadow,
+        backgroundColor: this.props.theme.backgroundColor,
+      }),
     }
   }
 

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -109,6 +109,16 @@ class SubjectAreaDropdown extends React.Component {
         ...base,
         padding: 0,
       }),
+      menu: (base, { placement }) => ({
+        ...base,
+        borderRadius: `0 0 ${this.props.theme.borderRadius} ${
+          this.props.theme.borderRadius
+        }`,
+        borderWidth: this.props.theme.borderWidth,
+        marginBottom: 0,
+        // leave room for the bottom border of the Control component to be visible on validation/focus
+        marginTop: this.props.theme.borderWidth,
+      }),
       option: (base, { isSelected, isFocused }) => ({
         ...base,
         backgroundColor:

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -93,6 +93,16 @@ class SubjectAreaDropdown extends React.Component {
         ...base,
         padding: `${gridUnitValue / 2}px`, // combines with margin on multiValue to achieve gridUnit spacing around tags
       }),
+      placeholder: (base, state) => ({
+        ...base,
+        color: this.props.theme.colorText,
+        margin: `${gridUnitValue / 2}px`,
+        padding: `${gridUnitValue / 2}px`,
+      }),
+      input: (base, state) => ({
+        ...base,
+        padding: `${gridUnitValue / 2}px`,
+      }),
       multiValue: (base, state) => ({
         ...base,
         backgroundColor: this.props.theme.colorPrimary,
@@ -163,6 +173,7 @@ class SubjectAreaDropdown extends React.Component {
         },
         boxShadow: this.props.theme.boxShadow,
         backgroundColor: this.props.theme.backgroundColor,
+        minHeight: this.props.gridUnit,
       }),
     }
   }

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -112,8 +112,8 @@ class SubjectAreaDropdown extends React.Component {
         ...base,
         color: this.props.theme.colorTextReverse,
         fontSize: this.props.theme.fontSizeBase,
-        padding: this.props.theme.gridUnit,
-        paddingLeft: this.props.theme.gridUnit,
+        padding: '8px',
+        paddingLeft: '8px',
       }),
       multiValueRemove: (base, state) => ({
         ...base,

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -105,6 +105,18 @@ class SubjectAreaDropdown extends React.Component {
           color: this.props.theme.colorTextReverse,
         },
       }),
+      option: (base, { isSelected, isFocused }) => ({
+        ...base,
+        backgroundColor:
+          isSelected || isFocused
+            ? this.props.theme.colorPrimary
+            : 'transparent',
+        color:
+          isSelected || isFocused
+            ? this.props.theme.colorTextReverse
+            : this.props.theme.colorText,
+        padding: `${gridUnitValue * 2}px`,
+      }),
     }
   }
 

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -190,7 +190,7 @@ class SubjectAreaDropdown extends React.Component {
           ),
         },
         boxShadow: isFocused
-          ? `0 0 0 2pt ${chooseBorderColorFromProps(
+          ? `0 0 0 2px ${chooseBorderColorFromProps(
               this.props.theme,
               this.props.validationStatus,
               isFocused,

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -74,12 +74,18 @@ class SubjectAreaDropdown extends React.Component {
       hasReachedMultiselectLimit: false,
     }
 
+    const gridUnitValue = parseInt(this.props.theme.gridUnit, 10)
+
     this.customReactSelectStyles = {
+      valueContainer: (base, state) => ({
+        ...base,
+        padding: `${gridUnitValue / 2}px`, // combines with margin on multiValue to achieve gridUnit spacing around tags
+      }),
       multiValue: (base, state) => ({
         ...base,
         backgroundColor: this.props.theme.colorPrimary,
         color: this.props.theme.colorTextReverse,
-        margin: 0,
+        margin: `${gridUnitValue / 2}px`, // combines with padding on valueContainer to achieve gridUnit spacing around tags
       }),
       multiValueLabel: (base, state) => ({
         ...base,

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -78,6 +78,26 @@ class SubjectAreaDropdown extends React.Component {
       multiValue: (base, state) => ({
         ...base,
         backgroundColor: this.props.theme.colorPrimary,
+        color: this.props.theme.colorTextReverse,
+        margin: 0,
+      }),
+      multiValueLabel: (base, state) => ({
+        ...base,
+        color: this.props.theme.colorTextReverse,
+        fontSize: this.props.theme.fontSizeBase,
+        padding: this.props.theme.gridUnit,
+        paddingLeft: this.props.theme.gridUnit,
+      }),
+      multiValueRemove: (base, state) => ({
+        ...base,
+        padding: `0 ${this.props.theme.gridUnit} 0 0`,
+        backgroundColor: this.props.theme.colorPrimary,
+        ':hover': {
+          cursor: 'pointer',
+          // overriding react-select's default hover behaviour - changing colours
+          backgroundColor: this.props.theme.colorPrimary,
+          color: this.props.theme.colorTextReverse,
+        },
       }),
     }
   }

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -4,6 +4,8 @@ import styled, { withTheme } from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
 import Select, { createFilter } from 'react-select'
 
+import TagRemovalIcon from '../../ui/atoms/icons/TagRemovalIcon'
+
 const Root = styled.div`
   display: flex;
   flex-direction: column;
@@ -224,7 +226,11 @@ class SubjectAreaDropdown extends React.Component {
           <div>
             <Select
               {...selectChildProps}
-              components={{ ClearIndicator: null, DropdownIndicator: null }}
+              components={{
+                ClearIndicator: null,
+                DropdownIndicator: null,
+                MultiValueRemove: TagRemovalIcon,
+              }}
               isSearchable={false}
               menuIsOpen={false}
             />

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -221,6 +221,7 @@ class SubjectAreaDropdown extends React.Component {
     const selectChildProps = {
       components: {
         ClearIndicator: null,
+        IndicatorSeparator: null,
         MultiValueRemove: StyledTagRemovalIcon,
       },
       inputId: 'subject-area-select',
@@ -247,9 +248,8 @@ class SubjectAreaDropdown extends React.Component {
             <Select
               {...selectChildProps}
               components={{
-                ClearIndicator: null,
+                ...selectChildProps.components,
                 DropdownIndicator: null,
-                MultiValueRemove: StyledTagRemovalIcon,
               }}
               isSearchable={false}
               menuIsOpen={false}

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -6,23 +6,6 @@ import Select, { createFilter, components } from 'react-select'
 
 import Icon from '../../ui/atoms/Icon'
 
-const TagRemovalIcon = props => (
-  <components.MultiValueRemove {...props}>
-    {/* Icon requires a size, but width and height are more accurate and applied in styling below */}
-    <Icon size={3}>Cross</Icon>
-  </components.MultiValueRemove>
-)
-
-const StyledTagRemovalIcon = styled(TagRemovalIcon)`
-  svg {
-    stroke: ${props => props.theme.colorTextReverse};
-    fill: ${props => props.theme.colorTextReverse};
-    padding: 0;
-    width: 20px;
-    height: 20px;
-  }
-`
-
 const Root = styled.div`
   display: flex;
   flex-direction: column;
@@ -216,7 +199,26 @@ class SubjectAreaDropdown extends React.Component {
 
   render() {
     const { selectedOptions, hasReachedMultiselectLimit } = this.state
-    const { label, name, onBlur } = this.props
+    const { label, name, onBlur, theme } = this.props
+
+    const TagRemovalIcon = props => (
+        <components.MultiValueRemove {...props}>
+          {/* Icon requires a size, but width and height are more accurate and applied in styling below */}
+          <Icon size={3} {...props} theme={theme}>
+            Cross
+          </Icon>
+        </components.MultiValueRemove>
+      )
+
+    const StyledTagRemovalIcon = styled(TagRemovalIcon)`
+      svg {
+        stroke: ${theme.colorTextReverse};
+        fill: ${theme.colorTextReverse};
+        padding: 0;
+        width: 20px;
+        height: 20px;
+      }
+    `
 
     const selectChildProps = {
       components: {

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -7,7 +7,6 @@ import Select, { createFilter } from 'react-select'
 const Root = styled.div`
   display: flex;
   flex-direction: column;
-  margin-bottom: ${th('space.3')};
 `
 
 const SelectLimitMessage = styled.p`

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -74,6 +74,18 @@ class SubjectAreaDropdown extends React.Component {
       hasReachedMultiselectLimit: false,
     }
 
+    const chooseBorderColorFromProps = (
+      theme,
+      validationStatus = 'default',
+      isFocused,
+    ) =>
+      ({
+        error: theme.colorError,
+        success: theme.colorSuccess,
+        warning: theme.colorWarning,
+        default: isFocused ? '#2684FF' : theme.colorBorder,
+      }[validationStatus])
+
     const gridUnitValue = parseInt(this.props.theme.gridUnit, 10)
 
     this.customReactSelectStyles = {
@@ -136,6 +148,19 @@ class SubjectAreaDropdown extends React.Component {
         borderRadius: this.props.theme.borderRadius,
         borderWidth: this.props.theme.borderWidth,
         borderStyle: this.props.theme.borderStyle,
+        borderColor: chooseBorderColorFromProps(
+          this.props.theme,
+          this.props.validationStatus,
+          isFocused,
+        ),
+        // overrides the fact that react-select changes borderColor on hover
+        '&:hover': {
+          borderColor: chooseBorderColorFromProps(
+            this.props.theme,
+            this.props.validationStatus,
+            isFocused,
+          ),
+        },
         boxShadow: this.props.theme.boxShadow,
         backgroundColor: this.props.theme.backgroundColor,
       }),

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -105,6 +105,10 @@ class SubjectAreaDropdown extends React.Component {
           color: this.props.theme.colorTextReverse,
         },
       }),
+      menuList: (base, state) => ({
+        ...base,
+        padding: 0,
+      }),
       option: (base, { isSelected, isFocused }) => ({
         ...base,
         backgroundColor:

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -2,9 +2,26 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { withTheme } from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
-import Select, { createFilter } from 'react-select'
+import Select, { createFilter, components } from 'react-select'
 
-import TagRemovalIcon from '../../ui/atoms/icons/TagRemovalIcon'
+import Icon from '../../ui/atoms/Icon'
+
+const TagRemovalIcon = props => (
+  <components.MultiValueRemove {...props}>
+    {/* Icon requires a size, but width and height are more accurate and applied in styling below */}
+    <Icon size={3}>Cross</Icon>
+  </components.MultiValueRemove>
+)
+
+const StyledTagRemovalIcon = styled(TagRemovalIcon)`
+  svg {
+    stroke: ${props => props.theme.colorTextReverse};
+    fill: ${props => props.theme.colorTextReverse};
+    padding: 0;
+    width: 20px;
+    height: 20px;
+  }
+`
 
 const Root = styled.div`
   display: flex;
@@ -114,7 +131,7 @@ class SubjectAreaDropdown extends React.Component {
         ...base,
         color: this.props.theme.colorTextReverse,
         fontSize: this.props.theme.fontSizeBase,
-        padding: '8px',
+        padding: '8px 4px 8px 8px',
         paddingLeft: '8px',
       }),
       multiValueRemove: (base, state) => ({
@@ -202,7 +219,10 @@ class SubjectAreaDropdown extends React.Component {
     const { label, name, onBlur } = this.props
 
     const selectChildProps = {
-      components: { ClearIndicator: null },
+      components: {
+        ClearIndicator: null,
+        MultiValueRemove: StyledTagRemovalIcon,
+      },
       inputId: 'subject-area-select',
       isMulti: true,
       name,
@@ -229,7 +249,7 @@ class SubjectAreaDropdown extends React.Component {
               components={{
                 ClearIndicator: null,
                 DropdownIndicator: null,
-                MultiValueRemove: TagRemovalIcon,
+                MultiValueRemove: StyledTagRemovalIcon,
               }}
               isSearchable={false}
               menuIsOpen={false}

--- a/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
+++ b/app/components/submission/ManuscriptMetadata/SubjectAreaDropdown.js
@@ -170,7 +170,13 @@ class SubjectAreaDropdown extends React.Component {
             isFocused,
           ),
         },
-        boxShadow: this.props.theme.boxShadow,
+        boxShadow: isFocused
+          ? `0 0 0 2pt ${chooseBorderColorFromProps(
+              this.props.theme,
+              this.props.validationStatus,
+              isFocused,
+            )}`
+          : this.props.theme.boxShadow,
         backgroundColor: this.props.theme.backgroundColor,
         minHeight: this.props.gridUnit,
       }),

--- a/app/components/ui/atoms/icons/TagRemovalIcon.js
+++ b/app/components/ui/atoms/icons/TagRemovalIcon.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const TagRemovalIcon = props => (
+  <svg height="1em" viewBox="0 0 12 12" width="1em" {...props}>
+    <g fill="none" fillRule="evenodd">
+      <path
+        d="M12 1.41L10.59 0 6 4.59 1.41 0 0 1.41 4.59 6 0 10.59 1.41 12 6 7.41 10.59 12 12 10.59 7.41 6z"
+        fill="#FFF"
+        fillRule="nonzero"
+      />
+      <path d="M-6-6h24v24H-6z" />
+    </g>
+  </svg>
+)
+
+export default TagRemovalIcon

--- a/client/elife-theme/src/index.js
+++ b/client/elife-theme/src/index.js
@@ -14,7 +14,7 @@ export default {
   colorBackgroundHue: '#f7f7f7',
   colorSuccess: '#629f43',
   colorError: '#cf0c4e',
-  colourWarning: '#e65100',
+  colorWarning: '#e65100',
   colorText: '#212121',
   colorTextSecondary: '#888',
   colorTextPlaceholder: '#bdbdbd',


### PR DESCRIPTION
#### Background
Note: to style `react-select`'s sub-components, we need to use a custom styles object - see [the docs](https://deploy-preview-2289--react-select.netlify.com/styles#style-object). This looks similar to styled components, but in fact uses "emotion".

This is the component structure for the multi-select version of `react-select`:
 - First diagram - shows when there is only a placeholder present & the ability to type a letter in the input.
- Second diagram - shows how the structure of the ValueContainer changes after a user selects their option(s)

![image](https://user-images.githubusercontent.com/15656538/41868812-181a6d6c-78af-11e8-98df-32b13dd54d35.png)

### What does this PR do?
1. Tidy up:
    - fix typo in eLife theme - "col**our**Warning" -> `colorWarning`
    - remove bottom margin from overall component - relates #238 

2. Then update SubjectAreaDropdown component to conform to styleguide - see issue #225:

_Border colour_
- alter the Control component's border colour, based on whether the number of options chosen is valid (validity comes from prop on parent component)

_Spacing_
- combine `padding = gridUnit /2` on the parent + `margin = gridUnit / 2` on the child wherever possible  
Now sub-components can slot in and out & still achieve `gridUnit` spacing everywhere  
e.g.  
Parent: `ValueContainer` - responsible for half the gridUnit spacing, via padding  
Each child: `Input`, `Placeholder` & `MultiValue` - each responsible for the other half of spacing, via margin

- override `react-select` defaults & make as many margins and padding `0px` as possible, to reduce complexity
 
_Rest_
- indicate that a tag is delete-able - pointer on the X icon instead of background colour chaning (override default behaviour of `react-select`)
- remove the space between the Select Control and the Menu (`react-select` default), but leave enough room to see the Select's validation border
- remove `react-select`'s hover behaviour on the Select Control - eLife designs don't contain hover behaviour for Input fields
- update all other variables for consistency with eLife theme: tags have white text colour + blue background on, border styling to match other eLife input fields, round the edges on the bottom of the Menu with eLife's border radius

### How has this been tested?
Locally/manually. Should we be writing actual tests for CSS? (I'm mainly thinking validation behaviour, not every bit of styling)

### Known inconsistencies with design
- X icon inside the tags is smaller than designs. I could replace the default `react-select` SVG with our own one if this is important?
- Menu indicator (down chevron) does not turn upside down when the menu is open, as it is supposed to according to the designs. Again, this is default behaviour from `react-select`. Can be replaced with our own upside-down SVG chevron if we want?
- Select Control & error message overlap. This will be fixed when the `ValidatedField` component is styled. We will need to add space between the component and the validation message in `ValidatedField`, rather than relying on `margin-bottom` existing each of its sub-components.

### Issues still to be dealt with
- How to display focus on input fields in general  
Current designs suggest different greys for focused & unfocused, but ideally the colour contrast would be stronger. By default, browsers have a blue focus ring - I have left this in for now.  
See [comments in invision styleguide](https://projects.invisionapp.com/share/NZKXOQUV4P3#/screens/302926985/comments/99774850)
- How to display focus after red/orange/green validation border is applied  
Current designs don't specify. See my comment in the issue on pubsweet's design repo - https://gitlab.coko.foundation/pubsweet/design/issues/11
- Would be better to refactor, so that this Dropdown component isn't so tightly coupled with `ValidatedField` & the multiselect functionality could be re-used in other places
- Dropdown icon does not match designs