### PR TITLE
test: update selector to avoid max wait

### DIFF
--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -89,7 +89,7 @@ test('Happy path', async t => {
     .eql('The Relationship Between Lamport Clocks and Interrupts Using Obi')
     .click('[role=listbox] button')
     .click(Selector('[role=option]').nth(0))
-    .click(Selector('[id=subject-area-select'))
+    .click(Selector('label[for=subject-area-select'))
     .pressKey('enter')
     .pressKey('down')
     .pressKey('enter')


### PR DESCRIPTION
#### Background

Previously this end-to-end test tried to click on a background element. This causes a delay while TestCafe waits for the element to become visible (see https://github.com/DevExpress/testcafe/issues/2381).

Switching to a different selector shaves ~10 seconds off the test run time.

#### How has this been tested?

n/a