### PR TITLE
refactor(ui): make icons in styleguide small again

### DIFF
--- a/app/components/ui/atoms/Icon.md
+++ b/app/components/ui/atoms/Icon.md
@@ -1,19 +1,19 @@
 An upload icon (you must specify a size).
 
 ```js
-<Icon size={6}>Upload</Icon>
+<Icon size={4}>Upload</Icon>
 ```
 
 Upload failure icon.
 
 ```js
-<Icon size={6}>UploadFailure</Icon>
+<Icon size={4}>UploadFailure</Icon>
 ```
 
 Some icons accept additional parameters.
 
 ```js
-<Icon size={6} percentage={100}>
+<Icon size={4} percentage={100}>
   Upload
 </Icon>
 ```


### PR DESCRIPTION
#### Background

After https://github.com/elifesciences/elife-xpub/pull/249 icons look too big in styleguide.

#### How has this been tested?

Locally in styleguide.