### PR TITLE
fix: change PlainButton to Action - after breaking change in pubsweet

### DIFF
--- a/app/components/submission/ReviewerSuggestions/ReviewerSuggestions.js
+++ b/app/components/submission/ReviewerSuggestions/ReviewerSuggestions.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Box } from 'grid-styled'
-import { Button, PlainButton } from '@pubsweet/ui'
+import { Button, Action } from '@pubsweet/ui'
 
 import ButtonLink from '../../ui/atoms/ButtonLink'
 import ProgressBar from '../ProgressBar'
@@ -24,14 +24,14 @@ const MoreButton = ({
   more = 'another',
   values,
 }) => (
-  <PlainButton
+  <Action
     onClick={() =>
       setFieldValue(fieldName, values[fieldName].concat(empty), false)
     }
     type="button"
   >
     {type} {values[fieldName].length ? more : 'a'} {roleName}
-  </PlainButton>
+  </Action>
 )
 
 const MAX_EXCLUDED_EDITORS = 2


### PR DESCRIPTION
#### Background
pubsweet has removed their `PlainButton` atom & now has a `Action` component, which we need to use instead

#### What does this PR do?
Replaces buttons with links on page 4

#### Any relevant tickets
fixes #271 