### PR TITLE
feat: temporary dashboard view

### DIFF
--- a/app/components/dashboard/Dashboard.js
+++ b/app/components/dashboard/Dashboard.js
@@ -1,25 +1,66 @@
 import React from 'react'
+import styled from 'styled-components'
 import { Link } from 'react-router-dom'
+import { Box } from 'grid-styled'
+import { Button } from '@pubsweet/ui'
+
 import { FormH2, FormH3 } from '../ui/atoms/FormHeadings'
 import ButtonLink from '../ui/atoms/ButtonLink'
 
-const Dashboard = ({ manuscripts }) => (
+/* Temporary dashboard view pending receipt of designs */
+
+const Header = styled.th`
+  text-align: left;
+  padding: 3px 6px;
+`
+
+const Cell = styled.td`
+  border-top: 1px solid grey;
+  padding: 3px 6px;
+`
+
+const Dashboard = ({ manuscripts, deleteManuscript }) => (
   <React.Fragment>
     <FormH2>Dashboard Dummy Page</FormH2>
-    <ButtonLink data-test-id="submit" primary to="/submit">
-      Submit a manuscript
-    </ButtonLink>
+
+    <Box mb={4}>
+      <ButtonLink data-test-id="submit" primary to="/submit">
+        Submit a manuscript
+      </ButtonLink>
+    </Box>
 
     <FormH3>All manuscripts</FormH3>
-    <ul>
-      {manuscripts.map(manuscript => (
-        <li key={manuscript.id}>
-          <Link to={`/manuscript/${manuscript.id}`}>
-            {manuscript.title || '(Untitled manuscript)'}
-          </Link>
-        </li>
-      ))}
-    </ul>
+
+    {!manuscripts.length && <p>No manuscripts to display</p>}
+
+    {!!manuscripts.length && (
+      <table>
+        <thead>
+          <tr>
+            <Header>Title</Header>
+            <Header>Stage</Header>
+            <Header />
+          </tr>
+        </thead>
+        <tbody>
+          {manuscripts.map(manuscript => (
+            <tr key={manuscript.id}>
+              <Cell>
+                <Link to={`/manuscript/${manuscript.id}`}>
+                  {manuscript.title || '(Untitled manuscript)'}
+                </Link>
+              </Cell>
+              <Cell>{manuscript.submissionMeta.stage}</Cell>
+              <Cell>
+                <Button onClick={() => deleteManuscript(manuscript.id)} small>
+                  Delete
+                </Button>
+              </Cell>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )}
   </React.Fragment>
 )
 

--- a/app/components/dashboard/DashboardPage.js
+++ b/app/components/dashboard/DashboardPage.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import gql from 'graphql-tag'
-import { Query } from 'react-apollo'
+import { Query, Mutation } from 'react-apollo'
+import { GET_CURRENT_SUBMISSION } from '../submission/WithCurrentSubmission'
 import Dashboard from './Dashboard'
 
 const MANUSCRIPTS_QUERY = gql`
@@ -8,7 +9,16 @@ const MANUSCRIPTS_QUERY = gql`
     manuscripts {
       id
       title
+      submissionMeta {
+        stage
+      }
     }
+  }
+`
+
+const DELETE_MANUSCRIPT_MUTATION = gql`
+  mutation($id: ID!) {
+    deleteManuscript(id: $id)
   }
 `
 
@@ -23,7 +33,22 @@ const DashboardPage = () => (
         return <div>{error.message}</div>
       }
 
-      return <Dashboard manuscripts={data.manuscripts} />
+      return (
+        <Mutation
+          mutation={DELETE_MANUSCRIPT_MUTATION}
+          refetchQueries={[
+            { query: MANUSCRIPTS_QUERY },
+            { query: GET_CURRENT_SUBMISSION },
+          ]}
+        >
+          {deleteManuscript => (
+            <Dashboard
+              deleteManuscript={id => deleteManuscript({ variables: { id } })}
+              manuscripts={data.manuscripts}
+            />
+          )}
+        </Mutation>
+      )
     }}
   </Query>
 )

--- a/server/db-helpers/index.js
+++ b/server/db-helpers/index.js
@@ -62,9 +62,13 @@ const select = async selector => {
   return rows.map(row => manuscriptDbToGql(row.data, row.id))
 }
 
+const deleteManuscript = id =>
+  db.query('DELETE FROM entities WHERE id = $1', [id])
+
 module.exports = {
   manuscriptGqlToDb,
   manuscriptDbToGql,
+  deleteManuscript,
   select,
   save,
   update,

--- a/server/submission/definitions.js
+++ b/server/submission/definitions.js
@@ -12,6 +12,7 @@ const typeDefs = `
     }
     extend type Mutation {
       createSubmission: Manuscript!
+      deleteManuscript(id: ID!): ID!
       updateSubmission(data: ManuscriptInput!, isAutoSave: Boolean): Manuscript!
       uploadManuscript(id: ID!, file: Upload!): Manuscript!
       finishSubmission(data: ManuscriptInput!): Manuscript!

--- a/server/submission/resolvers.js
+++ b/server/submission/resolvers.js
@@ -111,6 +111,11 @@ const resolvers = {
       return manuscript
     },
 
+    async deleteManuscript(_, { id }) {
+      await db.deleteManuscript(id)
+      return id
+    },
+
     async updateSubmission(_, { data, isAutoSave }, ctx) {
       let manuscript = await db.selectId(data.id)
       db.checkPermission(manuscript, ctx.user)


### PR DESCRIPTION
#### Background

I've taken the initiative and added some more functionality to the dashboard view. I frequently have to manipulate the database to delete an in progress manuscript. This is easy enough on a development machine but it's a bit trickier on staging/demo. This is very much a temporary solution but will hopefully be useful until we have a better idea of the design and functionality of the dashboard.

FWIW on previous projects I've found it useful to create a special admin dashboard with this kind of functionality and some built in checks to ensure it can't get deployed to production. 

#### How has this been tested?

Manually.