### PR TITLE
fix: cover letter editor validation

### DIFF
--- a/app/components/submission/FileUploads/FileUploadsSchema.js
+++ b/app/components/submission/FileUploads/FileUploadsSchema.js
@@ -1,6 +1,6 @@
 import yup from 'yup'
 
-const MIN_WORDS = 57
+const MIN_WORDS = 60
 
 function stripHtml(html) {
   const htmlWithLineBreaks = html.replace(/<\/p>/g, '</p>\n')
@@ -14,8 +14,8 @@ const schema = yup.object().shape({
       .string()
       .test(
         'hasContent',
-        'Your cover letter should be longer',
-        value => stripHtml(value).split(/\s/).length > MIN_WORDS,
+        `Your cover letter should be at least ${MIN_WORDS} words long`,
+        value => stripHtml(value).split(/\s+/).length > MIN_WORDS,
       ),
   }),
   files: yup.array().min(1, 'Please upload a manuscript'),


### PR DESCRIPTION
#### Background

Validation was miscounting words which meant the cover letter was valid by default.

Also the validation message was too vague and causing confusion when people typed gibberish into the input instead of separate words.

#### How has this been tested?
 
Manually.