### PR TITLE
test: add end-to-end test assertions for manuscript stage transition

### DIFF
--- a/app/components/dashboard/Dashboard.js
+++ b/app/components/dashboard/Dashboard.js
@@ -34,7 +34,7 @@ const Dashboard = ({ manuscripts, deleteManuscript }) => (
     {!manuscripts.length && <p>No manuscripts to display</p>}
 
     {!!manuscripts.length && (
-      <table>
+      <table data-test-id="manuscripts">
         <thead>
           <tr>
             <Header>Title</Header>
@@ -45,12 +45,14 @@ const Dashboard = ({ manuscripts, deleteManuscript }) => (
         <tbody>
           {manuscripts.map(manuscript => (
             <tr key={manuscript.id}>
-              <Cell>
-                <Link to={`/manuscript/${manuscript.id}`}>
+              <Cell data-test-id="title">
+                <Link data-test-id="title" to={`/manuscript/${manuscript.id}`}>
                   {manuscript.title || '(Untitled manuscript)'}
                 </Link>
               </Cell>
-              <Cell>{manuscript.submissionMeta.stage}</Cell>
+              <Cell data-test-id="stage">
+                {manuscript.submissionMeta.stage}
+              </Cell>
               <Cell>
                 <Button onClick={() => deleteManuscript(manuscript.id)} small>
                   Delete

--- a/app/components/dashboard/DashboardPage.js
+++ b/app/components/dashboard/DashboardPage.js
@@ -4,7 +4,7 @@ import { Query, Mutation } from 'react-apollo'
 import { GET_CURRENT_SUBMISSION } from '../submission/WithCurrentSubmission'
 import Dashboard from './Dashboard'
 
-const MANUSCRIPTS_QUERY = gql`
+export const MANUSCRIPTS_QUERY = gql`
   query {
     manuscripts {
       id
@@ -16,7 +16,7 @@ const MANUSCRIPTS_QUERY = gql`
   }
 `
 
-const DELETE_MANUSCRIPT_MUTATION = gql`
+export const DELETE_MANUSCRIPT_MUTATION = gql`
   mutation($id: ID!) {
     deleteManuscript(id: $id)
   }

--- a/app/components/submission/WithCurrentSubmission.js
+++ b/app/components/submission/WithCurrentSubmission.js
@@ -3,6 +3,7 @@ import { withApollo } from 'react-apollo'
 import React from 'react'
 import omitDeep from 'omit-deep-lodash'
 import ErrorPage from '../global/ErrorPage'
+import { MANUSCRIPTS_QUERY } from '../dashboard/DashboardPage'
 
 const manuscriptFragment = gql`
   fragment WholeManuscript on Manuscript {
@@ -166,7 +167,10 @@ class WithCurrentSubmission extends React.Component {
       progressSubmission: values => this.mutate(values, UPDATE_SUBMISSION),
       finishSubmission: values =>
         this.mutate(values, FINISH_SUBMISSION, {
-          refetchQueries: [{ query: GET_CURRENT_SUBMISSION }],
+          refetchQueries: [
+            { query: GET_CURRENT_SUBMISSION },
+            { query: MANUSCRIPTS_QUERY },
+          ],
         }),
     })
   }

--- a/test/pageObjects/dashboard.js
+++ b/test/pageObjects/dashboard.js
@@ -2,6 +2,8 @@ import config from 'config'
 
 const dashboard = {
   url: `${config.get('pubsweet-server.baseUrl')}`,
+  titles: '[data-test-id=title]',
+  stages: '[data-test-id=stage]',
 }
 
 export default dashboard

--- a/test/pageObjects/file-uploads.js
+++ b/test/pageObjects/file-uploads.js
@@ -1,0 +1,12 @@
+import config from 'config'
+import { Selector } from 'testcafe'
+
+const fileUploads = {
+  url: `${config.get('pubsweet-server.baseUrl')}/submit/upload`,
+  editor: Selector(
+    '[name="submissionMeta.coverLetter"] div[contenteditable=true]',
+  ),
+  manuscriptUpload: Selector('[data-test-id=upload]>input'),
+}
+
+export default fileUploads

--- a/test/pageObjects/index.js
+++ b/test/pageObjects/index.js
@@ -1,2 +1,3 @@
 export { default as dashboard } from './dashboard'
+export { default as fileUploads } from './file-uploads'
 export { default as authorDetails } from './author-details'

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -1,10 +1,15 @@
 import { ClientFunction, Selector } from 'testcafe'
 import replaySetup from './helpers/replay-setup'
-import { dashboard, authorDetails } from './pageObjects'
+import { dashboard, authorDetails, fileUploads } from './pageObjects'
 import setFixtureHooks from './helpers/set-fixture-hooks'
 
 const f = fixture('Submission')
 setFixtureHooks(f)
+
+const manuscript = {
+  title: 'The Relationship Between Lamport Clocks and Interrupts Using Obi',
+  file: './fixtures/dummy-manuscript-2.pdf',
+}
 
 test('Happy path', async t => {
   replaySetup('success')
@@ -59,7 +64,6 @@ test('Happy path', async t => {
       'Error is displayed when user enters invalid email',
     )
     .click('[data-test-id=next]')
-    .wait(1000)
     .expect(ClientFunction(() => window.location.href)())
     .eql(
       authorDetails.url,
@@ -71,14 +75,8 @@ test('Happy path', async t => {
 
   // file uploads
   await t
-    .typeText(
-      '[name="submissionMeta.coverLetter"] div[contenteditable=true]',
-      'Please consider this for publication',
-    )
-    .setFilesToUpload(
-      '[data-test-id=upload]>input',
-      './fixtures/dummy-manuscript-2.pdf',
-    )
+    .typeText(fileUploads.editor, '\nPlease consider this for publication')
+    .setFilesToUpload(fileUploads.manuscriptUpload, manuscript.file)
     // wait for editor onChange
     .wait(1000)
     .click('[data-test-id=next]')
@@ -86,7 +84,7 @@ test('Happy path', async t => {
   // metadata
   await t
     .expect(Selector('[name=title]').value)
-    .eql('The Relationship Between Lamport Clocks and Interrupts Using Obi')
+    .eql(manuscript.title)
     .click('[role=listbox] button')
     .click(Selector('[role=option]').nth(0))
     .click(Selector('label[for=subject-area-select'))
@@ -118,6 +116,13 @@ test('Happy path', async t => {
     .typeText('[name="suggestedReviewers.2.email"]', 'dave@example.org')
     .click(Selector('[name=noConflictOfInterest]').parent())
     .click('[data-test-id=next]')
+
+  // dashboard
+  await t
+    .expect(Selector('[data-test-id=title]').textContent)
+    .eql(manuscript.title)
+    .expect(Selector('[data-test-id=stage]').textContent)
+    .eql('QA')
 })
 
 test('Submission form details are saved to server on submit', async t => {
@@ -139,7 +144,10 @@ test('Submission form details are saved to server on submit', async t => {
     .typeText(authorDetails.institutionField, 'iTunes U', { replace: true })
     .click('[data-test-id=next]')
 
+  // ensure save completed before reloading
+  await fileUploads.editor
   await t.navigateTo(authorDetails.url)
+
   await t
     .expect(Selector(authorDetails.firstNameField).value)
     .eql('Meghan', 'First name has been saved')


### PR DESCRIPTION
#### Background

- Add a test to assert that the manuscript goes into the QA stage after initial submission
- Refetch the dashboard query on submit so that the data on the dashboard is up to date. It's not yet clear what the best approach is for this.
- Create a page object for the file uploads page test
- Add a wait in the saving test which was sometimes failing because it reloaded the page before the save had completed

#### How has this been tested?
 
With TestCafe.