### PR TITLE
fix: correct preview link on manuscript upload component

### DIFF
--- a/app/components/submission/AutoSave.js
+++ b/app/components/submission/AutoSave.js
@@ -18,6 +18,7 @@ export default class AutoSave extends React.Component {
 
   componentWillUnmount() {
     clearInterval(this.timer)
+    this.save()
   }
 
   save() {

--- a/app/components/submission/AutoSave.test.js
+++ b/app/components/submission/AutoSave.test.js
@@ -27,4 +27,13 @@ describe('AutoSave', () => {
     jest.advanceTimersByTime(6000)
     expect(onSave).toHaveBeenCalled()
   })
+
+  it('saves on unmount', () => {
+    const onSave = jest.fn()
+    const values = { a: 1 }
+    const wrapper = makeWrapper({ onSave, values, children: 'Some text' })
+    wrapper.setProps({ values: { a: 2 } })
+    wrapper.unmount()
+    expect(onSave).toHaveBeenCalled()
+  })
 })

--- a/app/components/submission/FileUploads/FileUploads.js
+++ b/app/components/submission/FileUploads/FileUploads.js
@@ -33,6 +33,7 @@ const FileUploads = ({
   onDrop,
   conversion,
   formError,
+  previewUrl,
 }) => (
   <form onSubmit={handleSubmit}>
     <ProgressBar currentStep={1} />
@@ -55,6 +56,7 @@ const FileUploads = ({
           data-test-id="upload"
           formError={formError}
           onDrop={onDrop}
+          previewUrl={previewUrl}
         />
       </Box>
     </Flex>

--- a/app/components/submission/FileUploads/FileUploadsPage.js
+++ b/app/components/submission/FileUploads/FileUploadsPage.js
@@ -17,7 +17,6 @@ const UPLOAD_MUTATION = gql`
 `
 
 const FileUploadsPage = ({
-  manuscriptId,
   setFieldValue,
   errors,
   touched,
@@ -46,6 +45,7 @@ const FileUploadsPage = ({
               setFieldValue(fieldName, data.uploadManuscript.files)
             })
           }
+          previewUrl={`/manuscript/${values.id}`}
           setFieldValue={setFieldValue}
           {...props}
         />

--- a/app/components/ui/molecules/FileUpload.js
+++ b/app/components/ui/molecules/FileUpload.js
@@ -32,7 +32,12 @@ const CentredFlex = styled(Flex)`
   text-align: center;
 `
 
-const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
+const DropzoneContent = ({
+  conversion,
+  formError,
+  dropzoneOpen,
+  previewUrl,
+}) => {
   if (conversion.converting) {
     return (
       <React.Fragment>
@@ -74,8 +79,11 @@ const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
       <React.Fragment>
         <Icon size={5}>UploadSuccess</Icon>
         <Instruction data-test-id="dropzoneMessage">
-          Success! <Action to="/manuscript">Preview</Action> or{' '}
-          <Action onClick={dropzoneOpen}>replace</Action> your Manuscript.
+          Success!{' '}
+          <Action data-test-id="preview" to={previewUrl}>
+            Preview
+          </Action>{' '}
+          or <Action onClick={dropzoneOpen}>replace</Action> your Manuscript.
         </Instruction>
       </React.Fragment>
     )
@@ -91,7 +99,13 @@ const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
   )
 }
 
-const FileUpload = ({ onDrop, conversion, formError, ...props }) => {
+const FileUpload = ({
+  onDrop,
+  conversion,
+  formError,
+  previewUrl,
+  ...props
+}) => {
   let dropzoneRef
   return (
     <StyledDropzone
@@ -110,6 +124,7 @@ const FileUpload = ({ onDrop, conversion, formError, ...props }) => {
             conversion={conversion}
             dropzoneOpen={() => dropzoneRef.open()}
             formError={formError}
+            previewUrl={previewUrl}
           />
         </Box>
       </CentredFlex>

--- a/config/test.js
+++ b/config/test.js
@@ -19,6 +19,9 @@ module.exports = {
   'orcid-server': {
     port: 8080,
   },
+  darServer: {
+    basePath: 'test/temp/uploads',
+  },
   mailer: {
     transport: {
       sendmail: false,

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -81,7 +81,14 @@ test('Happy path', async t => {
     )
     // wait for editor onChange
     .wait(1000)
-    .click('[data-test-id=next]')
+
+    .click('[data-test-id=preview')
+    .expect(Selector('.sc-title-group').textContent)
+    .eql('The Relationship Between Lamport Clocks and Interrupts Using Obi')
+
+  const goBack = ClientFunction(() => window.history.back())
+  await goBack()
+  await t.click('[data-test-id=next]')
 
   // metadata
   await t


### PR DESCRIPTION
#### Background

- Pass the Texture preview page URL down to the file upload component
- Add a test into the submission flow end to end test
- Fix DAR server config in `test` environment
- Make the `AutoSave` component trigger a save when it gets unmounted. This should ensure that the latest data is saved when a user navigates away from the form. Note this is only for "in-app" navigation, it doesn't account for full page reloads like navigating to a different site.

Related to #234.

#### How has this been tested?

TestCafe.