### PR TITLE
fix: add missing params to update mutation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ test:e2e:
     - npm run test:e2e -- --screenshots test/screenshots --screenshots-on-fails
   artifacts:
     paths:
-      - "test/screenshots/*/*/*/errors/*.png"
+      - test/screenshots
     when: on_failure
     expire_in: 1 week
 

--- a/app/components/submission/WithCurrentSubmission.js
+++ b/app/components/submission/WithCurrentSubmission.js
@@ -98,8 +98,8 @@ const UPDATE_SUBMISSION = gql`
 `
 
 const FINISH_SUBMISSION = gql`
-  mutation FinishSubmission($data: ManuscriptInput!, $isAutoSave: Boolean) {
-    updateSubmission(data: $data, isAutoSave: $isAutoSave) {
+  mutation FinishSubmission($data: ManuscriptInput!) {
+    finishSubmission(data: $data) {
       ...WholeManuscript
     }
   }

--- a/app/components/submission/WithCurrentSubmission.js
+++ b/app/components/submission/WithCurrentSubmission.js
@@ -89,8 +89,8 @@ const CREATE_SUBMISSION = gql`
 `
 
 const UPDATE_SUBMISSION = gql`
-  mutation UpdateSubmission($data: ManuscriptInput!) {
-    updateSubmission(data: $data) {
+  mutation UpdateSubmission($data: ManuscriptInput!, $isAutoSave: Boolean) {
+    updateSubmission(data: $data, isAutoSave: $isAutoSave) {
       ...WholeManuscript
     }
   }
@@ -98,8 +98,8 @@ const UPDATE_SUBMISSION = gql`
 `
 
 const FINISH_SUBMISSION = gql`
-  mutation FinishSubmission($data: ManuscriptInput!) {
-    finishSubmission(data: $data) {
+  mutation FinishSubmission($data: ManuscriptInput!, $isAutoSave: Boolean) {
+    updateSubmission(data: $data, isAutoSave: $isAutoSave) {
       ...WholeManuscript
     }
   }


### PR DESCRIPTION
#### Background

`isAutoSave` wasn't being passed through resulting in emails being sent when the form was auto saved rather than only when the "Next" button was clicked.
