### PR TITLE
fix: e2e tests - add a wait for a second before looking for the element

### DIFF
--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -90,6 +90,7 @@ test('Happy path', async t => {
 
   // metadata
   await t
+    .wait(1000)
     .expect(Selector('[name=title]').value)
     .eql(manuscript.title)
     .click('[role=listbox] button')


### PR DESCRIPTION
#### Background

Failing tests fixed by a simple wait

#### Any relevant tickets

None

#### How has this been tested?

Locally