### PR TITLE
chore: set specific version of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": ">=8",
+    "node": ">=8.9.4",
     "yarn": ">=1.2"
   },
   "repository": {


### PR DESCRIPTION
#### Background

Specify the version of node to use in  `.engines` within `package.json`, so you don't have to look for the base Dockerfile and find the version from there.