### PR TITLE
test: split submission flow into two tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,10 +76,11 @@ test:e2e:
     - cd ${HOME}
     # specify host here else it confuses the linked postgres image
     - export PGHOSTADDR=127.0.0.1
-    - npm run test:e2e -- ---screenshots test/screenshots --screenshots-on-fails
+    - npm run test:e2e -- --screenshots test/screenshots --screenshots-on-fails
   artifacts:
     paths:
-    - test/screenshots
+      - "test/screenshots/*/*/*/errors/*.png"
+    when: on_failure
     expire_in: 1 week
 
 push:latest:

--- a/app/components/submission/WizardStep.js
+++ b/app/components/submission/WizardStep.js
@@ -13,7 +13,7 @@ const EmailVerificationRibbon = ({ values }) => {
   return (
     show && (
       <Box mb={5} mx={-3}>
-        <NotificationRibbon>
+        <NotificationRibbon data-test-id="author-verification">
           A verification email has been sent to the corresponding author.
         </NotificationRibbon>
       </Box>

--- a/test/pageObjects/dashboard.js
+++ b/test/pageObjects/dashboard.js
@@ -1,9 +1,14 @@
 import config from 'config'
+import { t, Selector } from 'testcafe'
 
 const dashboard = {
   url: `${config.get('pubsweet-server.baseUrl')}`,
-  titles: '[data-test-id=title]',
-  stages: '[data-test-id=stage]',
+  login: async () => {
+    await t.navigateTo(config.get('pubsweet-server.baseUrl'))
+    await t.ctx.localStorageSet(t.ctx.token)
+  },
+  titles: Selector('[data-test-id=title]'),
+  stages: Selector('[data-test-id=stage]'),
 }
 
 export default dashboard

--- a/test/pageObjects/file-uploads.js
+++ b/test/pageObjects/file-uploads.js
@@ -7,6 +7,7 @@ const fileUploads = {
     '[name="submissionMeta.coverLetter"] div[contenteditable=true]',
   ),
   manuscriptUpload: Selector('[data-test-id=upload]>input'),
+  preview: Selector('[data-test-id=preview]'),
 }
 
 export default fileUploads

--- a/test/pageObjects/index.js
+++ b/test/pageObjects/index.js
@@ -1,3 +1,6 @@
 export { default as dashboard } from './dashboard'
-export { default as fileUploads } from './file-uploads'
+export { default as submission } from './submission'
 export { default as authorDetails } from './author-details'
+export { default as fileUploads } from './file-uploads'
+export { default as metadata } from './metadata'
+export { default as suggestions } from './suggestions'

--- a/test/pageObjects/metadata.js
+++ b/test/pageObjects/metadata.js
@@ -1,0 +1,22 @@
+import config from 'config'
+import { Selector } from 'testcafe'
+
+const metadata = {
+  url: `${config.get('pubsweet-server.baseUrl')}/submit/metadata`,
+  title: Selector('[name=title]'),
+  articleType: Selector('[role=listbox] button'),
+  articleTypes: Selector('[role=option]'),
+  subjectAreaLabel: Selector('label[for=subject-area-select]'),
+  discussedPreviously: Selector(
+    '[name="submissionMeta.discussedPreviously"]',
+  ).parent(),
+  discussion: Selector('[name="submissionMeta.discussion"]'),
+  consideredPreviously: Selector(
+    '[name="submissionMeta.consideredPreviously"]',
+  ).parent(),
+  previousArticle: Selector('[name="submissionMeta.previousArticle"]'),
+  cosubmission: Selector('[name="submissionMeta.cosubmission"]').parent(),
+  cosubmissionTitle: Selector('[name="submissionMeta.cosubmissionTitle"]'),
+}
+
+export default metadata

--- a/test/pageObjects/submission.js
+++ b/test/pageObjects/submission.js
@@ -1,0 +1,8 @@
+import { Selector } from 'testcafe'
+
+const fileUploads = {
+  verificationRibbon: Selector('[data-test-id=author-verification]'),
+  next: Selector('[data-test-id=next]'),
+}
+
+export default fileUploads

--- a/test/pageObjects/suggestions.js
+++ b/test/pageObjects/suggestions.js
@@ -1,0 +1,21 @@
+import config from 'config'
+import { Selector, t } from 'testcafe'
+
+const suggestions = {
+  url: `${config.get('pubsweet-server.baseUrl')}/submit/suggestions`,
+  fillWithDummyData: () =>
+    t
+      .typeText('[name="suggestedSeniorEditors.0"]', 'Angela')
+      .typeText('[name="suggestedSeniorEditors.1"]', 'Bobby')
+      .typeText('[name="suggestedReviewingEditors.0"]', 'Charlie')
+      .typeText('[name="suggestedReviewingEditors.1"]', 'Delia')
+      .typeText('[name="suggestedReviewers.0.name"]', 'Edward')
+      .typeText('[name="suggestedReviewers.0.email"]', 'edward@example.com')
+      .typeText('[name="suggestedReviewers.1.name"]', 'Frances')
+      .typeText('[name="suggestedReviewers.1.email"]', 'frances@example.net')
+      .typeText('[name="suggestedReviewers.2.name"]', 'George')
+      .typeText('[name="suggestedReviewers.2.email"]', 'george@example.org'),
+  conflictOfInterest: Selector('[name=noConflictOfInterest]').parent(),
+}
+
+export default suggestions

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -1,6 +1,13 @@
 import { ClientFunction, Selector } from 'testcafe'
 import replaySetup from './helpers/replay-setup'
-import { dashboard, authorDetails, fileUploads } from './pageObjects'
+import {
+  dashboard,
+  submission,
+  authorDetails,
+  fileUploads,
+  metadata,
+  suggestions,
+} from './pageObjects'
 import setFixtureHooks from './helpers/set-fixture-hooks'
 
 const f = fixture('Submission')
@@ -13,9 +20,7 @@ const manuscript = {
 
 test('Happy path', async t => {
   replaySetup('success')
-  // fake login by navigating to site and injecting token into local storage
-  await t.navigateTo(dashboard.url)
-  await t.ctx.localStorageSet(t.ctx.token)
+  await dashboard.login()
   await t.navigateTo(dashboard.url).click('[data-test-id=submit]')
 
   // author details initially empty
@@ -43,126 +48,138 @@ test('Happy path', async t => {
       'University of eLife',
       'Institution is populated by query to the Orchid API',
     )
+    .click(submission.next)
 
-  // change author details
+  // file uploads
   await t
-    .typeText(authorDetails.firstNameField, 'Anne', {
-      replace: true,
-    })
-    .typeText(authorDetails.secondNameField, 'Author', {
-      replace: true,
-    })
-    .typeText(authorDetails.emailField, 'anne.author@life', {
-      replace: true,
-    })
-    .typeText(authorDetails.institutionField, 'University of Life', {
-      replace: true,
-    })
+    // TODO re-enable this assertion once https://github.com/elifesciences/elife-xpub/issues/309 is resolved
+    // .expect(submission.verificationRibbon.exists)
+    // .eql(false)
+    .typeText(fileUploads.editor, '\nPlease consider this for publication')
+    .setFilesToUpload(fileUploads.manuscriptUpload, manuscript.file)
+    // wait for editor onChange
+    .wait(1000)
+    .click(submission.next)
+
+  // metadata
+  await t
+    .expect(metadata.title.value)
+    .eql(manuscript.title)
+    .click(metadata.articleType)
+    .click(metadata.articleTypes.nth(0))
+    .click(metadata.subjectAreaLabel)
+    .pressKey('enter')
+    .pressKey('down')
+    .pressKey('enter')
+    .click(submission.next)
+
+  // reviewer suggestions
+  await suggestions.fillWithDummyData()
+  await t.click(suggestions.conflictOfInterest).click(submission.next)
+
+  // dashboard
+  await t
+    .expect(dashboard.titles.textContent)
+    .eql(manuscript.title)
+    .expect(dashboard.stages.textContent)
+    .eql('QA')
+})
+
+test('Corresponding author', async t => {
+  replaySetup('success')
+  await dashboard.login()
+  await t.navigateTo(authorDetails.url)
+
+  // set author details
+  await t
+    .typeText(authorDetails.firstNameField, 'Anne')
+    .typeText(authorDetails.secondNameField, 'Author')
+    .typeText(authorDetails.emailField, 'anne.author@life')
+    .typeText(authorDetails.institutionField, 'University of eLife')
     .expect(Selector(authorDetails.emailValidationMessage).textContent)
     .eql(
       'Must be a valid email address',
       'Error is displayed when user enters invalid email',
     )
-    .click('[data-test-id=next]')
+    .click(submission.next)
     .expect(ClientFunction(() => window.location.href)())
     .eql(
       authorDetails.url,
       'Validation errors prevent progress to the next page',
     )
     .typeText(authorDetails.emailField, '.ac.uk')
-
-    .click('[data-test-id=next]')
+    .click(submission.next)
 
   // file uploads
   await t
+    .expect(submission.verificationRibbon.exists)
+    .eql(true)
     .typeText(fileUploads.editor, '\nPlease consider this for publication')
     .setFilesToUpload(fileUploads.manuscriptUpload, manuscript.file)
     // wait for editor onChange
     .wait(1000)
 
-    .click('[data-test-id=preview')
+    .click(fileUploads.preview)
     .expect(Selector('.sc-title-group').textContent)
-    .eql('The Relationship Between Lamport Clocks and Interrupts Using Obi')
+    .eql(manuscript.title)
 
   const goBack = ClientFunction(() => window.history.back())
   await goBack()
-  await t.click('[data-test-id=next]')
+  await t.click(submission.next)
 
   // metadata
   await t
     .wait(1000)
-    .expect(Selector('[name=title]').value)
+    .expect(metadata.title.value)
     .eql(manuscript.title)
-    .click('[role=listbox] button')
-    .click(Selector('[role=option]').nth(0))
-    .click(Selector('label[for=subject-area-select'))
+    .click(metadata.articleType)
+    .click(metadata.articleTypes.nth(0))
+    .click(metadata.subjectAreaLabel)
     .pressKey('enter')
     .pressKey('down')
     .pressKey('enter')
-    .click(Selector('[name="submissionMeta.discussedPreviously"]').parent())
-    .typeText(
-      '[name="submissionMeta.discussion"]',
-      'Spoke to Bob about another article',
-    )
-    .click(Selector('[name="submissionMeta.consideredPreviously"]').parent())
-    .typeText('[name="submissionMeta.previousArticle"]', '01234')
-    .click(Selector('[name="submissionMeta.cosubmission"]').parent())
-    .typeText('[name="submissionMeta.cosubmissionTitle"]', '56789')
-    .click('[data-test-id=next]')
+    .click(metadata.discussedPreviously)
+    .typeText(metadata.discussion, 'Spoke to Bob about another article')
+    .click(metadata.consideredPreviously)
+    .typeText(metadata.previousArticle, '01234')
+    .click(metadata.cosubmission)
+    .typeText(metadata.cosubmissionTitle, '56789')
+    .click(submission.next)
 
   // reviewer suggestions
-  await t
-    .typeText('[name="suggestedSeniorEditors.0"]', 'Sen Yor')
-    .typeText('[name="suggestedSeniorEditors.1"]', 'Eddie Tar')
-    .typeText('[name="suggestedReviewingEditors.0"]', 'Rev. Ewing')
-    .typeText('[name="suggestedReviewingEditors.1"]', 'Ed Eater')
-    .typeText('[name="suggestedReviewers.0.name"]', 'Si Entist')
-    .typeText('[name="suggestedReviewers.0.email"]', 'si.entist@example.com')
-    .typeText('[name="suggestedReviewers.1.name"]', 'Reece Archer')
-    .typeText('[name="suggestedReviewers.1.email"]', 'reece@example.net')
-    .typeText('[name="suggestedReviewers.2.name"]', 'Dave')
-    .typeText('[name="suggestedReviewers.2.email"]', 'dave@example.org')
-    .click(Selector('[name=noConflictOfInterest]').parent())
-    .click('[data-test-id=next]')
+  await suggestions.fillWithDummyData()
+  await t.click(suggestions.conflictOfInterest).click(submission.next)
 
   // dashboard
   await t
-    .expect(Selector('[data-test-id=title]').textContent)
+    .expect(dashboard.titles.textContent)
     .eql(manuscript.title)
-    .expect(Selector('[data-test-id=stage]').textContent)
+    .expect(dashboard.stages.textContent)
     .eql('QA')
 })
 
 test('Submission form details are saved to server on submit', async t => {
-  await t.navigateTo(dashboard.url)
-  await t.ctx.localStorageSet(t.ctx.token)
-
-  await t.navigateTo(dashboard.url).click('[data-test-id=submit]')
+  await dashboard.login()
+  await t.navigateTo(authorDetails.url)
 
   await t
-    .typeText(authorDetails.firstNameField, 'Meghan', {
-      replace: true,
-    })
-    .typeText(authorDetails.secondNameField, 'Moggy', {
-      replace: true,
-    })
-    .typeText(authorDetails.emailField, 'meghan.moggy@life.ac.uk', {
-      replace: true,
-    })
-    .typeText(authorDetails.institutionField, 'iTunes U', { replace: true })
-    .click('[data-test-id=next]')
+    .typeText(authorDetails.firstNameField, 'Meghan')
+    .typeText(authorDetails.secondNameField, 'Moggy')
+    .typeText(authorDetails.emailField, 'meghan@example.com')
+    .typeText(authorDetails.institutionField, 'iTunes U')
+    .click(submission.next)
 
   // ensure save completed before reloading
   await fileUploads.editor
   await t.navigateTo(authorDetails.url)
 
   await t
-    .expect(Selector(authorDetails.firstNameField).value)
+    .expect(authorDetails.firstNameField.value)
     .eql('Meghan', 'First name has been saved')
-    .expect(Selector(authorDetails.secondNameField).value)
+    .expect(authorDetails.secondNameField.value)
     .eql('Moggy', 'Second name has been saved')
-    .expect(Selector(authorDetails.emailField).value)
-    .eql('meghan.moggy@life.ac.uk', 'Email has been saved')
-    .expect(Selector(authorDetails.institutionField).value)
+    .expect(authorDetails.emailField.value)
+    .eql('meghan@example.com', 'Email has been saved')
+    .expect(authorDetails.institutionField.value)
     .eql('iTunes U', 'Institution has been saved')
 })


### PR DESCRIPTION
#### Background

The "Happy path" test was getting too complex and jeopardising its happiness.

This simplifies the happy path and moves diversions and special cases into other tests. One of these includes a test for the notification ribbon being displayed.

Also create page objects for every page to improve maintainability of the tests.

