### PR TITLE
Email corresponding author on Submit instead of Next

### DIFF
--- a/app/components/submission/WizardStep.js
+++ b/app/components/submission/WizardStep.js
@@ -2,28 +2,10 @@ import React from 'react'
 import { Formik } from 'formik'
 import { Box, Flex } from 'grid-styled'
 import { Button } from '@pubsweet/ui'
-import NotificationRibbon from '../ui/atoms/NotificationRibbon'
 import ButtonLink from '../ui/atoms/ButtonLink'
 import { FormH2 } from '../ui/atoms/FormHeadings'
 import AutoSave from './AutoSave'
 import ProgressBar from './ProgressBar'
-
-const EmailVerificationRibbon = ({ values }) => {
-  const show = values.manuscriptPersons.some(
-    manuscriptPerson =>
-      manuscriptPerson.role === 'AUTHOR' &&
-      !manuscriptPerson.metadata.confirmed,
-  )
-  return (
-    show && (
-      <Box mb={5} mx={-3}>
-        <NotificationRibbon data-test-id="author-verification">
-          A verification email has been sent to the corresponding author.
-        </NotificationRibbon>
-      </Box>
-    )
-  )
-}
 
 const WizardStep = ({
   component: FormComponent,
@@ -46,7 +28,6 @@ const WizardStep = ({
     render={({ values, handleSubmit: handleFormSubmit, ...formProps }) => (
       <form noValidate onSubmit={handleFormSubmit}>
         <AutoSave onSave={handleUpdate} values={values} />
-        <EmailVerificationRibbon values={values} />
 
         <ProgressBar currentStep={step} />
         <Box mt={6}>

--- a/server/submission/resolvers.js
+++ b/server/submission/resolvers.js
@@ -142,10 +142,10 @@ const resolvers = {
           logger.error(`Error sending submitter confirmation email: ${err}`)
         })
 
-      if (ctx.user.email !== manuscript.submissionMeta.author.email) {
+      const user = await User.find(ctx.user)
+      if (user.email !== newManuscript.submissionMeta.author.email) {
         mailer
           .send({
-            from: config.get('mailer.from'),
             to: newManuscript.submissionMeta.author.email,
             text: 'Please verify that you are a corresponding author',
           })

--- a/server/submission/resolvers.js
+++ b/server/submission/resolvers.js
@@ -130,18 +130,6 @@ const resolvers = {
       const newManuscriptDb = db.manuscriptGqlToDb(newManuscript, ctx.user)
       await db.update(newManuscriptDb, data.id)
 
-      mailer
-        .send({
-          from: config.get('mailer.from'),
-          to: newManuscript.submissionMeta.author.email,
-          subject: 'Congratulations! You submitted your manuscript!',
-          text: 'Your manuscript has been submitted',
-          html: '<p>Your manuscript has been submitted</p>',
-        })
-        .catch(err => {
-          logger.error(`Error sending submitter confirmation email: ${err}`)
-        })
-
       const user = await User.find(ctx.user)
       if (user.email !== newManuscript.submissionMeta.author.email) {
         mailer

--- a/server/submission/resolvers.js
+++ b/server/submission/resolvers.js
@@ -142,17 +142,19 @@ const resolvers = {
           logger.error(`Error sending submitter confirmation email: ${err}`)
         })
 
-      mailer
-        .send({
-          from: config.get('mailer.from'),
-          to: newManuscript.submissionMeta.author.email,
-          text: 'Please verify that you are a corresponding author',
-        })
-        .catch(err => {
-          logger.error(
-            `Error sending corresponding author verification email: ${err}`,
-          )
-        })
+      if (ctx.user.email !== manuscript.submissionMeta.author.email) {
+        mailer
+          .send({
+            from: config.get('mailer.from'),
+            to: newManuscript.submissionMeta.author.email,
+            text: 'Please verify that you are a corresponding author',
+          })
+          .catch(err => {
+            logger.error(
+              `Error sending corresponding author verification email: ${err}`,
+            )
+          })
+      }
 
       return newManuscript
     },

--- a/server/submission/resolvers.test.js
+++ b/server/submission/resolvers.test.js
@@ -206,8 +206,6 @@ describe('Submission', () => {
       const expectedManuscript = lodash.merge(initialManuscript, manuscript)
       expectedManuscript.submissionMeta.stage = 'QA'
       expect(expectedManuscript).toMatchObject(storedManuscript)
-
-      expect(mailer.getMails()).toHaveLength(1)
     })
 
     it("sends a verification email if the submitter is not the corresponding author - email address entered on step 1 of the wizard differs from submitter's login email", async () => {

--- a/server/submission/resolvers.test.js
+++ b/server/submission/resolvers.test.js
@@ -3,7 +3,7 @@ const config = require('config')
 const fs = require('fs-extra')
 const { createTables } = require('@pubsweet/db-manager')
 const User = require('pubsweet-server/src/models/User')
-const Email = require('@pubsweet/component-send-email')
+const mailer = require('@pubsweet/component-send-email')
 const { save, select, selectId, manuscriptGqlToDb } = require('../db-helpers/')
 const { Mutation, Query } = require('./resolvers')
 const { emptyManuscript } = require('./definitions')
@@ -29,7 +29,7 @@ describe('Submission', () => {
     const user = new User(userData)
     await user.save()
     userId = user.id
-    Email.clearMails()
+    mailer.clearMails()
   })
 
   describe('currentSubmission', () => {
@@ -138,78 +138,6 @@ describe('Submission', () => {
       const expectedManuscript = lodash.merge({}, manuscriptInput)
       expect(actualManuscript).toMatchObject(expectedManuscript)
     })
-
-    describe('corresponding author', () => {
-      it('does not add manuscript person if emails match', async () => {
-        const manuscript = lodash.merge({}, emptyManuscript)
-        manuscript.submissionMeta.author.email = userData.email
-
-        const id = await save(manuscriptGqlToDb(manuscript, userId))
-        await Mutation.updateSubmission(
-          {},
-          {
-            data: { id },
-            isAutoSave: false,
-          },
-          { user: userId },
-        )
-
-        const actualManuscript = await selectId(id)
-        expect(actualManuscript.manuscriptPersons).toHaveLength(0)
-        expect(Email.getMails()).toHaveLength(0)
-      })
-
-      it('adds manuscript person if emails differ', async () => {
-        const manuscript = lodash.merge({}, emptyManuscript)
-        manuscript.submissionMeta.author.email = 'author@example.com'
-
-        const id = await save(manuscriptGqlToDb(manuscript, userId))
-        await Mutation.updateSubmission(
-          {},
-          {
-            data: { id },
-            isAutoSave: false,
-          },
-          { user: userId },
-        )
-
-        const actualManuscript = await selectId(id)
-        expect(actualManuscript.manuscriptPersons).toHaveLength(1)
-        expect(Email.getMails()).toHaveLength(1)
-      })
-
-      it('does not add another manuscript person if already present', async () => {
-        const manuscript = lodash.merge({}, emptyManuscript, {
-          submissionMeta: {
-            author: {
-              email: 'email@example.com',
-            },
-          },
-          manuscriptPersons: [
-            {
-              alias: {
-                email: 'email@example.com',
-              },
-              role: 'AUTHOR',
-            },
-          ],
-        })
-
-        const id = await save(manuscriptGqlToDb(manuscript, userId))
-        await Mutation.updateSubmission(
-          {},
-          {
-            data: { id },
-            isAutoSave: false,
-          },
-          { user: userId },
-        )
-
-        const actualManuscript = await selectId(id)
-        expect(actualManuscript.manuscriptPersons).toHaveLength(1)
-        expect(Email.getMails()).toHaveLength(0)
-      })
-    })
   })
 
   describe('finshSubmission', () => {
@@ -279,7 +207,36 @@ describe('Submission', () => {
       expectedManuscript.submissionMeta.stage = 'QA'
       expect(expectedManuscript).toMatchObject(storedManuscript)
 
-      expect(Email.getMails()).toHaveLength(1)
+      expect(mailer.getMails()).toHaveLength(1)
+    })
+
+    it("sends a verification email if the submitter is not the corresponding author - email address entered on step 1 of the wizard differs from submitter's login email", async () => {
+      const manuscript = lodash.cloneDeep(fullManuscript)
+      manuscript.id = id
+      await Mutation.finishSubmission(
+        {},
+        {
+          data: manuscript,
+        },
+        { user: userId },
+      )
+
+      expect(mailer.getMails()).toHaveLength(1)
+    })
+
+    it('does not send a verification email if the submitter is the corresponding author', async () => {
+      const manuscript = lodash.cloneDeep(fullManuscript)
+      manuscript.id = id
+      manuscript.submissionMeta.author.email = userData.email
+      await Mutation.finishSubmission(
+        {},
+        {
+          data: manuscript,
+        },
+        { user: userId },
+      )
+
+      expect(mailer.getMails()).toHaveLength(0)
     })
 
     // TODO more tests needed here

--- a/test/pageObjects/submission.js
+++ b/test/pageObjects/submission.js
@@ -1,7 +1,6 @@
 import { Selector } from 'testcafe'
 
 const fileUploads = {
-  verificationRibbon: Selector('[data-test-id=author-verification]'),
   next: Selector('[data-test-id=next]'),
 }
 

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -52,9 +52,6 @@ test('Happy path', async t => {
 
   // file uploads
   await t
-    // TODO re-enable this assertion once https://github.com/elifesciences/elife-xpub/issues/309 is resolved
-    // .expect(submission.verificationRibbon.exists)
-    // .eql(false)
     .typeText(fileUploads.editor, '\nPlease consider this for publication')
     .setFilesToUpload(fileUploads.manuscriptUpload, manuscript.file)
     // wait for editor onChange
@@ -114,8 +111,6 @@ test('Corresponding author', async t => {
 
   // file uploads
   await t
-    .expect(submission.verificationRibbon.exists)
-    .eql(true)
     .typeText(fileUploads.editor, '\nPlease consider this for publication')
     .setFilesToUpload(fileUploads.manuscriptUpload, manuscript.file)
     // wait for editor onChange


### PR DESCRIPTION
#### Background
Product requirements now have the corresponding author emailed on Submit, rather than on clicking Next in step 1 of the wizard.

The corresponding author no longer needs to be added to the manuscript object in the middle of the submission process (`updateSubmission` resolver). Differentiating between the submitter email address & the corresponding author email address is to be completed in another ticket - issue #309 

#### What does this PR do?
- Removes code that adds corresponding author to the manuscript object on clicking 'Next' & associated tests
- Moves the sending of an email from the 'updateSubmission' resolver to the `finishSubmission` resolver  
**Note: This email is currently sent every time a user clicks 'Submit'. In order to check whether it should be sent, we first need to store the submitter's email address somewhere** - see issue #309 
- Removes the notification ribbon from the wizard - decision on how/where to display this to the user is still pending
- Removes the 'Confirmation' email that was being sent to the submitter whenever they clicked 'Submit'  (issue #240) - necessary to do within this PR, in order for tests to pass

#### Any relevant tickets
fixes #310 #240 

#### How has this been tested?
Added tests for `finishSubmission` resolver:
- check that email isn't sent if submitter = corresponding author
- check that email is sent if submitter & corresponding author are different