### PR TITLE
style: apply consistent spacing to next and previous buttons

### DIFF
--- a/app/components/submission/AuthorDetails/AuthorDetails.js
+++ b/app/components/submission/AuthorDetails/AuthorDetails.js
@@ -1,16 +1,10 @@
 import React from 'react'
 import { Flex, Box } from 'grid-styled'
-import { Button, Action, ErrorText } from '@pubsweet/ui'
-import { FormH2 } from '../../ui/atoms/FormHeadings'
+import { Action, ErrorText } from '@pubsweet/ui'
 import ValidatedField from '../../ui/atoms/ValidatedField'
-import ProgressBar from '../ProgressBar'
 
-const AuthorDetails = ({ handleSubmit, fetchOrcid, loading, error }) => (
-  <form noValidate onSubmit={handleSubmit}>
-    <ProgressBar currentStep={0} />
-
-    <FormH2>Who is the corresponding author?</FormH2>
-
+const AuthorDetails = ({ fetchOrcid, loading, error }) => (
+  <React.Fragment>
     <p>
       <Action data-test-id="orcid-prefill" onClick={fetchOrcid}>
         Pre-fill my details
@@ -51,15 +45,7 @@ const AuthorDetails = ({ handleSubmit, fetchOrcid, loading, error }) => (
         />
       </Box>
     </Flex>
-
-    <Flex>
-      <Box width={1}>
-        <Button data-test-id="next" primary type="submit">
-          Next
-        </Button>
-      </Box>
-    </Flex>
-  </form>
+  </React.Fragment>
 )
 
 export default AuthorDetails

--- a/app/components/submission/AutoSave.js
+++ b/app/components/submission/AutoSave.js
@@ -29,7 +29,7 @@ export default class AutoSave extends React.Component {
   }
 
   render() {
-    return this.props.children
+    return this.props.children || null
   }
 }
 

--- a/app/components/submission/FileUploads/FileUploads.js
+++ b/app/components/submission/FileUploads/FileUploads.js
@@ -2,10 +2,7 @@
 
 import React from 'react'
 import { Flex, Box } from 'grid-styled'
-import { Button } from '@pubsweet/ui'
 import ConfigurableEditor from 'xpub-edit/src/components/configurable/ConfigurableEditor'
-import { FormH2 } from '../../ui/atoms/FormHeadings'
-import ButtonLink from '../../ui/atoms/ButtonLink'
 import FileUpload from '../../ui/molecules/FileUpload'
 import ValidatedField from '../../ui/atoms/ValidatedField'
 import IconTextBold from '../../ui/atoms/icons/TextBold'
@@ -13,7 +10,6 @@ import IconTextItalic from '../../ui/atoms/icons/TextItalic'
 import IconTextUnderline from '../../ui/atoms/icons/TextUnderline'
 import IconTextSub from '../../ui/atoms/icons/TextSub'
 import IconTextSup from '../../ui/atoms/icons/TextSup'
-import ProgressBar from '../ProgressBar'
 
 // order of props affects order of menu buttons
 const Editor = ({ validationStatus, ...props }) => (
@@ -28,44 +24,32 @@ const Editor = ({ validationStatus, ...props }) => (
 )
 
 const FileUploads = ({
-  handleSubmit,
   setFieldValue,
   onDrop,
   conversion,
   formError,
   previewUrl,
 }) => (
-  <form onSubmit={handleSubmit}>
-    <ProgressBar currentStep={1} />
-
-    <FormH2>Write your cover letter and upload your manuscript</FormH2>
-
-    <Flex flexDirection="column">
-      <Box mb={3} width={1}>
-        <ValidatedField
-          component={Editor}
-          id="coverLetter"
-          name="submissionMeta.coverLetter"
-          onBlur={value => setFieldValue('submissionMeta.coverLetter', value)}
-          onChange={value => setFieldValue('submissionMeta.coverLetter', value)}
-        />
-      </Box>
-      <Box mb={3} width={1}>
-        <FileUpload
-          conversion={conversion}
-          data-test-id="upload"
-          formError={formError}
-          onDrop={onDrop}
-          previewUrl={previewUrl}
-        />
-      </Box>
-    </Flex>
-
-    <ButtonLink to="/submit">Back</ButtonLink>
-    <Button data-test-id="next" primary type="submit">
-      Next
-    </Button>
-  </form>
+  <Flex flexDirection="column">
+    <Box mb={3} width={1}>
+      <ValidatedField
+        component={Editor}
+        id="coverLetter"
+        name="submissionMeta.coverLetter"
+        onBlur={value => setFieldValue('submissionMeta.coverLetter', value)}
+        onChange={value => setFieldValue('submissionMeta.coverLetter', value)}
+      />
+    </Box>
+    <Box mb={3} width={1}>
+      <FileUpload
+        conversion={conversion}
+        data-test-id="upload"
+        formError={formError}
+        onDrop={onDrop}
+        previewUrl={previewUrl}
+      />
+    </Box>
+  </Flex>
 )
 
 export default FileUploads

--- a/app/components/submission/ManuscriptMetadata/ManuscriptMetadata.js
+++ b/app/components/submission/ManuscriptMetadata/ManuscriptMetadata.js
@@ -1,16 +1,13 @@
 import React from 'react'
-import { Menu, Checkbox, Button } from '@pubsweet/ui'
+import { Menu, Checkbox } from '@pubsweet/ui'
 import { Field } from 'formik'
 import { get } from 'lodash'
 import { Box } from 'grid-styled'
 
 import ValidatedField from '../../ui/atoms/ValidatedField'
 import CalloutBox from '../../ui/atoms/CalloutBox'
-import ButtonLink from '../../ui/atoms/ButtonLink'
 import Textarea from '../../ui/atoms/Textarea'
-import ProgressBar from '../ProgressBar'
 import SubjectAreaDropdown from './SubjectAreaDropdown'
-import { FormH2 } from '../../ui/atoms/FormHeadings'
 
 const CheckboxGeneratedChild = ({
   fieldName,
@@ -31,17 +28,8 @@ const CheckboxGeneratedChild = ({
   </Box>
 )
 
-const ManuscriptMetadata = ({
-  handleSubmit,
-  values,
-  setFieldValue,
-  setFieldTouched,
-}) => (
-  <form noValidate onSubmit={handleSubmit}>
-    <ProgressBar currentStep={2} />
-
-    <FormH2>Help us get your work seen by the right people</FormH2>
-
+const ManuscriptMetadata = ({ values, setFieldValue, setFieldTouched }) => (
+  <React.Fragment>
     <ValidatedField label="Manuscript title" name="title" />
 
     <Box mb={3} w={1 / 2}>
@@ -110,12 +98,7 @@ const ManuscriptMetadata = ({
         />
       </div>
     </CheckboxGeneratedChild>
-
-    <ButtonLink to="/submit/upload">Back</ButtonLink>
-    <Button data-test-id="next" primary type="submit">
-      Next
-    </Button>
-  </form>
+  </React.Fragment>
 )
 
 export default ManuscriptMetadata

--- a/app/components/submission/ReviewerSuggestions/ReviewerSuggestions.js
+++ b/app/components/submission/ReviewerSuggestions/ReviewerSuggestions.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import { Box } from 'grid-styled'
-import { Button, Action } from '@pubsweet/ui'
+import { Action } from '@pubsweet/ui'
 
-import ButtonLink from '../../ui/atoms/ButtonLink'
-import ProgressBar from '../ProgressBar'
 import {
   Declaration,
   ExcludedReviewer,
@@ -13,7 +11,7 @@ import {
   SuggestedReviewingEditorRow,
   SuggestedSeniorEditorRow,
 } from './FormSections'
-import { FormH2, FormH3 } from '../../ui/atoms/FormHeadings'
+import { FormH3 } from '../../ui/atoms/FormHeadings'
 
 const MoreButton = ({
   empty,
@@ -36,12 +34,8 @@ const MoreButton = ({
 
 const MAX_EXCLUDED_EDITORS = 2
 
-const ReviewerSuggestions = ({ handleSubmit, values, setFieldValue }) => (
-  <form noValidate onSubmit={handleSubmit}>
-    <ProgressBar currentStep={3} />
-
-    <FormH2>Who should review your work?</FormH2>
-
+const ReviewerSuggestions = ({ values, setFieldValue }) => (
+  <React.Fragment>
     <FormH3>Suggest a Senior Editor</FormH3>
 
     <SuggestedSeniorEditorRow rowIndex={0} />
@@ -146,12 +140,7 @@ const ReviewerSuggestions = ({ handleSubmit, values, setFieldValue }) => (
     </Box>
 
     <Declaration />
-
-    <ButtonLink to="/submit/metadata">Back</ButtonLink>
-    <Button data-test-id="next" primary type="submit">
-      Submit
-    </Button>
-  </form>
+  </React.Fragment>
 )
 
 export default ReviewerSuggestions

--- a/app/components/submission/SubmissionPage.js
+++ b/app/components/submission/SubmissionPage.js
@@ -31,6 +31,9 @@ const SubmissionPage = ({ match, history }) => (
               history={history}
               initialValues={initialValues}
               nextUrl={`${match.path}/metadata`}
+              previousUrl={`${match.path}`}
+              step={1}
+              title="Write your cover letter and upload your manuscript"
               validationSchema={fileUploadsSchema}
             />
           )}
@@ -45,6 +48,9 @@ const SubmissionPage = ({ match, history }) => (
               history={history}
               initialValues={initialValues}
               nextUrl={`${match.path}/suggestions`}
+              previousUrl={`${match.path}/upload`}
+              step={2}
+              title="Help us get your work seen by the right people"
               validationSchema={manuscriptMetadataSchema}
             />
           )}
@@ -59,6 +65,10 @@ const SubmissionPage = ({ match, history }) => (
               history={history}
               initialValues={initialValues}
               nextUrl="/dashboard"
+              previousUrl={`${match.path}/metadata`}
+              step={3}
+              submitButtonText="Submit"
+              title="Who should review your work?"
               validationSchema={reviewerSuggestionsSchema}
             />
           )}
@@ -72,6 +82,8 @@ const SubmissionPage = ({ match, history }) => (
               history={history}
               initialValues={initialValues}
               nextUrl={`${match.path}/upload`}
+              step={0}
+              title="Who is the corresponding author?"
               validationSchema={authorDetailsSchema}
             />
           )}

--- a/app/components/submission/WizardStep.js
+++ b/app/components/submission/WizardStep.js
@@ -1,8 +1,12 @@
 import React from 'react'
 import { Formik } from 'formik'
-import { Box } from 'grid-styled'
-import AutoSave from './AutoSave'
+import { Box, Flex } from 'grid-styled'
+import { Button } from '@pubsweet/ui'
 import NotificationRibbon from '../ui/atoms/NotificationRibbon'
+import ButtonLink from '../ui/atoms/ButtonLink'
+import { FormH2 } from '../ui/atoms/FormHeadings'
+import AutoSave from './AutoSave'
+import ProgressBar from './ProgressBar'
 
 const EmailVerificationRibbon = ({ values }) => {
   const show = values.manuscriptPersons.some(
@@ -27,7 +31,11 @@ const WizardStep = ({
   handleUpdate,
   history,
   nextUrl,
+  previousUrl,
   initialValues,
+  title,
+  step,
+  submitButtonText = 'Next',
   validationSchema,
 }) => (
   <Formik
@@ -35,11 +43,30 @@ const WizardStep = ({
     // ensure each page gets a new form instance otherwise all fields are touched
     key={FormComponent.name}
     onSubmit={values => handleSubmit(values).then(() => history.push(nextUrl))}
-    render={formProps => (
-      <AutoSave onSave={handleUpdate} values={formProps.values}>
-        <EmailVerificationRibbon values={formProps.values} />
-        <FormComponent {...formProps} />
-      </AutoSave>
+    render={({ values, handleSubmit: handleFormSubmit, ...formProps }) => (
+      <form noValidate onSubmit={handleFormSubmit}>
+        <AutoSave onSave={handleUpdate} values={values} />
+        <EmailVerificationRibbon values={values} />
+
+        <ProgressBar currentStep={step} />
+        <Box mt={6}>
+          <FormH2>{title}</FormH2>
+        </Box>
+        <FormComponent values={values} {...formProps} />
+
+        <Flex mt={5}>
+          {previousUrl && (
+            <Box mr={3}>
+              <ButtonLink to={previousUrl}>Back</ButtonLink>
+            </Box>
+          )}
+          <Box>
+            <Button data-test-id="next" primary type="submit">
+              {submitButtonText}
+            </Button>
+          </Box>
+        </Flex>
+      </form>
     )}
     validationSchema={validationSchema}
   />

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -102,6 +102,8 @@ test('Corresponding author', async t => {
       'Error is displayed when user enters invalid email',
     )
     .click(submission.next)
+    // without this wait the tests sometimes fail on CI ¯\_(ツ)_/¯
+    .wait(1000)
     .expect(ClientFunction(() => window.location.href)())
     .eql(
       authorDetails.url,
@@ -129,7 +131,6 @@ test('Corresponding author', async t => {
 
   // metadata
   await t
-    .wait(1000)
     .expect(metadata.title.value)
     .eql(manuscript.title)
     .click(metadata.articleType)


### PR DESCRIPTION
#### Background

Instead of having the buttons on each page, move them up into the shared `WizardStep` component. As well as reducing duplication, this paves the way for the QC page which needs to combine the four steps into a single form with a single submit button.

#### Any relevant tickets

No, going off road a little here to distract myself from the misery of debugging end to end tests.

#### How has this been tested?

Visually.