### PR TITLE
remove success & warning borders on validation

### DIFF
--- a/app/components/ui/atoms/Textarea.js
+++ b/app/components/ui/atoms/Textarea.js
@@ -8,17 +8,10 @@ const Label = styled.label`
   font-size: ${th('fontSizeBaseSmall')};
 `
 
-// TODO - remove when this function is added to pubsweet
-const borderColor = ({ theme, validationStatus = 'default' }) =>
-  ({
-    error: theme.colorError,
-    success: theme.colorSuccess,
-    warning: theme.colorWarning,
-    default: theme.colorBorder,
-  }[validationStatus])
-
 const Input = styled.textarea`
-  border: ${th('borderWidth')} ${th('borderStyle')} ${borderColor};
+  border: ${th('borderWidth')} ${th('borderStyle')}
+    ${({ validationStatus }) =>
+      validationStatus === 'error' ? th('colorError') : th('colorBorder')};
 
   border-radius: ${th('borderRadius')};
 

--- a/client/elife-theme/src/elements/ui/TextField.js
+++ b/client/elife-theme/src/elements/ui/TextField.js
@@ -10,7 +10,9 @@ import { th } from '@pubsweet/ui-toolkit'
  */
 export default {
   Input: css`
-    color: ${th('colorText')};
+    border: ${th('borderWidth')} ${th('borderStyle')}
+      ${({ validationStatus }) =>
+        validationStatus === 'error' ? th('colorError') : th('colorBorder')};
     font-family: ${th('fontInterface')};
     font-size: 16px;
     line-height: 24px;


### PR DESCRIPTION
#### What does this PR do?
- remove border colour change for 'success' and 'warning' states on `TextField` & `TextArea`

#### Any relevant tickets
fixes #303 

#### How has this been tested?
Visually, manually