### PR TITLE
feat: improve request logging

### DIFF
--- a/app/components/dashboard/DashboardPage.js
+++ b/app/components/dashboard/DashboardPage.js
@@ -5,7 +5,7 @@ import { GET_CURRENT_SUBMISSION } from '../submission/WithCurrentSubmission'
 import Dashboard from './Dashboard'
 
 export const MANUSCRIPTS_QUERY = gql`
-  query {
+  query DashboardManuscripts {
     manuscripts {
       id
       title
@@ -17,7 +17,7 @@ export const MANUSCRIPTS_QUERY = gql`
 `
 
 export const DELETE_MANUSCRIPT_MUTATION = gql`
-  mutation($id: ID!) {
+  mutation DeleteManuscript($id: ID!) {
     deleteManuscript(id: $id)
   }
 `

--- a/config/default.js
+++ b/config/default.js
@@ -16,6 +16,8 @@ module.exports = {
     logger,
     uploads: 'uploads',
     enableExperimentalGraphql: true,
+    morganLogFormat:
+      ':remote-addr [:date[clf]] :method :url :status :graphql[operation] :res[content-length] :response-time ms',
   },
   'pubsweet-client': {
     API_ENDPOINT: '/api',

--- a/config/development.js
+++ b/config/development.js
@@ -11,6 +11,8 @@ module.exports = {
     secret: 'not very secret',
     graphiql: true,
     logger: winston,
+    morganLogFormat:
+      ':method :url :status :graphql[operation] :res[content-length] :response-time ms',
   },
 
   dbManager: {


### PR DESCRIPTION
#### Background

Use the new `morganLogFormat` option in `pubsweet-server` to improve the log output.

- Log graphql operation name
- Don't log user agent string
- Only log remote IP and time in test/production

Old:
```
info: ::1 - - [11/Jul/2018:11:14:41 +0000] "POST /graphql HTTP/1.1" 200 133 "http://localhost:3000/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36"

info: ::1 - - [11/Jul/2018:11:14:41 +0000] "POST /graphql HTTP/1.1" 200 385 "http://localhost:3000/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36"
```

New (development):
```
info: POST /graphql 200 CurrentUser 133 361.909 ms

info: POST /graphql 200 DashboardManuscripts 385 11.297 ms
```

New (test and production):
```
info: ::1 [11/Jul/2018:11:14:41 +0000] POST /graphql 200 CurrentUser 133 361.909 ms

info: ::1 [11/Jul/2018:11:14:41 +0000] POST /graphql 200 DashboardManuscripts 385 11.297 ms
```
#### How has this been tested?

Manually.