### PR TITLE
Scaling down the cluster out of hours

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,8 +121,6 @@ review:
   stage: review
   tags:
     - elife-kubernetes-runner
-  except:
-    - schedules
   variables:
     PACKAGE_NAME: xpub-elife
     FORCE_FRESH_DB: "yes"
@@ -135,6 +133,7 @@ review:
   except:
   - master
   - develop
+  - schedules
   script:
     - source deploy.sh
     - create_deployment
@@ -144,8 +143,6 @@ stop_review:
   stage: review
   tags:
     - elife-kubernetes-runner
-  except:
-    - schedules
   variables:
     PACKAGE_NAME: xpub-elife
     REQUIRES_PROVISIONING: "yes"
@@ -157,6 +154,7 @@ stop_review:
   except:
   - master
   - develop
+  - schedules
   script:
     - source deploy.sh
     - delete_deployment

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -184,7 +184,8 @@ demo:
 scale-cluster:
   image: pubsweet/kubernetes:latest
   stage: build
-  when: manual
+  variables:
+    DOCKER_HOST: ""
   only:
     - shedules
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -164,11 +164,21 @@ demo:
     - create_deployment
 
 scale-cluster:up:
-  stage: build
   image: pubsweet/kubernetes:latest
+  stage: build
   variables:
     MIN_SIZE: 9
     MAX_SIZE: 9
+  when: manual
+  script:
+    - scale-cluster
+
+scale-cluster:down:
+  image: pubsweet/kubernetes:latest
+  stage: build
+  variables:
+    MIN_SIZE: 1
+    MAX_SIZE: 1
   when: manual
   script:
     - scale-cluster

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,6 +170,8 @@ scale-cluster:up:
     MIN_SIZE: 9
     MAX_SIZE: 9
   when: manual
+  tags:
+    - docker
   script:
     - scale-cluster
 
@@ -180,5 +182,7 @@ scale-cluster:down:
     MIN_SIZE: 1
     MAX_SIZE: 1
   when: manual
+  tags:
+    - docker
   script:
     - scale-cluster

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,8 @@ stages:
 build:
   image: docker:latest
   stage: build
+  except:
+    - shedules
   script:
     - docker version
     - docker pull $IMAGE_ORG/$IMAGE_NAME:latest
@@ -32,6 +34,8 @@ build:
 lint:
   image: $IMAGE_ORG/$IMAGE_NAME:$CI_COMMIT_SHA
   stage: test
+  except:
+    - shedules
   variables:
     GIT_STRATEGY: none
   script:
@@ -41,6 +45,8 @@ lint:
 test:
   image: $IMAGE_ORG/$IMAGE_NAME:$CI_COMMIT_SHA
   stage: test
+  except:
+    - shedules
   variables:
     GIT_STRATEGY: none
     # setup data for postgres image
@@ -60,6 +66,8 @@ test:
 test:e2e:
   image: $IMAGE_ORG/$IMAGE_NAME:$CI_COMMIT_SHA
   stage: test
+  except:
+    - shedules
   variables:
     GIT_STRATEGY: none
     BROWSER: chrome:headless --no-sandbox
@@ -86,6 +94,8 @@ test:e2e:
 push:latest:
   image: docker:latest
   stage: staging
+  except:
+    - shedules
   script:
     - if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_PASSWORD" ]; then echo "Not pushing" && exit 0; fi
     - docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
@@ -99,6 +109,8 @@ push:latest:
 review:
   image: pubsweet/deployer:latest
   stage: review
+  except:
+    - shedules
   variables:
     PACKAGE_NAME: xpub-elife
     FORCE_FRESH_DB: "yes"
@@ -118,6 +130,8 @@ review:
 stop_review:
   image: pubsweet/deployer:latest
   stage: review
+  except:
+    - shedules
   variables:
     PACKAGE_NAME: xpub-elife
     REQUIRES_PROVISIONING: "yes"
@@ -137,6 +151,8 @@ stop_review:
 staging:
   image: pubsweet/deployer:latest
   stage: staging
+  except:
+    - shedules
   variables:
     PACKAGE_NAME: xpub-elife
     REQUIRES_PROVISIONING: "yes"
@@ -152,6 +168,8 @@ staging:
 demo:
   image: pubsweet/deployer:latest
   stage: demo
+  except:
+    - shedules
   variables:
     PACKAGE_NAME: xpub-elife
     REQUIRES_PROVISIONING: "yes"
@@ -163,25 +181,12 @@ demo:
     - source deploy.sh
     - create_deployment
 
-scale-cluster:up:
+scale-cluster:
   image: pubsweet/kubernetes:latest
   stage: build
-  variables:
-    MIN_SIZE: 9
-    MAX_SIZE: 9
   when: manual
-  tags:
-    - docker
-  script:
-    - scale-cluster
-
-scale-cluster:down:
-  image: pubsweet/kubernetes:latest
-  stage: build
-  variables:
-    MIN_SIZE: 1
-    MAX_SIZE: 1
-  when: manual
+  only:
+    - shedules
   tags:
     - docker
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,8 @@ stages:
 build:
   image: docker:latest
   stage: build
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   script:
@@ -34,6 +36,8 @@ build:
 lint:
   image: $IMAGE_ORG/$IMAGE_NAME:$CI_COMMIT_SHA
   stage: test
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   variables:
@@ -45,6 +49,8 @@ lint:
 test:
   image: $IMAGE_ORG/$IMAGE_NAME:$CI_COMMIT_SHA
   stage: test
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   variables:
@@ -66,6 +72,8 @@ test:
 test:e2e:
   image: $IMAGE_ORG/$IMAGE_NAME:$CI_COMMIT_SHA
   stage: test
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   variables:
@@ -94,6 +102,8 @@ test:e2e:
 push:latest:
   image: docker:latest
   stage: staging
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   script:
@@ -109,6 +119,8 @@ push:latest:
 review:
   image: pubsweet/deployer:latest
   stage: review
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   variables:
@@ -130,6 +142,8 @@ review:
 stop_review:
   image: pubsweet/deployer:latest
   stage: review
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   variables:
@@ -151,6 +165,8 @@ stop_review:
 staging:
   image: pubsweet/deployer:latest
   stage: staging
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   variables:
@@ -168,6 +184,8 @@ staging:
 demo:
   image: pubsweet/deployer:latest
   stage: demo
+  tags:
+    - elife-kubernetes-runner
   except:
     - shedules
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ build:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   script:
     - docker version
     - docker pull $IMAGE_ORG/$IMAGE_NAME:latest
@@ -39,7 +39,7 @@ lint:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   variables:
     GIT_STRATEGY: none
   script:
@@ -52,7 +52,7 @@ test:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   variables:
     GIT_STRATEGY: none
     # setup data for postgres image
@@ -75,7 +75,7 @@ test:e2e:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   variables:
     GIT_STRATEGY: none
     BROWSER: chrome:headless --no-sandbox
@@ -105,7 +105,7 @@ push:latest:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   script:
     - if [ -z "$DOCKERHUB_USERNAME" ] || [ -z "$DOCKERHUB_PASSWORD" ]; then echo "Not pushing" && exit 0; fi
     - docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
@@ -122,7 +122,7 @@ review:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   variables:
     PACKAGE_NAME: xpub-elife
     FORCE_FRESH_DB: "yes"
@@ -145,7 +145,7 @@ stop_review:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   variables:
     PACKAGE_NAME: xpub-elife
     REQUIRES_PROVISIONING: "yes"
@@ -168,7 +168,7 @@ staging:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   variables:
     PACKAGE_NAME: xpub-elife
     REQUIRES_PROVISIONING: "yes"
@@ -187,7 +187,7 @@ demo:
   tags:
     - elife-kubernetes-runner
   except:
-    - shedules
+    - schedules
   variables:
     PACKAGE_NAME: xpub-elife
     REQUIRES_PROVISIONING: "yes"
@@ -205,7 +205,7 @@ scale-cluster:
   variables:
     DOCKER_HOST: ""
   only:
-    - shedules
+    - schedules
   tags:
     - docker
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -162,3 +162,13 @@ demo:
   script:
     - source deploy.sh
     - create_deployment
+
+scale-cluster:up:
+  stage: build
+  image: pubsweet/kubernetes:latest
+  variables:
+    MIN_SIZE: 9
+    MAX_SIZE: 9
+  when: manual
+  script:
+    - scale-cluster


### PR DESCRIPTION
#### Background

Addresses #331 

Uses [pubsweet/kubernetes](https://gitlab.coko.foundation/pubsweet/infra/blob/master/kubernetes/Dockerfile) and [Gitlab CI](https://gitlab.com/elifesciences/elife-xpub/pipeline_schedules) to scale down the Kubernetes cluster at 8pm, and scale up the cluster at 8am on weekdays. 

After the operation, a rolling update will be performed to balance deployments across the cluster, to balance out resource usage, CPU being the main concern. This takes about an hour.

#### How has this been tested?

The scheduled jobs can be [run manually](https://gitlab.com/elifesciences/elife-xpub/pipeline_schedules), which has been done.
