### PR TITLE
fix: using dynamic test databases rather than a default

### DIFF
--- a/server/jest-setup.js
+++ b/server/jest-setup.js
@@ -40,7 +40,6 @@ beforeAll(async () => {
     db = new pg.Client()
     await db.connect()
     await db.query(`CREATE DATABASE ${mockTestDbName}`)
-    await db.query(``)
   }
 })
 

--- a/server/jest-setup.js
+++ b/server/jest-setup.js
@@ -4,8 +4,8 @@ let mockTestDbName
 jest.mock('pubsweet-server/src/db', () => {
   const pg = require('pg')
   const logger = require('@pubsweet/logger')
-  mockTestDbName = `test_${Math.floor(Math.random() * 9999999)}`
-  const pool = new pg.Pool({ db: mockTestDbName })
+  mockTestDbName = `test_${Date.now()}_${Math.floor(Math.random() * 9999999)}`
+  const pool = new pg.Pool({ database: mockTestDbName })
   pool.on('error', err => {
     if (err.message !== 'terminating connection due to administrator command') {
       logger.error(err)
@@ -40,8 +40,7 @@ beforeAll(async () => {
     db = new pg.Client()
     await db.connect()
     await db.query(`CREATE DATABASE ${mockTestDbName}`)
-    const { createTables } = require('@pubsweet/db-manager')
-    await createTables(true)
+    await db.query(``)
   }
 })
 


### PR DESCRIPTION
#### Background

The server-side tests have been failing sporadically on our local machines. This was because all the tests were all using the same default database causing them to be polluted by each other's setup. They were meant to be using a dynamically created database to avoid this.

This allows the tests to be run in parallel on multi-core machines, but they would pass on CI because of the build runners having a single core.
