### PR TITLE
chore: added script to stop database and remove volumes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "setupdb": "pubsweet setupdb",
     "start": "docker-compose up",
     "start:services": "docker-compose up postgres",
+    "stop:services": "docker-compose down -v",
     "start:styleguide": "docker-compose run --no-deps -p 6060:6060 app yarn run styleguide",
     "styleguide": "styleguidist server",
     "test": "jest",


### PR DESCRIPTION
#### Background

There are cases where you would want to stop and cleanly remove the postgres service locally on your machine. This script removes the service as well as it's volume, so the next time it's started, you get a clean container which gets set up from scratch.
