### PR TITLE
feat: people picker modal container with margins and buttons

### DIFF
--- a/app/components/global/Centerer.js
+++ b/app/components/global/Centerer.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+import { Box } from 'grid-styled'
+
+const Centerer = styled(Box).attrs({
+  mx: 'auto',
+  px: 3,
+  width: [1, 1, 1, 1, 1272],
+})``
+
+export default Centerer

--- a/app/components/global/Layout.js
+++ b/app/components/global/Layout.js
@@ -1,13 +1,11 @@
 import React from 'react'
-import { Box } from 'grid-styled'
+import Centerer from './Centerer'
 import AppBar from './AppBar'
 
 const Layout = ({ children }) => (
   <React.Fragment>
     <AppBar />
-    <Box mx="auto" px={3} width={[1, 1, 1, 1, 1272]}>
-      {children}
-    </Box>
+    <Centerer>{children}</Centerer>
   </React.Fragment>
 )
 

--- a/app/components/pages/SubmissionWizard/steps/Author/AuthorDetails.md
+++ b/app/components/pages/SubmissionWizard/steps/Author/AuthorDetails.md
@@ -3,7 +3,7 @@ submitted.
 
 ```js
 const { Formik } = formik
-const { schema } = require('./AuthorDetailsSchema')
+const { schema } = require('./schema')
 
 const empty = {
   submissionMeta: {

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Button } from '@pubsweet/ui'
+import { th } from '@pubsweet/ui-toolkit'
+import { Box, Flex } from 'grid-styled'
+
+import ModalOverlay from '../../../../ui/molecules/ModalOverlay'
+import Centerer from '../../../../global/Centerer'
+
+const ButtonBar = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100vw;
+  border-top: ${th('borderWidth')} ${th('borderStyle')} ${th('colorBorder')};
+`
+
+const PeoplePickerModal = ({ open, onRequestClose, onRequestAdd }) => (
+  <ModalOverlay open={open}>
+    <Centerer p={3}>
+      <Flex>
+        <Box flex="1 1 auto" mx={[0, 0, 0, '16.666%']}>
+          People picker goes here
+        </Box>
+      </Flex>
+    </Centerer>
+    <ButtonBar>
+      <Centerer px={2} py={4}>
+        <Flex>
+          <Box flex="1 1 auto" mx={[0, 0, 0, '16.666%']}>
+            <Flex>
+              <Box mx={2}>
+                <Button onClick={onRequestClose}>Cancel</Button>
+              </Box>
+              <Box mx={2}>
+                <Button disabled onClick={onRequestAdd} primary>
+                  Add
+                </Button>
+              </Box>
+            </Flex>
+          </Box>
+        </Flex>
+      </Centerer>
+    </ButtonBar>
+  </ModalOverlay>
+)
+
+export default PeoplePickerModal

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
@@ -1,0 +1,13 @@
+A people picker in a modal
+
+```js
+initialState = { open: false }
+;<div>
+  <button onClick={() => setState({ open: true })}>Open</button>
+
+  <PeoplePickerModal
+    open={state.open}
+    onRequestClose={() => setState({ open: false })}
+  />
+</div>
+```

--- a/app/components/pages/SubmissionWizard/steps/Editors/index.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/index.md
@@ -1,6 +1,6 @@
 ```js
 const { Formik } = formik
-const { schema, empty } = require('./ReviewerSuggestionsSchema')
+const { schema, empty } = require('./schema')
 ;<Formik
   component={ReviewerSuggestions}
   initialValues={empty}

--- a/app/components/pages/SubmissionWizard/steps/Files/FileUploads.md
+++ b/app/components/pages/SubmissionWizard/steps/Files/FileUploads.md
@@ -2,7 +2,7 @@ A set of controls for uploading files
 
 ```js
 const { Formik } = formik
-const { schema } = require('./FileUploadsSchema')
+const { schema } = require('./schema')
 const empty = { coverLetter: '' }
 ;<Formik
   initialValues={empty}

--- a/app/components/pages/SubmissionWizard/steps/Submission/index.md
+++ b/app/components/pages/SubmissionWizard/steps/Submission/index.md
@@ -2,7 +2,7 @@ A form for entering metadata about the article being submitted e.g. title, type,
 
 ```js
 const { Formik } = formik
-const { schema, empty } = require('./ManuscriptMetadataSchema')
+const { schema, empty } = require('./schema')
 ;<Formik
   component={ManuscriptMetadata}
   initialValues={empty}

--- a/app/components/ui/molecules/ModalOverlay.js
+++ b/app/components/ui/molecules/ModalOverlay.js
@@ -2,6 +2,7 @@ import React from 'react'
 import styled, { withTheme } from 'styled-components'
 import { CSSTransition } from 'react-transition-group'
 import ScrollLock from 'react-scrolllock'
+import PropTypes from 'prop-types'
 import { th } from '@pubsweet/ui-toolkit'
 
 const Root = styled.div``
@@ -58,5 +59,10 @@ const ModalOverlay = ({ children, open, theme }) => (
     </CSSTransition>
   </Root>
 )
+
+ModalOverlay.propTypes = {
+  open: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+}
 
 export default withTheme(ModalOverlay)


### PR DESCRIPTION
#### Background

Creates an instance of a `ModalOverlay` with appropriate layout and Add/Cancel buttons. The people picker search and selection interface will be slotted in here when complete.

Closes #346 
Closes #356 

#### How has this been tested?

Visually in styleguide.
