### PR TITLE
feat: people picker selection functionality

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Button } from '@pubsweet/ui'
 import { th } from '@pubsweet/ui-toolkit'
 import { Box, Flex } from 'grid-styled'
 
-import ModalOverlay from '../../../../ui/molecules/ModalOverlay'
 import Centerer from '../../../../global/Centerer'
+import ModalOverlay from '../../../../ui/molecules/ModalOverlay'
+import PeoplePicker from '../../../../ui/molecules/PeoplePicker'
 
-const ButtonBar = styled.div`
+const ButtonBarContainer = styled.div`
   position: fixed;
   bottom: 0;
   left: 0;
@@ -15,33 +15,30 @@ const ButtonBar = styled.div`
   border-top: ${th('borderWidth')} ${th('borderStyle')} ${th('colorBorder')};
 `
 
-const PeoplePickerModal = ({ open, onRequestClose, onRequestAdd }) => (
+const PeoplePickerModal = ({ open, ...props }) => (
   <ModalOverlay open={open}>
-    <Centerer p={3}>
-      <Flex>
-        <Box flex="1 1 auto" mx={[0, 0, 0, '16.666%']}>
-          People picker goes here
-        </Box>
-      </Flex>
-    </Centerer>
-    <ButtonBar>
-      <Centerer px={2} py={4}>
-        <Flex>
-          <Box flex="1 1 auto" mx={[0, 0, 0, '16.666%']}>
+    <PeoplePicker {...props}>
+      {innerProps => (
+        <React.Fragment>
+          <Centerer p={3}>
             <Flex>
-              <Box mx={2}>
-                <Button onClick={onRequestClose}>Cancel</Button>
-              </Box>
-              <Box mx={2}>
-                <Button disabled onClick={onRequestAdd} primary>
-                  Add
-                </Button>
+              <Box flex="1 1 auto" mx={[0, 0, 0, '16.666%']}>
+                <PeoplePicker.Body {...innerProps} />
               </Box>
             </Flex>
-          </Box>
-        </Flex>
-      </Centerer>
-    </ButtonBar>
+          </Centerer>
+          <ButtonBarContainer>
+            <Centerer py={[3, 3, 3, 4]}>
+              <Flex>
+                <Box flex="1 1 auto" mx={[0, 0, 0, '16.666%']}>
+                  <PeoplePicker.Buttons {...innerProps} />
+                </Box>
+              </Flex>
+            </Centerer>
+          </ButtonBarContainer>
+        </React.Fragment>
+      )}
+    </PeoplePicker>
   </ModalOverlay>
 )
 

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
@@ -2,12 +2,25 @@ A people picker in a modal
 
 ```js
 initialState = { open: false }
+const people = [
+  { id: 1, name: 'Annie' },
+  { id: 2, name: 'Bobby' },
+  { id: 3, name: 'Chastity' },
+  { id: 4, name: 'Dave' },
+]
 ;<div>
   <button onClick={() => setState({ open: true })}>Open</button>
 
   <PeoplePickerModal
+    maxSelection={3}
+    minSelection={2}
     open={state.open}
-    onRequestClose={() => setState({ open: false })}
+    onCancel={() => setState({ open: false })}
+    onSubmit={selection => {
+      console.log('Selected', selection)
+      setState({ open: false })
+    }}
+    people={people}
   />
 </div>
 ```

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -44,11 +44,23 @@ const StyledPicker = styled(Flex)`
   height: 120px;
 `
 
-const PersonPod = ({ onIconClick, textContainer, icon, ...props }) => (
+const PersonPod = ({
+  isIconClickable,
+  onIconClick,
+  textContainer,
+  icon,
+  ...props
+}) => (
   <StyledPicker>
     {textContainer}
     <Flex flexDirection="column" justifyContent="center">
-      <StyledButton onClick={onIconClick}>{icon}</StyledButton>
+      <StyledButton
+        data-test-id="person-pod-toggle"
+        disabled={!isIconClickable}
+        onClick={onIconClick}
+      >
+        {icon}
+      </StyledButton>
     </Flex>
   </StyledPicker>
 )
@@ -91,10 +103,17 @@ const buildPersonText = ({
   </Box>
 )
 
-const ChosenPersonPod = props => {
+const ChosenPersonPod = ({ isIconClickable = true, onIconClick, ...props }) => {
   const IconByState = switchIcon(props.iconState)
   const ChosenPerson = buildPersonText(props)
-  return <PersonPod icon={IconByState} textContainer={ChosenPerson} />
+  return (
+    <PersonPod
+      icon={IconByState}
+      isIconClickable={isIconClickable}
+      onIconClick={onIconClick}
+      textContainer={ChosenPerson}
+    />
+  )
 }
 
 const buildChooserText = ({ role, isRequired, ...props }) => (
@@ -107,9 +126,15 @@ const buildChooserText = ({ role, isRequired, ...props }) => (
   </Flex>
 )
 
-const ChoosePersonPod = props => {
+const ChoosePersonPod = ({ onIconClick, ...props }) => {
   const ChooserText = buildChooserText(props)
-  return <PersonPod icon={PlusIcon} textContainer={ChooserText} />
+  return (
+    <PersonPod
+      icon={PlusIcon}
+      onIconClick={onIconClick}
+      textContainer={ChooserText}
+    />
+  )
 }
 
 PersonPod.ChosenPersonPod = ChosenPersonPod

--- a/app/components/ui/atoms/SelectedItem.js
+++ b/app/components/ui/atoms/SelectedItem.js
@@ -4,7 +4,7 @@ import { th } from '@pubsweet/ui-toolkit'
 import CrossIcon from './icons/Cross'
 
 const Root = styled.div`
-  border-radius: ${th('borderRadius')}
+  border-radius: ${th('borderRadius')};
   background-color: ${th('colorPrimary')};
   line-height: ${th('fontLineHeightBase')};
   padding: ${th('space.1')};

--- a/app/components/ui/molecules/PeoplePicker.js
+++ b/app/components/ui/molecules/PeoplePicker.js
@@ -93,7 +93,10 @@ const PeoplePickerButtons = ({ isValid, onCancel, onSubmit }) => (
 )
 
 class PeoplePicker extends React.Component {
-  state = { selection: [] }
+  constructor(props) {
+    super(props)
+    this.state = { selection: this.props.initialSelection }
+  }
 
   toggleSelection(person) {
     if (this.isSelected(person)) {
@@ -134,21 +137,24 @@ class PeoplePicker extends React.Component {
     })
   }
 }
+const peopleArrayPropType = PropTypes.arrayOf(
+  PropTypes.shape({
+    id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    name: PropTypes.string.isRequired,
+  }),
+)
 
 PeoplePicker.propTypes = {
+  initialSelection: peopleArrayPropType,
   minSelection: PropTypes.number,
   maxSelection: PropTypes.number,
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
-  people: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-      name: PropTypes.string.isRequired,
-    }),
-  ).isRequired,
+  people: peopleArrayPropType.isRequired,
 }
 
 PeoplePicker.defaultProps = {
+  initialSelection: [],
   minSelection: 0,
   maxSelection: Infinity,
 }

--- a/app/components/ui/molecules/PeoplePicker.js
+++ b/app/components/ui/molecules/PeoplePicker.js
@@ -1,0 +1,159 @@
+/* eslint-disable react/no-unused-prop-types */
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Button } from '@pubsweet/ui'
+import { th } from '@pubsweet/ui-toolkit'
+import { Box, Flex } from 'grid-styled'
+
+import SelectedItem from '../atoms/SelectedItem'
+import PersonPod from '../atoms/PersonPod'
+
+const SelectedItems = ({ selection, onCloseClick }) => (
+  <Flex>
+    {selection.map(person => (
+      <Box key={person.id} mr={1}>
+        <SelectedItem
+          label={person.name}
+          onCloseClick={() => onCloseClick(person)}
+        />
+      </Box>
+    ))}
+  </Flex>
+)
+
+const SuccessMessage = styled.div`
+  color: ${th('colorSuccess')};
+`
+
+const SelectionHint = ({ selection, minSelection, maxSelection }) => {
+  const selectionLength = selection.length
+  if (selectionLength < minSelection) {
+    const numRequired = minSelection - selectionLength
+    return (
+      <div>
+        {numRequired} more suggestion{numRequired === 1 ? '' : 's'} required
+      </div>
+    )
+  }
+  if (selectionLength >= maxSelection) {
+    return <SuccessMessage>Maximum {maxSelection} choices</SuccessMessage>
+  }
+  return null
+}
+
+const PeoplePickerBody = ({
+  isSelected,
+  maxSelection,
+  minSelection,
+  onCancel,
+  onSubmit,
+  people,
+  selection,
+  toggleSelection,
+}) => (
+  <React.Fragment>
+    <Flex justifyContent="space-between">
+      <SelectedItems onCloseClick={toggleSelection} selection={selection} />
+      <SelectionHint
+        maxSelection={maxSelection}
+        minSelection={minSelection}
+        selection={selection}
+      />
+    </Flex>
+    <Flex flexWrap="wrap" mx={-2}>
+      {people.map(person => (
+        <Box key={person.id} p={2} width={1 / 2}>
+          <PersonPod.ChosenPersonPod
+            iconState={isSelected(person) ? 'selected' : 'add'}
+            institution={person.institution}
+            isIconClickable={
+              isSelected(person) || selection.length < maxSelection
+            }
+            name={person.name}
+            onIconClick={() => toggleSelection(person)}
+          />
+        </Box>
+      ))}
+    </Flex>
+  </React.Fragment>
+)
+
+const PeoplePickerButtons = ({ isValid, onCancel, onSubmit }) => (
+  <Flex>
+    <Box mr={3}>
+      <Button onClick={onCancel}>Cancel</Button>
+    </Box>
+    <Box>
+      <Button disabled={!isValid} onClick={onSubmit} primary>
+        Add
+      </Button>
+    </Box>
+  </Flex>
+)
+
+class PeoplePicker extends React.Component {
+  state = { selection: [] }
+
+  toggleSelection(person) {
+    if (this.isSelected(person)) {
+      this.setState({
+        selection: this.state.selection.filter(p => p.id !== person.id),
+      })
+    } else {
+      this.setState({ selection: this.state.selection.concat(person) })
+    }
+  }
+
+  handleSubmit() {
+    if (this.isValid()) {
+      this.props.onSubmit(this.state.selection)
+    }
+  }
+
+  isSelected(person) {
+    return this.state.selection.some(p => p.id === person.id)
+  }
+
+  isValid() {
+    const selectionLength = this.state.selection.length
+    return (
+      selectionLength >= this.props.minSelection &&
+      selectionLength <= this.props.maxSelection
+    )
+  }
+
+  render() {
+    return this.props.children({
+      ...this.props,
+      isSelected: person => this.isSelected(person),
+      isValid: this.isValid(),
+      selection: this.state.selection,
+      onSubmit: () => this.handleSubmit(),
+      toggleSelection: person => this.toggleSelection(person),
+    })
+  }
+}
+
+PeoplePicker.propTypes = {
+  minSelection: PropTypes.number,
+  maxSelection: PropTypes.number,
+  onCancel: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  people: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+}
+
+PeoplePicker.defaultProps = {
+  minSelection: 0,
+  maxSelection: Infinity,
+}
+
+PeoplePicker.Body = PeoplePickerBody
+PeoplePicker.Buttons = PeoplePickerButtons
+
+export default PeoplePicker

--- a/app/components/ui/molecules/PeoplePicker.md
+++ b/app/components/ui/molecules/PeoplePicker.md
@@ -10,8 +10,9 @@ const people = [
   { id: 4, name: 'Dave Badger', institution: 'D Research Lab' },
 ]
 ;<PeoplePicker
-  minSelection="2"
-  maxSelection="3"
+  initialSelection={[people[1]]}
+  minSelection={2}
+  maxSelection={3}
   onSubmit={selection => console.log(selection)}
   people={people}
 >
@@ -25,6 +26,10 @@ const people = [
 </PeoplePicker>
 ```
 
+Note that by spreading the `prop` parameter from the render prop function into
+the `Buttons` and `Body` components as shown in the example, you avoid the need
+to update your code should the API change in future.
+
 ### Body only
 
 ```js
@@ -34,10 +39,13 @@ const people = [
   { id: 3, name: 'Chastity' },
   { id: 4, name: 'Dave' },
 ]
+const selection = people.slice(0, 2)
 ;<PeoplePicker.Body
+  isSelected={person => selection.includes(person)}
+  maxSelection={5}
+  minSelection={3}
   people={people}
-  selection={[]}
-  isSelected={() => false}
+  selection={selection}
   toggleSelection={person => console.log(person)}
 />
 ```

--- a/app/components/ui/molecules/PeoplePicker.md
+++ b/app/components/ui/molecules/PeoplePicker.md
@@ -1,0 +1,49 @@
+`PeoplePicker` uses a render prop to allow customising the layout.
+
+### Buttons above body
+
+```js
+const people = [
+  { id: 1, name: 'Annie Badger', institution: 'A University' },
+  { id: 2, name: 'Bobby Badger', institution: 'B College' },
+  { id: 3, name: 'Chastity Badger', institution: 'C Institute' },
+  { id: 4, name: 'Dave Badger', institution: 'D Research Lab' },
+]
+;<PeoplePicker
+  minSelection="2"
+  maxSelection="3"
+  onSubmit={selection => console.log(selection)}
+  people={people}
+>
+  {props => (
+    <React.Fragment>
+      <PeoplePicker.Buttons {...props} />
+      <hr />
+      <PeoplePicker.Body {...props} />
+    </React.Fragment>
+  )}
+</PeoplePicker>
+```
+
+### Body only
+
+```js
+const people = [
+  { id: 1, name: 'Annie' },
+  { id: 2, name: 'Bobby' },
+  { id: 3, name: 'Chastity' },
+  { id: 4, name: 'Dave' },
+]
+;<PeoplePicker.Body
+  people={people}
+  selection={[]}
+  isSelected={() => false}
+  toggleSelection={person => console.log(person)}
+/>
+```
+
+### Buttons only
+
+```js
+;<PeoplePicker.Buttons isValid={true} />
+```

--- a/app/components/ui/molecules/PeoplePicker.test.js
+++ b/app/components/ui/molecules/PeoplePicker.test.js
@@ -1,0 +1,101 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { ThemeProvider } from 'styled-components'
+import theme from '@elifesciences/elife-theme'
+import PeoplePicker from './PeoplePicker'
+
+const people = [
+  { id: 1, name: 'Annie' },
+  { id: 2, name: 'Bobby' },
+  { id: 3, name: 'Chastity' },
+  { id: 4, name: 'Dave' },
+]
+
+const makeWrapper = props =>
+  mount(
+    <ThemeProvider theme={theme}>
+      <PeoplePicker
+        // eslint-disable-next-line react/no-children-prop
+        children={innerProps => <PeoplePicker.Body {...innerProps} />}
+        onCancel={jest.fn()}
+        onSubmit={jest.fn()}
+        people={people}
+        {...props}
+      />
+    </ThemeProvider>,
+  )
+
+const getPersonPodButton = (wrapper, index) =>
+  wrapper.find('button[data-test-id="person-pod-toggle"]').at(index)
+
+const expectSelectionLength = (wrapper, length) =>
+  expect(wrapper.find('SelectedItem')).toHaveLength(length)
+
+describe('PeoplePicker', () => {
+  it('calls child render prop', () => {
+    const render = jest.fn(() => null)
+    makeWrapper({ children: render })
+    expect(render).toHaveBeenCalled()
+  })
+
+  it('renders one person pod per person', () => {
+    const wrapper = makeWrapper()
+    const buttons = wrapper.find('PersonPod')
+
+    expect(buttons).toHaveLength(4)
+  })
+
+  it('updates selection', () => {
+    const wrapper = makeWrapper()
+    expectSelectionLength(wrapper, 0)
+
+    getPersonPodButton(wrapper, 0).simulate('click')
+    expectSelectionLength(wrapper, 1)
+
+    getPersonPodButton(wrapper, 0).simulate('click')
+    expectSelectionLength(wrapper, 0)
+  })
+
+  it('disables inputs when maximum is reached', () => {
+    const wrapper = makeWrapper({ maxSelection: 1 })
+    expectSelectionLength(wrapper, 0)
+
+    getPersonPodButton(wrapper, 0).simulate('click')
+    expectSelectionLength(wrapper, 1)
+
+    getPersonPodButton(wrapper, 1).simulate('click')
+    expectSelectionLength(wrapper, 1)
+  })
+
+  it('allows submit only when minimum is met', () => {
+    const onSubmit = jest.fn()
+    const wrapper = makeWrapper({ minSelection: 1, onSubmit })
+
+    wrapper
+      .find('PeoplePicker')
+      .instance()
+      .handleSubmit()
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    getPersonPodButton(wrapper, 0).simulate('click')
+    wrapper
+      .find('PeoplePicker')
+      .instance()
+      .handleSubmit()
+    expect(onSubmit).toHaveBeenCalled()
+  })
+
+  it('shows selected items', () => {
+    const wrapper = makeWrapper()
+    expectSelectionLength(wrapper, 0)
+
+    getPersonPodButton(wrapper, 0).simulate('click')
+    expectSelectionLength(wrapper, 1)
+
+    wrapper
+      .find('SelectedItem')
+      .find('svg')
+      .simulate('click')
+    expectSelectionLength(wrapper, 0)
+  })
+})

--- a/app/components/ui/molecules/PeoplePicker.test.js
+++ b/app/components/ui/molecules/PeoplePicker.test.js
@@ -15,6 +15,7 @@ const makeWrapper = props =>
   mount(
     <ThemeProvider theme={theme}>
       <PeoplePicker
+        // need to pass children as a prop in order to override it in some tests
         // eslint-disable-next-line react/no-children-prop
         children={innerProps => <PeoplePicker.Body {...innerProps} />}
         onCancel={jest.fn()}
@@ -38,14 +39,14 @@ describe('PeoplePicker', () => {
     expect(render).toHaveBeenCalled()
   })
 
-  it('renders one person pod per person', () => {
+  it('renders as many person pods as people', () => {
     const wrapper = makeWrapper()
     const buttons = wrapper.find('PersonPod')
 
-    expect(buttons).toHaveLength(4)
+    expect(buttons).toHaveLength(people.length)
   })
 
-  it('updates selection', () => {
+  it('clicking the icon adds/removes a selected item from the page', () => {
     const wrapper = makeWrapper()
     expectSelectionLength(wrapper, 0)
 
@@ -56,7 +57,7 @@ describe('PeoplePicker', () => {
     expectSelectionLength(wrapper, 0)
   })
 
-  it('disables inputs when maximum is reached', () => {
+  it('cannot select more pods when maximum is reached', () => {
     const wrapper = makeWrapper({ maxSelection: 1 })
     expectSelectionLength(wrapper, 0)
 
@@ -67,7 +68,7 @@ describe('PeoplePicker', () => {
     expectSelectionLength(wrapper, 1)
   })
 
-  it('allows submit only when minimum is met', () => {
+  it('allows submit only after minimum is met', () => {
     const onSubmit = jest.fn()
     const wrapper = makeWrapper({ minSelection: 1, onSubmit })
 
@@ -85,7 +86,7 @@ describe('PeoplePicker', () => {
     expect(onSubmit).toHaveBeenCalled()
   })
 
-  it('shows selected items', () => {
+  it('clicking on selected item icon removes it', () => {
     const wrapper = makeWrapper()
     expectSelectionLength(wrapper, 0)
 


### PR DESCRIPTION
#### Background

Implement the `PeoplePicker` component which ties together the selected item tags, the selection hint message, the person pod search results and the button bar.

Closes #354 
Closes #355 

~~Uses a dummy person pod implementation pending #227.~~

#### How has this been tested?
 
Visually with styleguide and functionally with Jest.