### PR TITLE
fix(styleguide): remove material icons by themselves from the styleguide

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -19,7 +19,11 @@ module.exports = {
   context: {
     formik: 'formik',
   },
-  ignore: ['**/node_modules/**', '**/*.test.{js,jsx}'],
+  ignore: [
+    '**/node_modules/**',
+    '**/*.test.{js,jsx}',
+    '**/icons/material/*.js',
+  ],
   styleguideComponents: {
     StyleGuideRenderer: path.join(
       __dirname,


### PR DESCRIPTION
#### Background

Right now the `README.md` from material icons is picked by react styleguidist and this is not intended behavior.
