### PR TITLE
refactor: relax eslint destructuring rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,18 @@
     "import/no-extraneous-dependencies": 0,
     "import/prefer-default-export": 0,
     "no-underscore-dangle": 0,
+    "prefer-destructuring": ["error", {
+      "VariableDeclarator": {
+        "array": false,
+        "object": true
+      },
+      "AssignmentExpression": {
+        "array": false,
+        "object": false
+      }
+    }, {
+      "enforceForRenamedProperties": false
+    }],
     "prettier/prettier": 0,
     "react/prop-types": 0,
     "sort-keys": 0

--- a/server/submission/resolvers.js
+++ b/server/submission/resolvers.js
@@ -181,12 +181,12 @@ const resolvers = {
       let title = ''
       if (xmlData.article) {
         const firstArticle = xmlData.article.front[0]
-        const { 'article-meta': articleMeta } = firstArticle
+        const articleMeta = firstArticle['article-meta']
         const firstMeta = articleMeta[0]
-        const { 'title-group': titleGroup } = firstMeta
+        const titleGroup = firstMeta['title-group']
         const firstTitleGroup = titleGroup[0]
-        const { 'article-title': titleArray } = firstTitleGroup
-        ;[title] = titleArray
+        const titleArray = firstTitleGroup['article-title']
+        title = titleArray.title
       }
 
       const manuscript = await db.selectId(id)


### PR DESCRIPTION
#### Background

The default config for https://eslint.org/docs/rules/prefer-destructuring leads to convoluted code. This change in config turns the rule off for all but the simplest case and has already been applied to `pubsweet/pubsweet`.

