### PR TITLE
refactor person pod, add prop types & tests

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
@@ -3,10 +3,30 @@ A people picker in a modal
 ```js
 initialState = { open: false }
 const people = [
-  { id: 1, name: 'Annie' },
-  { id: 2, name: 'Bobby' },
-  { id: 3, name: 'Chastity' },
-  { id: 4, name: 'Dave' },
+  {
+    id: 1,
+    name: 'Annie Badger',
+    institution: 'A University',
+    keywords: 'cell biology',
+  },
+  {
+    id: 2,
+    name: 'Bobby Badger',
+    institution: 'B College',
+    keywords: 'biochemistry and chemical biology',
+  },
+  {
+    id: 3,
+    name: 'Chastity Badger',
+    institution: 'C Institute',
+    keywords: 'ecology',
+  },
+  {
+    id: 4,
+    name: 'Dave Badger',
+    institution: 'D Research Lab',
+    keywords: 'neuroscience',
+  },
 ]
 ;<div>
   <button onClick={() => setState({ open: true })}>Open</button>

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -42,7 +42,7 @@ const StyledPod = styled(Flex)`
   height: 120px;
 `
 
-const PersonPod = ({
+const PersonPodContainer = ({
   isIconClickable,
   onIconClick,
   textContainer,

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -63,24 +63,23 @@ const PersonPodContainer = ({
   </StyledPod>
 )
 
-const PlusIcon = <Icon size={3}>Plus</Icon>
-const RubbishBinIcon = <Icon size={3}>RubbishBin</Icon>
-const SelectedTickIcon = <Icon size={4}>SelectedTick</Icon>
+const plusIcon = <Icon size={3}>Plus</Icon>
+const rubbishBinIcon = <Icon size={3}>RubbishBin</Icon>
+const selectedTickIcon = <Icon size={4}>SelectedTick</Icon>
 
-const switchIcon = iconState => {
-  switch (iconState) {
-    case 'add':
-      return PlusIcon
+const PodIcon = ({ iconType }) => {
+  switch (iconType) {
     case 'remove':
-      return RubbishBinIcon
+      return rubbishBinIcon
     case 'selected':
-      return SelectedTickIcon
+      return selectedTickIcon
+    case 'add':
     default:
-      return PlusIcon
+      return plusIcon
   }
 }
 
-const buildPersonText = ({
+const PersonText = ({
   name,
   institution,
   keywords,
@@ -108,22 +107,18 @@ const buildPersonText = ({
 const PersonPod = ({
   isIconClickable = true,
   onIconClick,
-  iconState,
+  iconType,
   ...props
-}) => {
-  const IconByState = switchIcon(iconState)
-  const ChosenPerson = buildPersonText(props)
-  return (
-    <PersonPodContainer
-      icon={IconByState}
-      isIconClickable={isIconClickable}
-      onIconClick={onIconClick}
-      textContainer={ChosenPerson}
-    />
-  )
-}
+}) => (
+  <PersonPodContainer
+    icon={<PodIcon iconType={iconType} />}
+    isIconClickable={isIconClickable}
+    onIconClick={onIconClick}
+    textContainer={<PersonText {...props} />}
+  />
+)
 
-const buildChooserText = ({ role, isRequired, ...props }) => (
+const ChooserText = ({ role, isRequired, ...props }) => (
   <Flex flexDirection="column" justifyContent="center">
     <Box ml={2}>
       <RegularP>
@@ -133,24 +128,27 @@ const buildChooserText = ({ role, isRequired, ...props }) => (
   </Flex>
 )
 
-const SelectButton = ({ onIconClick, ...props }) => {
-  const ChooserText = buildChooserText(props)
-  return (
-    <PersonPodContainer
-      icon={PlusIcon}
-      onIconClick={onIconClick}
-      textContainer={ChooserText}
-    />
-  )
-}
+const SelectButton = ({ isIconClickable, onIconClick, ...props }) => (
+  <PersonPodContainer
+    icon={plusIcon}
+    isIconClickable
+    onIconClick={onIconClick}
+    textContainer={<ChooserText {...props} />}
+  />
+)
 
 PersonPodContainer.propTypes = {
+  isIconClickable: PropTypes.bool.isRequired,
   onIconClick: PropTypes.func.isRequired,
   textContainer: PropTypes.element.isRequired,
   icon: PropTypes.element.isRequired,
 }
 
-PersonPod.propTypes = {
+PodIcon.propTypes = {
+  iconType: PropTypes.oneOf(['add', 'remove', 'selected']).isRequired,
+}
+
+PersonText.propTypes = {
   name: PropTypes.string.isRequired,
   institution: PropTypes.string.isRequired,
   keywords: PropTypes.string.isRequired,
@@ -158,18 +156,29 @@ PersonPod.propTypes = {
   onKeywordClick: PropTypes.func,
   isStatusShown: PropTypes.bool.isRequired,
   status: PropTypes.string,
-  iconState: PropTypes.oneOf[('add', 'remove', 'selected')].isRequired,
-  onIconClick: PropTypes.func.isRequired,
 }
 
-PersonPod.defaultProps = {
+PersonText.defaultProps = {
   onKeywordClick: null,
   status: '',
 }
 
-SelectButton.propTypes = {
+PersonPod.propTypes = {
+  isIconClickable: PropTypes.bool,
+  onIconClick: PropTypes.func.isRequired,
+  iconType: PropTypes.oneOf(['add', 'remove', 'selected']).isRequired,
+}
+
+PersonPod.defaultProps = {
+  isIconClickable: true,
+}
+
+ChooserText.propTypes = {
   role: PropTypes.string.isRequired,
   isRequired: PropTypes.bool.isRequired,
+}
+
+SelectButton.propTypes = {
   onIconClick: PropTypes.func.isRequired,
 }
 

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
 import { Action, Button } from '@pubsweet/ui'
@@ -30,10 +31,7 @@ const StyledButton = styled(Button)`
   border: none;
 `
 
-const StyledPicker = styled(Flex)`
-  display: flex;
-  justify-content: space-between;
-
+const StyledPod = styled(Flex)`
   background: ${th('colorSecondary')};
   border: ${th('borderWidth')} ${th('borderStyle')} ${th('colorBorder')};
   border-radius: ${th('borderRadius')};
@@ -51,7 +49,7 @@ const PersonPod = ({
   icon,
   ...props
 }) => (
-  <StyledPicker>
+  <StyledPod justifyContent="space-between">
     {textContainer}
     <Flex flexDirection="column" justifyContent="center">
       <StyledButton
@@ -62,7 +60,7 @@ const PersonPod = ({
         {icon}
       </StyledButton>
     </Flex>
-  </StyledPicker>
+  </StyledPod>
 )
 
 const PlusIcon = <Icon size={3}>Plus</Icon>
@@ -87,27 +85,32 @@ const buildPersonText = ({
   institution,
   keywords,
   isKeywordClickable,
-  onKeywordClick,
+  onKeywordClick = null,
   isStatusShown,
-  status,
+  status = '',
   ...props
 }) => (
-  <Box m={2}>
+  <Box {...props} m={2}>
     <RegularP>{name}</RegularP>
     <RegularP>{institution}</RegularP>
     {isKeywordClickable && (
       <SmallAction onClick={onKeywordClick}>{keywords}</SmallAction>
     )}
-    {!isKeywordClickable && <RegularP>{keywords}</RegularP>}
+    {!isKeywordClickable && <SmallP>{keywords}</SmallP>}
     {isStatusShown && <SmallP>{status}</SmallP>}
   </Box>
 )
 
-const ChosenPersonPod = ({ isIconClickable = true, onIconClick, ...props }) => {
-  const IconByState = switchIcon(props.iconState)
+const PersonPod = ({
+  isIconClickable = true,
+  onIconClick,
+  iconState,
+  ...props
+}) => {
+  const IconByState = switchIcon(iconState)
   const ChosenPerson = buildPersonText(props)
   return (
-    <PersonPod
+    <PersonPodContainer
       icon={IconByState}
       isIconClickable={isIconClickable}
       onIconClick={onIconClick}
@@ -126,10 +129,10 @@ const buildChooserText = ({ role, isRequired, ...props }) => (
   </Flex>
 )
 
-const ChoosePersonPod = ({ onIconClick, ...props }) => {
+const SelectButton = ({ onIconClick, ...props }) => {
   const ChooserText = buildChooserText(props)
   return (
-    <PersonPod
+    <PersonPodContainer
       icon={PlusIcon}
       onIconClick={onIconClick}
       textContainer={ChooserText}
@@ -137,7 +140,45 @@ const ChoosePersonPod = ({ onIconClick, ...props }) => {
   )
 }
 
-PersonPod.ChosenPersonPod = ChosenPersonPod
-PersonPod.ChoosePersonPod = ChoosePersonPod
+PersonPodContainer.propTypes = {
+  onIconClick: PropTypes.func.isRequired,
+  textContainer: PropTypes.element.isRequired,
+  icon: PropTypes.element.isRequired,
+}
+
+switchIcon.PropTypes = {
+  iconState: PropTypes.oneOf[('add', 'remove', 'selected')],
+}
+
+buildPersonText.propTypes = {
+  name: PropTypes.string.isRequired,
+  institution: PropTypes.string.isRequired,
+  keywords: PropTypes.string.isRequired,
+  isKeywordClickable: PropTypes.bool.isRequired,
+  onKeywordClick: PropTypes.func,
+  isStatusShown: PropTypes.bool.isRequired,
+  status: PropTypes.string,
+}
+
+buildPersonText.defaultProps = {
+  onKeywordClick: null,
+  status: '',
+}
+
+PersonPod.propTypes = {
+  iconState: PropTypes.string.isRequired,
+  onIconClick: PropTypes.func.isRequired,
+}
+
+buildChooserText.propTypes = {
+  role: PropTypes.string.isRequired,
+  isRequired: PropTypes.bool.isRequired,
+}
+
+SelectButton.propTypes = {
+  onIconClick: PropTypes.func.isRequired,
+}
+
+PersonPod.SelectButton = SelectButton
 
 export default PersonPod

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -85,7 +85,7 @@ const PersonText = ({
   keywords,
   isKeywordClickable,
   onKeywordClick = null,
-  isStatusShown,
+  isStatusShown = false,
   status = '',
   ...props
 }) => (
@@ -154,12 +154,13 @@ PersonText.propTypes = {
   keywords: PropTypes.string.isRequired,
   isKeywordClickable: PropTypes.bool.isRequired,
   onKeywordClick: PropTypes.func,
-  isStatusShown: PropTypes.bool.isRequired,
+  isStatusShown: PropTypes.bool,
   status: PropTypes.string,
 }
 
 PersonText.defaultProps = {
   onKeywordClick: null,
+  isStatusShown: false,
   status: '',
 }
 

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -53,7 +53,7 @@ const PersonPod = ({
     {textContainer}
     <Flex flexDirection="column" justifyContent="center">
       <StyledButton
-        data-test-id="person-pod-toggle"
+        data-test-id="person-pod-button"
         disabled={!isIconClickable}
         onClick={onIconClick}
       >
@@ -94,9 +94,13 @@ const buildPersonText = ({
     <RegularP>{name}</RegularP>
     <RegularP>{institution}</RegularP>
     {isKeywordClickable && (
-      <SmallAction onClick={onKeywordClick}>{keywords}</SmallAction>
+      <SmallAction data-test-id="clickable-keyword" onClick={onKeywordClick}>
+        {keywords}
+      </SmallAction>
     )}
-    {!isKeywordClickable && <SmallP>{keywords}</SmallP>}
+    {!isKeywordClickable && (
+      <SmallP data-test-id="non-clickable-keyword">{keywords}</SmallP>
+    )}
     {isStatusShown && <SmallP>{status}</SmallP>}
   </Box>
 )

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -150,11 +150,7 @@ PersonPodContainer.propTypes = {
   icon: PropTypes.element.isRequired,
 }
 
-switchIcon.PropTypes = {
-  iconState: PropTypes.oneOf[('add', 'remove', 'selected')],
-}
-
-buildPersonText.propTypes = {
+PersonPod.propTypes = {
   name: PropTypes.string.isRequired,
   institution: PropTypes.string.isRequired,
   keywords: PropTypes.string.isRequired,
@@ -162,24 +158,18 @@ buildPersonText.propTypes = {
   onKeywordClick: PropTypes.func,
   isStatusShown: PropTypes.bool.isRequired,
   status: PropTypes.string,
+  iconState: PropTypes.oneOf[('add', 'remove', 'selected')].isRequired,
+  onIconClick: PropTypes.func.isRequired,
 }
 
-buildPersonText.defaultProps = {
+PersonPod.defaultProps = {
   onKeywordClick: null,
   status: '',
 }
 
-PersonPod.propTypes = {
-  iconState: PropTypes.string.isRequired,
-  onIconClick: PropTypes.func.isRequired,
-}
-
-buildChooserText.propTypes = {
+SelectButton.propTypes = {
   role: PropTypes.string.isRequired,
   isRequired: PropTypes.bool.isRequired,
-}
-
-SelectButton.propTypes = {
   onIconClick: PropTypes.func.isRequired,
 }
 

--- a/app/components/ui/atoms/PersonPod.md
+++ b/app/components/ui/atoms/PersonPod.md
@@ -9,9 +9,9 @@ Clickable keywords:
   keywords="cell biology"
   isKeywordClickable={true}
   onKeywordClick={() => console.log('keyword clicked')}
-  onIconClick={() => console.log('icon clicked')}
   isStatusShown={false}
   iconState="add"
+  onIconClick={() => console.log('icon clicked')}
 />
 ```
 
@@ -24,10 +24,10 @@ Showing the person's status:
   keywords="cell biology"
   isKeywordClickable={true}
   onKeywordClick={() => console.log('keyword clicked')}
-  onIconClick={() => console.log('icon clicked')}
   status="Currently unavailable"
   isStatusShown={true}
   iconState="add"
+  onIconClick={() => console.log('icon clicked')}
 />
 ```
 
@@ -40,10 +40,10 @@ Removal icon:
   keywords="cell biology"
   isKeywordClickable={false}
   onKeywordClick={() => console.log('keyword clicked')}
-  onIconClick={() => console.log('icon clicked')}
   status="Currently unavailable"
   isStatusShown={true}
   iconState="remove"
+  onIconClick={() => console.log('icon clicked')}
 />
 ```
 
@@ -56,10 +56,10 @@ Selected icon:
   keywords="cell biology"
   isKeywordClickable={false}
   onKeywordClick={() => console.log('keyword clicked')}
-  onIconClick={() => console.log('icon clicked')}
   status="Currently unavailable"
   isStatusShown={true}
   iconState="selected"
+  onIconClick={() => console.log('icon clicked')}
 />
 ```
 
@@ -72,11 +72,11 @@ Disabled:
   keywords="cell biology"
   isKeywordClickable={false}
   onKeywordClick={() => console.log('keyword clicked')}
-  onIconClick={() => console.log('icon clicked')}
   status="Currently unavailable"
   isStatusShown={true}
   iconState="add"
   isIconClickable={false}
+  onIconClick={() => console.log('icon clicked')}
 />
 ```
 

--- a/app/components/ui/atoms/PersonPod.md
+++ b/app/components/ui/atoms/PersonPod.md
@@ -3,7 +3,7 @@
 Clickable keywords:
 
 ```js
-<PersonPod.ChosenPersonPod
+<PersonPod
   name="Richard Aldrich"
   institution="Utrecht University"
   keywords="cell biology"
@@ -18,7 +18,7 @@ Clickable keywords:
 Showing the person's status:
 
 ```js
-<PersonPod.ChosenPersonPod
+<PersonPod
   name="Richard Aldrich"
   institution="Utrecht University"
   keywords="cell biology"
@@ -34,7 +34,7 @@ Showing the person's status:
 Removal icon:
 
 ```js
-<PersonPod.ChosenPersonPod
+<PersonPod
   name="Richard Aldrich"
   institution="Utrecht University"
   keywords="cell biology"
@@ -50,7 +50,7 @@ Removal icon:
 Selected icon:
 
 ```js
-<PersonPod.ChosenPersonPod
+<PersonPod
   name="Richard Aldrich"
   institution="Utrecht University"
   keywords="cell biology"
@@ -66,7 +66,7 @@ Selected icon:
 Disabled:
 
 ```js
-<PersonPod.ChosenPersonPod
+<PersonPod
   name="Richard Aldrich"
   institution="Utrecht University"
   keywords="cell biology"
@@ -83,7 +83,7 @@ Disabled:
 ### ChoosePersonPod
 
 ```js
-<PersonPod.ChoosePersonPod
+<PersonPod.SelectButton
   role="Senior Editor(s)"
   isRequired={true}
   onIconClick={() => console.log('icon clicked')}
@@ -91,7 +91,7 @@ Disabled:
 ```
 
 ```js
-<PersonPod.ChoosePersonPod
+<PersonPod.SelectButton
   role="Reviewing Editor(s)"
   isRequired={false}
   onIconClick={() => console.log('icon clicked')}

--- a/app/components/ui/atoms/PersonPod.md
+++ b/app/components/ui/atoms/PersonPod.md
@@ -10,7 +10,7 @@ Clickable keywords:
   isKeywordClickable={true}
   onKeywordClick={() => console.log('keyword clicked')}
   isStatusShown={false}
-  iconState="add"
+  iconType="add"
   onIconClick={() => console.log('icon clicked')}
 />
 ```
@@ -26,7 +26,7 @@ Showing the person's status:
   onKeywordClick={() => console.log('keyword clicked')}
   status="Currently unavailable"
   isStatusShown={true}
-  iconState="add"
+  iconType="add"
   onIconClick={() => console.log('icon clicked')}
 />
 ```
@@ -42,7 +42,7 @@ Removal icon:
   onKeywordClick={() => console.log('keyword clicked')}
   status="Currently unavailable"
   isStatusShown={true}
-  iconState="remove"
+  iconType="remove"
   onIconClick={() => console.log('icon clicked')}
 />
 ```
@@ -58,7 +58,7 @@ Selected icon:
   onKeywordClick={() => console.log('keyword clicked')}
   status="Currently unavailable"
   isStatusShown={true}
-  iconState="selected"
+  iconType="selected"
   onIconClick={() => console.log('icon clicked')}
 />
 ```
@@ -74,7 +74,7 @@ Disabled:
   onKeywordClick={() => console.log('keyword clicked')}
   status="Currently unavailable"
   isStatusShown={true}
-  iconState="add"
+  iconType="add"
   isIconClickable={false}
   onIconClick={() => console.log('icon clicked')}
 />

--- a/app/components/ui/atoms/PersonPod.md
+++ b/app/components/ui/atoms/PersonPod.md
@@ -76,7 +76,7 @@ Disabled:
   status="Currently unavailable"
   isStatusShown={true}
   iconState="add"
-  disabled
+  isIconClickable={false}
 />
 ```
 

--- a/app/components/ui/atoms/PersonPod.test.js
+++ b/app/components/ui/atoms/PersonPod.test.js
@@ -17,7 +17,7 @@ function makePersonPodWrapper(props) {
 }
 
 const propsWithClickableFunctionality = {
-  iconState: 'add',
+  iconType: 'add',
   institution: 'Utrecht University',
   isKeywordClickable: true,
   isStatusShown: false,

--- a/app/components/ui/atoms/PersonPod.test.js
+++ b/app/components/ui/atoms/PersonPod.test.js
@@ -1,0 +1,66 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { ThemeProvider } from 'styled-components'
+import theme from '@elifesciences/elife-theme'
+
+import PersonPod from './PersonPod'
+
+const handleIconClick = jest.fn()
+const handleKeywordClick = jest.fn()
+
+function makePersonPodWrapper(props) {
+  return mount(
+    <ThemeProvider theme={theme}>
+      <PersonPod {...props} />
+    </ThemeProvider>,
+  )
+}
+
+const propsWithClickableFunctionality = {
+  iconState: 'add',
+  institution: 'Utrecht University',
+  isKeywordClickable: true,
+  isStatusShown: false,
+  keywords: 'cell biology',
+  name: 'Richard Aldrich',
+  onIconClick: handleIconClick,
+  onKeywordClick: handleKeywordClick,
+}
+
+const propsWithDisabledKeywords = {
+  ...propsWithClickableFunctionality,
+  isKeywordClickable: false,
+}
+
+describe('PersonPod component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('onIconClick handler - fired when selection button is clicked', () => {
+    const wrapper = makePersonPodWrapper(propsWithClickableFunctionality)
+    const selectionButton = wrapper.find(
+      'button[data-test-id="person-pod-button"]',
+    )
+    selectionButton.simulate('click')
+    expect(handleIconClick.mock.calls).toHaveLength(1)
+  })
+
+  it('onKeywordClick handler - fired when selection button is clicked', () => {
+    const wrapper = makePersonPodWrapper(propsWithClickableFunctionality)
+    const keyword = wrapper.find('button[data-test-id="clickable-keyword"]')
+    keyword.simulate('click')
+    expect(handleKeywordClick.mock.calls).toHaveLength(1)
+  })
+
+  it('passing in isKeywordClickable = false - should render keywords that are not clickable', () => {
+    const wrapper = makePersonPodWrapper(propsWithDisabledKeywords)
+    expect(
+      wrapper.find('button[data-test-id="clickable-keyword"]').exists(),
+    ).toBe(false)
+    const keywords = wrapper.find('p[data-test-id="non-clickable-keyword"]')
+    expect(keywords.exists()).toBe(true)
+    keywords.simulate('click')
+    expect(handleKeywordClick.mock.calls).toHaveLength(0)
+  })
+})

--- a/app/components/ui/molecules/PeoplePicker.js
+++ b/app/components/ui/molecules/PeoplePicker.js
@@ -64,14 +64,17 @@ const PeoplePickerBody = ({
     <Flex flexWrap="wrap" mx={-2}>
       {people.map(person => (
         <Box key={person.id} p={2} width={1 / 2}>
-          <PersonPod.ChosenPersonPod
-            iconState={isSelected(person) ? 'selected' : 'add'}
+          <PersonPod
+            iconType={isSelected(person) ? 'selected' : 'add'}
             institution={person.institution}
             isIconClickable={
               isSelected(person) || selection.length < maxSelection
             }
+            isKeywordClickable
+            keywords={person.keywords}
             name={person.name}
             onIconClick={() => toggleSelection(person)}
+            // onKeywordClick will need to be added, once we know what the desired behaviour is
           />
         </Box>
       ))}

--- a/app/components/ui/molecules/PeoplePicker.md
+++ b/app/components/ui/molecules/PeoplePicker.md
@@ -4,10 +4,30 @@
 
 ```js
 const people = [
-  { id: 1, name: 'Annie Badger', institution: 'A University' },
-  { id: 2, name: 'Bobby Badger', institution: 'B College' },
-  { id: 3, name: 'Chastity Badger', institution: 'C Institute' },
-  { id: 4, name: 'Dave Badger', institution: 'D Research Lab' },
+  {
+    id: 1,
+    name: 'Annie Badger',
+    institution: 'A University',
+    keywords: 'cell biology',
+  },
+  {
+    id: 2,
+    name: 'Bobby Badger',
+    institution: 'B College',
+    keywords: 'biochemistry and chemical biology',
+  },
+  {
+    id: 3,
+    name: 'Chastity Badger',
+    institution: 'C Institute',
+    keywords: 'ecology',
+  },
+  {
+    id: 4,
+    name: 'Dave Badger',
+    institution: 'D Research Lab',
+    keywords: 'neuroscience',
+  },
 ]
 ;<PeoplePicker
   initialSelection={[people[1]]}
@@ -34,11 +54,32 @@ to update your code should the API change in future.
 
 ```js
 const people = [
-  { id: 1, name: 'Annie' },
-  { id: 2, name: 'Bobby' },
-  { id: 3, name: 'Chastity' },
-  { id: 4, name: 'Dave' },
+  {
+    id: 1,
+    name: 'Annie Badger',
+    institution: 'A University',
+    keywords: 'cell biology',
+  },
+  {
+    id: 2,
+    name: 'Bobby Badger',
+    institution: 'B College',
+    keywords: 'biochemistry and chemical biology',
+  },
+  {
+    id: 3,
+    name: 'Chastity Badger',
+    institution: 'C Institute',
+    keywords: 'ecology',
+  },
+  {
+    id: 4,
+    name: 'Dave Badger',
+    institution: 'D Research Lab',
+    keywords: 'neuroscience',
+  },
 ]
+
 const selection = people.slice(0, 2)
 ;<PeoplePicker.Body
   isSelected={person => selection.includes(person)}

--- a/app/components/ui/molecules/PeoplePicker.test.js
+++ b/app/components/ui/molecules/PeoplePicker.test.js
@@ -27,7 +27,7 @@ const makeWrapper = props =>
   )
 
 const getPersonPodButton = (wrapper, index) =>
-  wrapper.find('button[data-test-id="person-pod-toggle"]').at(index)
+  wrapper.find('button[data-test-id="person-pod-button"]').at(index)
 
 const expectSelectionLength = (wrapper, length) =>
   expect(wrapper.find('SelectedItem')).toHaveLength(length)


### PR DESCRIPTION
#### What does this PR do?
1. Refactor, as per comment in #227:
    - `PersonPod` -> `PersonPodContainer`
    - `ChosenPersonPod` -> `PersonPod`
    - `ChoosePersonPod` -> `PersonPod.SelectButton`

I don't think this is necessarily ideal, as it suggests that `SelectButton` is a sub-component of `PersonPod`, which is not really accurate. Unfortunately, styleguidist does not seem to allow you to export 2 components from the same file? :confused: Suggestions welcome!

2. Specify prop types
3. Add tests
4. Tiny fix - keywords are now a small paragraph rather than regular

#### Any relevant tickets
#227 

#### How has this been tested?
Icon clicking & keyword clicking has been tested for `PersonPod`.

Disabling the icon hasn't been tested, since this functionality is coming in a different PR - #390 