### PR TITLE
fix: some broken component examples in styleguide

### DIFF
--- a/app/components/pages/Dashboard/Dashboard.md
+++ b/app/components/pages/Dashboard/Dashboard.md
@@ -1,5 +1,10 @@
 ## Dashboard Component
 
 ```js
-<Dashboard />
+;<Dashboard
+  manuscripts={[
+    { id: 1, title: 'Something interesting', submissionMeta: { stage: 'QC' } },
+  ]}
+  deleteManuscript={id => console.log('delete', id)}
+/>
 ```

--- a/app/components/pages/Manuscript/Manuscript.md
+++ b/app/components/pages/Manuscript/Manuscript.md
@@ -1,3 +1,6 @@
+Display a Texture editor and load the specified DAR archive. This does not
+currently work in the context of the styleguide since there is no DAR server.
+
 ```js
-<Manuscript />
+;<Manuscript archiveId={'123'} />
 ```

--- a/app/components/pages/SubmissionWizard/steps/Files/FileUploads.md
+++ b/app/components/pages/SubmissionWizard/steps/Files/FileUploads.md
@@ -1,9 +1,14 @@
-A set of controls for uploading files
+A form step for uploading a manuscript and writing the cover letter
 
 ```js
 const { Formik } = formik
 const { schema } = require('./schema')
-const empty = { coverLetter: '' }
+const empty = {
+  submissionMeta: {
+    coverLetter:
+      '<p><b>How do you feel about writing cover letters?</b></p><p></p>',
+  },
+}
 ;<Formik
   initialValues={empty}
   onSubmit={data => console.log(data)}

--- a/app/components/ui/atoms/Textarea.md
+++ b/app/components/ui/atoms/Textarea.md
@@ -1,10 +1,3 @@
-Required props:
-
-* `label`: for accessibility purposes
-* `value` & `onChange`: to make this a controlled React component
-
-Note: other CSS properties for an input element may be passed in (e.g. placeholder) but are not required.
-
 ```js
 <Textarea
   label="Label"


### PR DESCRIPTION
#### Background

Fix some broken component examples in styleguide.

Also remove some text about required props since this is generated automatically by Styleguidist using `PropTypes`.