### PR TITLE
change colour of person pod icons on hover

### DIFF
--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -37,6 +37,20 @@ const StyledButton = styled.button`
   height: 100%;
   border: none;
   padding: 0 calc(${th('gridUnit')} * 2);
+
+  // careful, this is brittle & relies heavily on the icons' structure
+
+  &:hover {
+    // plus & rubbish icons
+    svg > path {
+      fill: #666666;
+    }
+
+    // selected tick icon
+    svg > g > circle {
+      fill: #1378bb;
+    }
+  }
 `
 
 const StyledPod = styled(Flex)`

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
-import { Action, Button } from '@pubsweet/ui'
+import { Action } from '@pubsweet/ui'
 import { Flex, Box } from 'grid-styled'
 
 import Icon from './Icon'
@@ -32,9 +32,11 @@ const SmallAction = styled(Action)`
   margin: 3px 0;
 `
 
-const StyledButton = styled(Button)`
+const StyledButton = styled.button`
+  background-color: inherit;
   height: 100%;
   border: none;
+  padding: 0 calc(${th('gridUnit')} * 2);
 `
 
 const StyledPod = styled(Flex)`

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -38,16 +38,13 @@ const StyledButton = styled.button`
   border: none;
   padding: 0 calc(${th('gridUnit')} * 2);
 
-  // careful, this is brittle & relies heavily on the icons' structure
-
   &:hover {
-    // plus & rubbish icons
-    svg > path {
+    .plus-icon,
+    .rubbish-bin {
       fill: #666666;
     }
 
-    // selected tick icon
-    svg > g > circle {
+    .selected-tick-circle {
       fill: #1378bb;
     }
   }

--- a/app/components/ui/atoms/icons/Plus.js
+++ b/app/components/ui/atoms/icons/Plus.js
@@ -1,8 +1,16 @@
 import React from 'react'
 
 const Plus = props => (
-  <svg height="1em" viewBox="0 0 14 14" width="1em" {...props}>
-    <path d="M14 8H8v6H6V8H0V6h6V0h2v6h6z" fill="#888" fillRule="evenodd" />
+  <svg
+    className="plus-icon"
+    fill="#888"
+    fillRule="evenodd"
+    height="1em"
+    viewBox="0 0 14 14"
+    width="1em"
+    {...props}
+  >
+    <path d="M14 8H8v6H6V8H0V6h6V0h2v6h6z" />
   </svg>
 )
 

--- a/app/components/ui/atoms/icons/RubbishBin.js
+++ b/app/components/ui/atoms/icons/RubbishBin.js
@@ -1,12 +1,16 @@
 import React from 'react'
 
 const RubbishBin = props => (
-  <svg height="1em" viewBox="0 0 14 18" width="1em" {...props}>
-    <path
-      d="M1 16c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V4H1v12zM14 1h-3.5l-1-1h-5l-1 1H0v2h14V1z"
-      fill="#888"
-      fillRule="evenodd"
-    />
+  <svg
+    className="rubbish-bin"
+    fill="#888"
+    fillRule="evenodd"
+    height="1em"
+    viewBox="0 0 14 18"
+    width="1em"
+    {...props}
+  >
+    <path d="M1 16c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V4H1v12zM14 1h-3.5l-1-1h-5l-1 1H0v2h14V1z" />
   </svg>
 )
 

--- a/app/components/ui/atoms/icons/SelectedTick.js
+++ b/app/components/ui/atoms/icons/SelectedTick.js
@@ -3,7 +3,13 @@ import React from 'react'
 const SelectedTick = props => (
   <svg height="1em" viewBox="0 0 36 36" width="1em" {...props}>
     <g fill="none" fillRule="evenodd">
-      <circle cx={18} cy={18} fill="#0288D1" r={18} />
+      <circle
+        className="selected-tick-circle"
+        cx={18}
+        cy={18}
+        fill="#0288D1"
+        r={18}
+      />
       <path d="M15 22.2L10.8 18l-1.4 1.4L15 25l12-12-1.4-1.4z" fill="#FFF" />
     </g>
   </svg>


### PR DESCRIPTION
#### What does this PR do?
- use regular HTML `button` element instead of pubsweet's button atom, since we don't need the regular hover behaviour for pubsweet buttons
- change/add padding to RHS of icon, so that spacing between icon and RHS of pod conform to styleguide
- change icon colours on hover using `fill`

Note:
The colour change has to happen when the user hovers over the button (not just the icon itself i.e. the SVG), so we need to change the CSS of the child from within the parent. But the parent (button) doesn't know which child (i.e. which icon) it has inside it. Hence the somewhat ugly `svg > path` & `svg > g > circle`

I considered changing the code structure altogether, to have `StyledPlusButton`, `StyledRubbishButton`, `StyledTickButton`, in order to apply different hover styles based on which icon was inside. But this would cause a lot of duplication.

If anyone has any better ideas, I'm all ears :+1: 

#### Any relevant tickets
#397 