### PR TITLE
feat: partially implement shared data model

### DIFF
--- a/app/components/pages/Dashboard/Dashboard.js
+++ b/app/components/pages/Dashboard/Dashboard.js
@@ -47,12 +47,10 @@ const Dashboard = ({ manuscripts, deleteManuscript }) => (
             <tr key={manuscript.id}>
               <Cell data-test-id="title">
                 <Link data-test-id="title" to={`/manuscript/${manuscript.id}`}>
-                  {manuscript.title || '(Untitled manuscript)'}
+                  {manuscript.meta.title || '(Untitled manuscript)'}
                 </Link>
               </Cell>
-              <Cell data-test-id="stage">
-                {manuscript.submissionMeta.stage}
-              </Cell>
+              <Cell data-test-id="stage">{manuscript.status}</Cell>
               <Cell>
                 <Button onClick={() => deleteManuscript(manuscript.id)} small>
                   Delete

--- a/app/components/pages/Dashboard/Dashboard.md
+++ b/app/components/pages/Dashboard/Dashboard.md
@@ -3,7 +3,7 @@
 ```js
 ;<Dashboard
   manuscripts={[
-    { id: 1, title: 'Something interesting', submissionMeta: { stage: 'QC' } },
+    { id: 1, status: 'QC', meta: { title: 'Something interesting' } },
   ]}
   deleteManuscript={id => console.log('delete', id)}
 />

--- a/app/components/pages/Dashboard/index.js
+++ b/app/components/pages/Dashboard/index.js
@@ -8,10 +8,10 @@ export const MANUSCRIPTS_QUERY = gql`
   query DashboardManuscripts {
     manuscripts {
       id
-      title
-      submissionMeta {
-        stage
+      meta {
+        title
       }
+      status
     }
   }
 `

--- a/app/components/pages/SubmissionWizard/WithCurrentSubmission.js
+++ b/app/components/pages/SubmissionWizard/WithCurrentSubmission.js
@@ -63,12 +63,7 @@ class WithCurrentSubmission extends React.Component {
     mutation,
     { isAutoSave = false, refetchQueries = [] } = {},
   ) {
-    const omitList = [
-      '__typename',
-      'files',
-      'manuscriptPersons',
-      'submissionMeta.stage',
-    ]
+    const omitList = ['__typename', 'files', 'teams', 'status']
 
     this.dataModifiers.forEach(modifier => {
       omitList.push(...modifier.omitList())

--- a/app/components/pages/SubmissionWizard/formDataModifiers/CosubmissionModifier.js
+++ b/app/components/pages/SubmissionWizard/formDataModifiers/CosubmissionModifier.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /*
  * Data Modifiers -
  *    CosubmissionModifier
@@ -7,40 +8,35 @@
  * view model.
  */
 export default class CosubmissionModifier {
-  omitList = () => [
-    'submissionMeta.firstCosubmissionTitle',
-    'submissionMeta.secondCosubmissionTitle',
-  ]
+  omitList = () => ['firstCosubmissionTitle', 'secondCosubmissionTitle']
 
   toForm = values => {
-    const { submissionMeta } = values
-    const { cosubmission } = submissionMeta
+    const { cosubmission } = values
 
     const cosubLen = cosubmission.length
     if (cosubLen) {
-      submissionMeta.firstCosubmissionTitle = cosubmission[0].title
+      values.firstCosubmissionTitle = cosubmission[0]
     } else {
-      submissionMeta.firstCosubmissionTitle = null
+      values.firstCosubmissionTitle = null
     }
 
     if (cosubLen > 1) {
-      submissionMeta.secondCosubmissionTitle = cosubmission[1].title
+      values.secondCosubmissionTitle = cosubmission[1]
     } else {
-      submissionMeta.secondCosubmissionTitle = null
+      values.secondCosubmissionTitle = null
     }
   }
 
   fromForm = (values, originalValues) => {
-    const { submissionMeta } = values
-    const first = originalValues.submissionMeta.firstCosubmissionTitle
-    const second = originalValues.submissionMeta.secondCosubmissionTitle
-    submissionMeta.cosubmission = []
+    const first = originalValues.firstCosubmissionTitle
+    const second = originalValues.secondCosubmissionTitle
+    values.cosubmission = []
 
     if (typeof first === 'string' && first.length) {
-      submissionMeta.cosubmission.push({ title: first })
+      values.cosubmission.push(first)
 
       if (typeof second === 'string' && second.length) {
-        submissionMeta.cosubmission.push({ title: second })
+        values.cosubmission.push(second)
       }
     }
   }

--- a/app/components/pages/SubmissionWizard/formDataModifiers/CosubmissionModifier.test.js
+++ b/app/components/pages/SubmissionWizard/formDataModifiers/CosubmissionModifier.test.js
@@ -5,72 +5,63 @@ const modifier = new CosubmissionModifier()
 describe('CosubmissionModifier', () => {
   describe('from form to API', () => {
     it('handles no titles', () => {
-      const values = { submissionMeta: {} }
-      const originalValues = { submissionMeta: {} }
+      const values = {}
+      const originalValues = {}
       modifier.fromForm(values, originalValues)
 
-      expect(values.submissionMeta.cosubmission).toEqual([])
+      expect(values.cosubmission).toEqual([])
     })
 
     it('handles first title', () => {
-      const values = { submissionMeta: {} }
+      const values = {}
       const originalValues = {
-        submissionMeta: { firstCosubmissionTitle: 'hey' },
+        firstCosubmissionTitle: 'hey',
       }
       modifier.fromForm(values, originalValues)
 
-      expect(values.submissionMeta.cosubmission).toEqual([{ title: 'hey' }])
+      expect(values.cosubmission).toEqual(['hey'])
     })
 
     it('handles both titles', () => {
-      const values = { submissionMeta: {} }
+      const values = {}
       const originalValues = {
-        submissionMeta: {
-          firstCosubmissionTitle: 'hey',
-          secondCosubmissionTitle: 'there',
-        },
+        firstCosubmissionTitle: 'hey',
+        secondCosubmissionTitle: 'there',
       }
       modifier.fromForm(values, originalValues)
 
-      expect(values.submissionMeta.cosubmission).toEqual([
-        { title: 'hey' },
-        { title: 'there' },
-      ])
+      expect(values.cosubmission).toEqual(['hey', 'there'])
     })
 
     it('ignores second title if first not set', () => {
-      const values = { submissionMeta: {} }
+      const values = {}
       const originalValues = {
-        submissionMeta: {
-          firstCosubmissionTitle: null,
-          secondCosubmissionTitle: 'there',
-        },
+        firstCosubmissionTitle: null,
+        secondCosubmissionTitle: 'there',
       }
       modifier.fromForm(values, originalValues)
 
-      expect(values.submissionMeta.cosubmission).toEqual([])
+      expect(values.cosubmission).toEqual([])
     })
 
     it('ignores empty strings', () => {
-      const values = { submissionMeta: {} }
+      const values = {}
       const originalValues = {
-        submissionMeta: {
-          firstCosubmissionTitle: '',
-          secondCosubmissionTitle: '',
-        },
+        firstCosubmissionTitle: '',
+        secondCosubmissionTitle: '',
       }
       modifier.fromForm(values, originalValues)
 
-      expect(values.submissionMeta.cosubmission).toEqual([])
+      expect(values.cosubmission).toEqual([])
     })
   })
 
   describe('from API to form', () => {
     it('handles no titles', () => {
-      const values = { submissionMeta: { cosubmission: [] } }
+      const values = { cosubmission: [] }
       modifier.toForm(values)
 
-      expect(values.submissionMeta).toEqual({
+      expect(values).toEqual({
         cosubmission: [],
         firstCosubmissionTitle: null,
         secondCosubmissionTitle: null,
@@ -79,12 +70,12 @@ describe('CosubmissionModifier', () => {
 
     it('handles one title', () => {
       const values = {
-        submissionMeta: { cosubmission: [{ title: 'hey' }] },
+        cosubmission: ['hey'],
       }
       modifier.toForm(values)
 
-      expect(values.submissionMeta).toEqual({
-        cosubmission: [{ title: 'hey' }],
+      expect(values).toEqual({
+        cosubmission: ['hey'],
         firstCosubmissionTitle: 'hey',
         secondCosubmissionTitle: null,
       })
@@ -92,14 +83,12 @@ describe('CosubmissionModifier', () => {
 
     it('handles two titles', () => {
       const values = {
-        submissionMeta: {
-          cosubmission: [{ title: 'hey' }, { title: 'there' }],
-        },
+        cosubmission: ['hey', 'there'],
       }
       modifier.toForm(values)
 
-      expect(values.submissionMeta).toEqual({
-        cosubmission: [{ title: 'hey' }, { title: 'there' }],
+      expect(values).toEqual({
+        cosubmission: ['hey', 'there'],
         firstCosubmissionTitle: 'hey',
         secondCosubmissionTitle: 'there',
       })

--- a/app/components/pages/SubmissionWizard/operations.js
+++ b/app/components/pages/SubmissionWizard/operations.js
@@ -4,7 +4,7 @@ const editorFragment = gql`
   fragment EditorDetails on EditorUser {
     id
     name
-    institution
+    aff
     subjectAreas
   }
 `
@@ -12,9 +12,12 @@ const editorFragment = gql`
 const manuscriptFragment = gql`
   fragment WholeManuscript on Manuscript {
     id
-    title
-    manuscriptType
-    subjectAreas
+    status
+    meta {
+      title
+      articleType
+      subjects
+    }
     suggestedSeniorEditors {
       ...EditorDetails
     }
@@ -38,34 +41,21 @@ const manuscriptFragment = gql`
       email
       reason
     }
-    noConflictOfInterest
+    suggestionsConflict
     files {
-      name
+      filename
       type
     }
-    submissionMeta {
-      coverLetter
-      author {
-        firstName
-        lastName
-        email
-        institution
-      }
-      stage
-      discussion
-      previousArticle
-      cosubmission {
-        title
-      }
+    coverLetter
+    author {
+      firstName
+      lastName
+      email
+      aff
     }
-    manuscriptPersons {
-      role
-      metadata {
-        ... on AuthorMetadata {
-          confirmed
-        }
-      }
-    }
+    previouslyDiscussed
+    previouslySubmitted
+    cosubmission
   }
   ${editorFragment}
 `

--- a/app/components/pages/SubmissionWizard/steps/Author/AuthorDetails.js
+++ b/app/components/pages/SubmissionWizard/steps/Author/AuthorDetails.js
@@ -17,20 +17,14 @@ const AuthorDetails = ({ fetchOrcid, loading, error }) => (
     </ErrorText>
 
     <TwoColumnLayout bottomSpacing={false}>
-      <ValidatedField
-        label="First name"
-        name="submissionMeta.author.firstName"
-      />
-      <ValidatedField label="Last name" name="submissionMeta.author.lastName" />
+      <ValidatedField label="First name" name="author.firstName" />
+      <ValidatedField label="Last name" name="author.lastName" />
       <ValidatedField
         label="Email (correspondence)"
-        name="submissionMeta.author.email"
+        name="author.email"
         type="email"
       />
-      <ValidatedField
-        label="Institution"
-        name="submissionMeta.author.institution"
-      />
+      <ValidatedField label="Institution" name="author.aff" />
     </TwoColumnLayout>
   </React.Fragment>
 )

--- a/app/components/pages/SubmissionWizard/steps/Author/AuthorDetails.md
+++ b/app/components/pages/SubmissionWizard/steps/Author/AuthorDetails.md
@@ -6,13 +6,11 @@ const { Formik } = formik
 const { schema } = require('./schema')
 
 const empty = {
-  submissionMeta: {
-    author: {
-      firstName: '',
-      lastName: '',
-      email: '',
-      institution: '',
-    },
+  author: {
+    firstName: '',
+    lastName: '',
+    email: '',
+    aff: '',
   },
 }
 ;<Formik

--- a/app/components/pages/SubmissionWizard/steps/Author/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Author/index.js
@@ -9,7 +9,7 @@ const ORCID_DETAILS_QUERY = gql`
       firstName
       lastName
       email
-      institution
+      aff
     }
   }
 `
@@ -35,7 +35,7 @@ class AuthorDetailsPage extends React.Component {
       .then(({ data }) => {
         const author = this.sanitizeAuthor(data.orcidDetails)
         this.setState({ loading: false })
-        this.props.setFieldValue('submissionMeta.author', author)
+        this.props.setFieldValue('author', author)
       })
       .catch(error => this.setState({ loading: false, error: error.message }))
   }

--- a/app/components/pages/SubmissionWizard/steps/Author/schema.js
+++ b/app/components/pages/SubmissionWizard/steps/Author/schema.js
@@ -12,13 +12,11 @@ const email = () =>
 const institution = () => yup.string().required('Institution is required')
 
 const schema = yup.object().shape({
-  submissionMeta: yup.object().shape({
-    author: yup.object().shape({
-      firstName: firstName(),
-      lastName: lastName(),
-      email: email(),
-      institution: institution(),
-    }),
+  author: yup.object().shape({
+    firstName: firstName(),
+    lastName: lastName(),
+    email: email(),
+    aff: institution(),
   }),
 })
 

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsContent.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsContent.md
@@ -6,7 +6,7 @@ const data = {
     {
       id: 1,
       name: 'Alfred Badger',
-      institution: 'Institute of Badgers',
+      aff: 'Institute of Badgers',
       subjectAreas: ['Human Biology and Medicine', 'Neuroscience'],
     },
   ],
@@ -14,7 +14,7 @@ const data = {
     {
       id: 3,
       name: 'Charlie Badger',
-      institution: 'Badger University',
+      aff: 'Badger University',
       subjectAreas: ['Cell Biology'],
     },
   ],

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsContent.test.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsContent.test.js
@@ -12,7 +12,7 @@ const formValues = {
     {
       id: 1,
       name: 'Alfred Badger',
-      institution: 'Institute of Badgers',
+      aff: 'Institute of Badgers',
     },
   ],
   opposedSeniorEditors: [],
@@ -26,7 +26,7 @@ const formValues = {
     { name: '', email: '' },
   ],
   opposedReviewers: [],
-  noConflictOfInterest: false,
+  suggestionsConflict: false,
 }
 
 function makeWrapper(props) {
@@ -36,7 +36,12 @@ function makeWrapper(props) {
         initialValues={formValues}
         onSubmit={jest.fn()}
         render={formProps => (
-          <EditorsContent history={{ location: {} }} {...formProps} />
+          <EditorsContent
+            history={{ location: {} }}
+            reviewingEditors={[]}
+            seniorEditors={[]}
+            {...formProps}
+          />
         )}
         validationSchema={schema}
         {...props}

--- a/app/components/pages/SubmissionWizard/steps/Editors/FormSections.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/FormSections.js
@@ -66,6 +66,6 @@ export const Declaration = () => (
   <ValidatedField
     component={ValueCheckbox}
     label="I declare that, to the best of my knowledge, these experts have no conflict of interest"
-    name="noConflictOfInterest"
+    name="suggestionsConflict"
   />
 )

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerControl.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerControl.js
@@ -18,7 +18,7 @@ const PeoplePickerControl = ({
   const items = initialSelection.map(person => (
     <PersonPod
       iconType="remove"
-      institution={person.institution}
+      institution={person.aff}
       isKeywordClickable={false}
       key={person.id}
       keywords={person.subjectAreas}

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
@@ -6,26 +6,26 @@ const people = [
   {
     id: 1,
     name: 'Annie Badger',
-    institution: 'A University',
-    keywords: 'cell biology',
+    aff: 'A University',
+    subjectAreas: ['cell biology'],
   },
   {
     id: 2,
     name: 'Bobby Badger',
-    institution: 'B College',
-    keywords: 'biochemistry and chemical biology',
+    aff: 'B College',
+    subjectAreas: ['biochemistry and chemical', 'biology'],
   },
   {
     id: 3,
     name: 'Chastity Badger',
-    institution: 'C Institute',
-    keywords: 'ecology',
+    aff: 'C Institute',
+    subjectAreas: ['ecology'],
   },
   {
     id: 4,
     name: 'Dave Badger',
-    institution: 'D Research Lab',
-    keywords: 'neuroscience',
+    aff: 'D Research Lab',
+    subjectAreas: ['neuroscience'],
   },
 ]
 ;<div>

--- a/app/components/pages/SubmissionWizard/steps/Editors/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/index.js
@@ -8,7 +8,7 @@ const EDITOR_LIST_QUERY = gql`
     editors(role: $role) {
       id
       name
-      institution
+      aff
       subjectAreas
     }
   }

--- a/app/components/pages/SubmissionWizard/steps/Editors/schema.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/schema.js
@@ -57,7 +57,7 @@ const schema = yup.object().shape({
   ),
   suggestedReviewers: suggestedReviewerValidator(),
   opposedReviewers: opposedReviewerValidator(),
-  noConflictOfInterest: yup
+  suggestionsConflict: yup
     .bool()
     .required()
     .oneOf(

--- a/app/components/pages/SubmissionWizard/steps/Editors/schema.test.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/schema.test.js
@@ -10,7 +10,7 @@ describe('Editors form validation', () => {
       suggestedReviewingEditors: [{ id: 1 }, { id: 2 }],
       opposedReviewingEditors: [{ id: 3 }],
       opposedReviewingEditorsReason: 'Just because',
-      noConflictOfInterest: true,
+      suggestionsConflict: true,
     }
 
     expect(() => schema.validateSync(validData)).not.toThrow()
@@ -24,7 +24,7 @@ describe('Editors form validation', () => {
       suggestedReviewingEditors: [],
       opposedReviewingEditors: [{ id: 1 }, { id: 2 }, { id: 3 }],
       opposedReviewingEditorsReason: '',
-      noConflictOfInterest: false,
+      suggestionsConflict: false,
       suggestedReviewers: [{ name: '', email: 'bloop' }],
     }
 
@@ -44,7 +44,7 @@ describe('Editors form validation', () => {
       ],
       suggestedReviewingEditors: 'Please suggest at least 2 editors',
       suggestedSeniorEditors: 'Please suggest at least 2 editors',
-      noConflictOfInterest:
+      suggestionsConflict:
         'Please do not suggest people with a known conflict of interest',
     })
   })

--- a/app/components/pages/SubmissionWizard/steps/Files/FileUploads.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/FileUploads.js
@@ -35,9 +35,9 @@ const FileUploads = ({
       <ValidatedField
         component={Editor}
         id="coverLetter"
-        name="submissionMeta.coverLetter"
-        onBlur={value => setFieldValue('submissionMeta.coverLetter', value)}
-        onChange={value => setFieldValue('submissionMeta.coverLetter', value)}
+        name="coverLetter"
+        onBlur={value => setFieldValue('coverLetter', value)}
+        onChange={value => setFieldValue('coverLetter', value)}
       />
     </Box>
     <Box width={1}>

--- a/app/components/pages/SubmissionWizard/steps/Files/FileUploads.md
+++ b/app/components/pages/SubmissionWizard/steps/Files/FileUploads.md
@@ -4,10 +4,8 @@ A form step for uploading a manuscript and writing the cover letter
 const { Formik } = formik
 const { schema } = require('./schema')
 const empty = {
-  submissionMeta: {
-    coverLetter:
-      '<p><b>How do you feel about writing cover letters?</b></p><p></p>',
-  },
+  coverLetter:
+    '<p><b>How do you feel about writing cover letters?</b></p><p></p>',
 }
 ;<Formik
   initialValues={empty}

--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -7,9 +7,11 @@ const UPLOAD_MUTATION = gql`
   mutation UploadFile($id: ID!, $file: Upload!) {
     uploadManuscript(id: $id, file: $file) {
       id
-      title
+      meta {
+        title
+      }
       files {
-        name
+        filename
         type
       }
     }
@@ -41,7 +43,7 @@ const FileUploadsPage = ({
             uploadFile({
               variables: { file, id: values.id },
             }).then(({ data }) => {
-              setFieldValue('title', data.uploadManuscript.title)
+              setFieldValue('meta.title', data.uploadManuscript.meta.title)
               setFieldValue(fieldName, data.uploadManuscript.files)
             })
           }

--- a/app/components/pages/SubmissionWizard/steps/Files/schema.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/schema.js
@@ -9,15 +9,13 @@ function stripHtml(html) {
 }
 
 const schema = yup.object().shape({
-  submissionMeta: yup.object({
-    coverLetter: yup
-      .string()
-      .test(
-        'hasContent',
-        `Your cover letter should be at least ${MIN_WORDS} words long`,
-        value => stripHtml(value).split(/\s+/).length > MIN_WORDS,
-      ),
-  }),
+  coverLetter: yup
+    .string()
+    .test(
+      'hasContent',
+      `Your cover letter should be at least ${MIN_WORDS} words long`,
+      value => stripHtml(value).split(/\s+/).length > MIN_WORDS,
+    ),
   files: yup.array().min(1, 'Please upload a manuscript'),
 })
 

--- a/app/components/pages/SubmissionWizard/steps/Submission/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Submission/index.js
@@ -10,16 +10,16 @@ import OptionalSection from './OptionalSection'
 const ManuscriptMetadata = ({ values, setFieldValue, setFieldTouched }) => (
   <React.Fragment>
     <Box mb={3}>
-      <ValidatedField label="Manuscript title" name="title" />
+      <ValidatedField label="Manuscript title" name="meta.title" />
     </Box>
 
     <Box mb={3} w={1 / 2}>
       <ValidatedField
         component={Menu}
         label="Article type"
-        name="manuscriptType"
-        onBlur={value => setFieldValue('manuscriptType', value)}
-        onChange={value => setFieldValue('manuscriptType', value)}
+        name="meta.articleType"
+        onBlur={value => setFieldValue('meta.articleType', value)}
+        onChange={value => setFieldValue('meta.articleType', value)}
         options={[
           { value: 'research-article', label: 'Research article' },
           { value: 'feature', label: 'Feature article' },
@@ -32,68 +32,61 @@ const ManuscriptMetadata = ({ values, setFieldValue, setFieldTouched }) => (
       <ValidatedField
         component={SubjectAreaDropdown}
         label="Subject areas"
-        name="subjectAreas"
-        onBlur={e => setFieldTouched('subjectAreas', true)}
+        name="meta.subjects"
+        onBlur={e => setFieldTouched('meta.subjects', true)}
         onChange={selectedOptions => {
-          const subjectAreas = selectedOptions.map(option => option.value)
-          setFieldValue('subjectAreas', subjectAreas)
+          const subjects = selectedOptions.map(option => option.value)
+          setFieldValue('meta.subjects', subjects)
         }}
-        savedValues={values.subjectAreas}
+        savedValues={values.meta.subjects}
       />
     </Box>
 
     <OptionalSection
       label="This manuscript has been discussed with an eLife editor"
-      namedAs="discussion"
-      onClose={() => setFieldValue('submissionMeta.discussion', null)}
-      onOpen={() => setFieldValue('submissionMeta.discussion', '')}
-      open={values.submissionMeta.discussion !== null}
+      namedAs="previouslyDiscussedToggle"
+      onClose={() => setFieldValue('previouslyDiscussed', null)}
+      onOpen={() => setFieldValue('previouslyDiscussed', '')}
+      open={values.previouslyDiscussed !== null}
     >
       <ValidatedField
         component={Textarea}
         label="What did you discuss and with whom?"
-        name="submissionMeta.discussion"
+        name="previouslyDiscussed"
       />
     </OptionalSection>
 
     <OptionalSection
       label="This manuscript has been previously considered by eLife"
-      namedAs="previousArticle"
-      onClose={() => setFieldValue('submissionMeta.previousArticle', null)}
-      onOpen={() => setFieldValue('submissionMeta.previousArticle', '')}
-      open={values.submissionMeta.previousArticle !== null}
+      namedAs="previouslySubmittedToggle"
+      onClose={() => setFieldValue('previouslySubmitted', [])}
+      onOpen={() => setFieldValue('previouslySubmitted', [''])}
+      open={values.previouslySubmitted.length}
     >
-      <ValidatedField
-        label="Article title"
-        name="submissionMeta.previousArticle"
-      />
+      <ValidatedField label="Article title" name="previouslySubmitted.0" />
     </OptionalSection>
 
     <OptionalSection
       label="This manuscript is part of a co-submission"
-      namedAs="cosubmission"
-      onClose={() =>
-        setFieldValue('submissionMeta.firstCosubmissionTitle', null)
-      }
-      onOpen={() => setFieldValue('submissionMeta.firstCosubmissionTitle', '')}
-      open={values.submissionMeta.firstCosubmissionTitle !== null}
+      namedAs="cosubmissionToggle"
+      onClose={() => setFieldValue('firstCosubmissionTitle', null)}
+      onOpen={() => setFieldValue('firstCosubmissionTitle', '')}
+      open={values.firstCosubmissionTitle !== null}
     >
       <Box mb={2}>
         <ValidatedField
           label="Second article title"
-          name="submissionMeta.firstCosubmissionTitle"
+          name="firstCosubmissionTitle"
         />
       </Box>
 
-      {values.submissionMeta.secondCosubmissionTitle === null ? (
+      {values.secondCosubmissionTitle === null ? (
         // If null showing the link to show the second title...
         <Box>
           Would you like to{' '}
           <Action
-            name="submissionMeta.moreSubmission"
-            onClick={() =>
-              setFieldValue('submissionMeta.secondCosubmissionTitle', '', false)
-            }
+            name="moreSubmission"
+            onClick={() => setFieldValue('secondCosubmissionTitle', '', false)}
             type="button"
           >
             include
@@ -105,7 +98,7 @@ const ManuscriptMetadata = ({ values, setFieldValue, setFieldTouched }) => (
         <Box mb={2}>
           <ValidatedField
             label="Third article title (optional)"
-            name="submissionMeta.secondCosubmissionTitle"
+            name="secondCosubmissionTitle"
           />
         </Box>
       )}

--- a/app/components/pages/SubmissionWizard/steps/Submission/index.md
+++ b/app/components/pages/SubmissionWizard/steps/Submission/index.md
@@ -1,8 +1,19 @@
-A form for entering metadata about the article being submitted e.g. title, type, etc.
+A form for entering metadata about the article being submitted e.g. title, type,
+etc.
 
 ```js
 const { Formik } = formik
-const { schema, empty } = require('./schema')
+const { schema } = require('./schema')
+const empty = {
+  meta: {
+    title: '',
+    articleType: '',
+    subjects: [],
+  },
+  previouslyDiscussed: null,
+  previouslySubmitted: [],
+  cosubmission: [],
+}
 ;<Formik
   component={ManuscriptMetadata}
   initialValues={empty}

--- a/app/components/pages/SubmissionWizard/steps/Submission/schema.js
+++ b/app/components/pages/SubmissionWizard/steps/Submission/schema.js
@@ -1,38 +1,29 @@
 import yup from 'yup'
 
 const schema = yup.object().shape({
-  title: yup.string().required('Title is required'),
-  manuscriptType: yup.string().required('Article type is required'),
-  subjectAreas: yup
-    .array()
-    .min(1, `Choose at least 1 subject area`)
-    .max(2, `No more than 2 subject areas`)
-    .required('Subject area(s) required'),
-  submissionMeta: yup.object().shape({
-    discussion: yup
-      .string()
-      .notOneOf([''], 'Please describe your previous discussion')
-      .nullable(),
-    previousArticle: yup
-      .string()
-      .notOneOf([''], 'Article title is required')
-      .nullable(),
-    firstCosubmissionTitle: yup
-      .string()
-      .notOneOf([''], 'Article title is required')
-      .nullable(),
+  meta: yup.object().shape({
+    title: yup.string().required('Title is required'),
+    articleType: yup.string().required('Article type is required'),
+    subjects: yup
+      .array()
+      .min(1, `Choose at least 1 subject area`)
+      .max(2, `No more than 2 subject areas`)
+      .required('Subject area(s) required'),
   }),
+  previouslyDiscussed: yup
+    .string()
+    .notOneOf(['', undefined], 'Please describe your previous discussion')
+    .nullable(),
+  previouslySubmitted: yup.array(
+    yup
+      .string()
+      .notOneOf([''], 'Article title is required')
+      .nullable(),
+  ),
+  firstCosubmissionTitle: yup
+    .string()
+    .notOneOf(['', undefined], 'Article title is required')
+    .nullable(),
 })
 
-const empty = {
-  title: '',
-  manuscriptType: '',
-  subjectAreas: [],
-  submissionMeta: {
-    discussion: null,
-    previousArticle: null,
-    cosubmission: [],
-  },
-}
-
-export { schema, empty }
+export { schema }

--- a/app/components/ui/molecules/PeoplePicker.js
+++ b/app/components/ui/molecules/PeoplePicker.js
@@ -69,7 +69,7 @@ const PeoplePickerBody = ({
         .map(person => (
           <PersonPod
             iconType={isSelected(person) ? 'selected' : 'add'}
-            institution={person.institution}
+            institution={person.aff}
             isIconClickable={
               isSelected(person) || selection.length < maxSelection
             }

--- a/server/auth/fetchUserDetails.js
+++ b/server/auth/fetchUserDetails.js
@@ -33,7 +33,7 @@ module.exports = async user => {
   const email = _.get(personResponse, 'body.emails.email[0].email')
 
   const employments = _.get(employmentsResponse, 'body.employment-summary')
-  const institution = employments.length
+  const aff = employments.length
     ? // sort by most recently ended
       employments
         .sort((a, b) => toDate(a['end-date']) - toDate(b['end-date']))
@@ -44,11 +44,11 @@ module.exports = async user => {
     first: ${firstName},
     last: ${lastName}
     email: ${email},
-    institution: ${institution}`)
+    aff: ${aff}`)
   return {
     firstName,
     lastName,
     email,
-    institution,
+    aff,
   }
 }

--- a/server/auth/fetchUserDetails.test.js
+++ b/server/auth/fetchUserDetails.test.js
@@ -14,7 +14,7 @@ describe('Fetch ORCID author details', () => {
       firstName: 'Test',
       lastName: 'User',
       email: 'elife@mailinator.com',
-      institution: 'University of eLife',
+      aff: 'University of eLife',
     })
   })
 })

--- a/server/db-helpers/index.js
+++ b/server/db-helpers/index.js
@@ -22,7 +22,8 @@ function manuscriptGqlToDb(manuscript, owner) {
   const manuscriptDb = _.cloneDeep(manuscript)
   delete manuscriptDb.id
   if (owner) {
-    manuscriptDb.submissionMeta.createdBy = owner
+    // todo: model this with submitter team
+    manuscriptDb.createdBy = owner
   }
   manuscriptDb.type = 'manuscript'
   return manuscriptDb
@@ -46,7 +47,7 @@ const update = async (obj, id) => {
 }
 
 const checkPermission = (manuscript, user) => {
-  if (user !== manuscript.submissionMeta.createdBy) {
+  if (user !== manuscript.createdBy) {
     throw new Error('Manuscript not owned by user')
   }
 }

--- a/server/submission/elife-api.js
+++ b/server/submission/elife-api.js
@@ -10,7 +10,7 @@ const request = (endpoint, query = {}) =>
 const convertPerson = apiPerson => ({
   id: apiPerson.id,
   name: apiPerson.name.preferred,
-  institution: apiPerson.affiliations && apiPerson.affiliations[0].name[0],
+  aff: apiPerson.affiliations && apiPerson.affiliations[0].name[0],
   subjectAreas: apiPerson.research.expertises.map(e => e.name),
 })
 

--- a/server/submission/elife.graphqls
+++ b/server/submission/elife.graphqls
@@ -1,7 +1,7 @@
 extend type Manuscript {
   previouslyDiscussed: String
   previouslySubmitted: [String!]
-  coSubmission: [String!]
+  cosubmission: [String!]
   relatedManuscripts: [RelatedManuscript!]
   suggestionsConflict: Boolean!
   qcIssues: [QCIssue!]

--- a/server/submission/xpub.graphqls
+++ b/server/submission/xpub.graphqls
@@ -159,7 +159,6 @@ type External {
     identifier: String
     email: Email
     aff: String
-    identifier: String
 }
 
 type Name {

--- a/test/pageObjects/author-details.js
+++ b/test/pageObjects/author-details.js
@@ -4,13 +4,11 @@ import { Selector } from 'testcafe'
 const authorDetails = {
   url: `${config.get('pubsweet-server.baseUrl')}/submit`,
   orcidPrefill: Selector('[data-test-id=orcid-prefill]'),
-  firstNameField: Selector('[name="submissionMeta.author.firstName"]'),
-  secondNameField: Selector('[name="submissionMeta.author.lastName"]'),
-  emailField: Selector('[name="submissionMeta.author.email"]'),
-  emailValidationMessage: Selector(
-    '[data-test-id="error-submissionMeta.author.email"]',
-  ),
-  institutionField: Selector('[name="submissionMeta.author.institution"]'),
+  firstNameField: Selector('[name="author.firstName"]'),
+  secondNameField: Selector('[name="author.lastName"]'),
+  emailField: Selector('[name="author.email"]'),
+  emailValidationMessage: Selector('[data-test-id="error-author.email"]'),
+  institutionField: Selector('[name="author.aff"]'),
 }
 
 export default authorDetails

--- a/test/pageObjects/file-uploads.js
+++ b/test/pageObjects/file-uploads.js
@@ -3,9 +3,7 @@ import { Selector } from 'testcafe'
 
 const fileUploads = {
   url: `${config.get('pubsweet-server.baseUrl')}/submit/upload`,
-  editor: Selector(
-    '[name="submissionMeta.coverLetter"] div[contenteditable=true]',
-  ),
+  editor: Selector('[name="coverLetter"] div[contenteditable=true]'),
   manuscriptUpload: Selector('[data-test-id=upload]>input'),
   preview: Selector('[data-test-id=preview]'),
 }

--- a/test/pageObjects/metadata.js
+++ b/test/pageObjects/metadata.js
@@ -3,25 +3,21 @@ import { Selector } from 'testcafe'
 
 const metadata = {
   url: `${config.get('pubsweet-server.baseUrl')}/submit/metadata`,
-  title: Selector('[name=title]'),
+  title: Selector('[name="meta.title"]'),
   articleType: Selector('[role=listbox] button'),
   articleTypes: Selector('[role=option]'),
   subjectAreaLabel: Selector('label[for=subject-area-select]'),
 
-  discussionCheckbox: Selector('[name="discussion"]'),
-  discussionText: Selector('[name="submissionMeta.discussion"]'),
+  discussionCheckbox: Selector('[name="previouslyDiscussedToggle"]'),
+  discussionText: Selector('[name="previouslyDiscussed"]'),
 
-  previousArticleCheckbox: Selector('[name="previousArticle"]'),
-  previousArticleText: Selector('[name="submissionMeta.previousArticle"]'),
+  previousArticleCheckbox: Selector('[name="previouslySubmittedToggle"]'),
+  previousArticleText: Selector('[name="previouslySubmitted.0"]'),
 
-  cosubmissionCheckbox: Selector('[name="cosubmission"]'),
-  firstCosubmissionTitle: Selector(
-    '[name="submissionMeta.firstCosubmissionTitle"]',
-  ),
-  secondCosubmissionTitle: Selector(
-    '[name="submissionMeta.secondCosubmissionTitle"]',
-  ),
-  moreSubmission: Selector('[name="submissionMeta.moreSubmission"]'),
+  cosubmissionCheckbox: Selector('[name="cosubmissionToggle"]'),
+  firstCosubmissionTitle: Selector('[name="firstCosubmissionTitle"]'),
+  secondCosubmissionTitle: Selector('[name="secondCosubmissionTitle"]'),
+  moreSubmission: Selector('[name="moreSubmission"]'),
 }
 
 export default metadata

--- a/test/pageObjects/suggestions.js
+++ b/test/pageObjects/suggestions.js
@@ -29,7 +29,7 @@ const suggestions = {
       .typeText('[name="suggestedReviewers.1.email"]', 'frances@example.net')
       .typeText('[name="suggestedReviewers.2.name"]', 'George')
       .typeText('[name="suggestedReviewers.2.email"]', 'george@example.org'),
-  conflictOfInterest: Selector('[name=noConflictOfInterest]').parent(),
+  conflictOfInterest: Selector('[name=suggestionsConflict]').parent(),
 }
 
 export default suggestions


### PR DESCRIPTION
#### Background

- Update app to use new manuscript object structure:
  - Some things go into `meta`
  - All things come out of `submissionMeta`
  - Some other objects get minor updates like property name changes
- Queries and mutations remain in `definitions.js` along with input types and temporary base type extensions like `author`

Deferred:
- Use teams to model editor suggestions, authors and submitters (see #436)

#### Any relevant tickets

Closes #424 
 
#### How has this been tested?

Existing tests updated.