### PR TITLE
ci: switch CD domain name to use new Kubernetes cluster

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ variables:
   DOCKER_HOST: tcp://localhost:2375/
   IMAGE_ORG: xpub
   IMAGE_NAME: xpub-elife
-  BASE_DOMAIN: gateway.xpub.semioticsquares.com
+  BASE_DOMAIN: gateway.xpub.elifesciences.yld.io
   CONFIGURATION_REPOSITORY: https://gitlab.coko.foundation/yld/xpub-deployment-config-postgres.git
 
 services:


### PR DESCRIPTION
#### Background

Complete the work that @fampinheiro has done migrating the Kubernetes cluster to its own AWS account.

#### How has this been tested?

If the pipeline passes then it's working.