### PR TITLE
refactor: use teams to persist author and suggested editors

### DIFF
--- a/app/components/pages/SubmissionWizard/operations.js
+++ b/app/components/pages/SubmissionWizard/operations.js
@@ -1,11 +1,17 @@
 import gql from 'graphql-tag'
 
 const editorFragment = gql`
-  fragment EditorDetails on EditorUser {
+  fragment EditorDetails on EditorAlias {
     id
     name
     aff
     subjectAreas
+  }
+`
+const reviewerFragment = gql`
+  fragment ReviewerDetails on ReviewerAlias {
+    name
+    email
   }
 `
 
@@ -18,23 +24,22 @@ const manuscriptFragment = gql`
       articleType
       subjects
     }
-    suggestedSeniorEditors {
+    suggestedSeniorEditors: assignees(role: "suggestedSeniorEditor") {
       ...EditorDetails
     }
-    opposedSeniorEditors {
+    opposedSeniorEditors: assignees(role: "opposedSeniorEditor") {
       ...EditorDetails
     }
     opposedSeniorEditorsReason
-    suggestedReviewingEditors {
+    suggestedReviewingEditors: assignees(role: "suggestedReviewingEditor") {
       ...EditorDetails
     }
-    opposedReviewingEditors {
+    opposedReviewingEditors: assignees(role: "opposedReviewingEditor") {
       ...EditorDetails
     }
     opposedReviewingEditorsReason
-    suggestedReviewers {
-      name
-      email
+    suggestedReviewers: assignees(role: "suggestedReviewer") {
+      ...ReviewerDetails
     }
     opposedReviewers {
       name
@@ -58,6 +63,7 @@ const manuscriptFragment = gql`
     cosubmission
   }
   ${editorFragment}
+  ${reviewerFragment}
 `
 
 export const GET_CURRENT_SUBMISSION = gql`

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsContent.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsContent.js
@@ -316,15 +316,7 @@ class EditorsContent extends React.Component {
           <Box>
             Would you like to{' '}
             <MoreButton
-              empty=""
-              fieldName="suggestedReviewers"
-              objectName="reviewer"
-              setFieldValue={setFieldValue}
-              values={values}
-            />{' '}
-            or{' '}
-            <MoreButton
-              empty={{ name: '', email: '', reason: '' }}
+              empty={{ name: '', email: '' }}
               fieldName="opposedReviewers"
               objectName="reviewer"
               setFieldValue={setFieldValue}

--- a/server/submission/elife.graphqls
+++ b/server/submission/elife.graphqls
@@ -5,6 +5,7 @@ extend type Manuscript {
   relatedManuscripts: [RelatedManuscript!]
   suggestionsConflict: Boolean!
   qcIssues: [QCIssue!]
+  assignees(role: String!): [Assignee]
 }
 
 # syntax supported in graphql-js >v14.0.0-rc.1
@@ -27,7 +28,7 @@ extend type Alias {
   lastName: String
 }
 
-union TeamMemberMeta = AuthorMetadata | ReviewerMetadata
+union TeamMemberMeta = AuthorMetadata | ReviewerMetadata | EditorMetadata
 
 type AuthorMetadata {
   rank: Int!
@@ -43,6 +44,10 @@ type ReviewerMetadata {
   coRelationship: [TeamMember]
   conflictOfInterest: String
   revealIdentity: Boolean!
+}
+
+type EditorMetadata {
+  elifePersonId: ID
 }
 
 extend type File {


### PR DESCRIPTION
#### Background

- Keep the same data shape on the client and in the input types
- Store suggested and opposed editors, author and suggested reviewers as teams
- Leave opposed reviewers because the change in design is likely to mean the opposed reason is no longer associated with the team members

#### Any relevant tickets

Closes #436 
- ~~reviewers left alone due to ongoing work in #336~~
- submitter left until after #423 due to the complexity in crafting appropriate SQL statements

#### How has this been tested?

Existing tests updated.