### PR TITLE
Handle when the people endpoint of the elife-api returns an empty body

### DIFF
--- a/server/submission/elife-api.js
+++ b/server/submission/elife-api.js
@@ -25,10 +25,12 @@ const people = async role => {
       'per-page': 100,
       type: role,
     })
-    items = items.concat(response.body.items)
+    if (response.body.items) {
+      items = items.concat(response.body.items)
+    }
     page += 1
   } while (items.length < response.body.total)
-  return items.map(convertPerson)
+  return !items || items.length === 0 ? [] : items.map(convertPerson)
 }
 
 const person = async id => {


### PR DESCRIPTION
#### Background

Fixes both server and client errors in the case the endpoint returns an empty body

#### How has this been tested?
 locally