### PR TITLE
feat: SQL schema for shared data model

### DIFF
--- a/server/xpub/index.js
+++ b/server/xpub/index.js
@@ -30,4 +30,7 @@ const resolvers = merge(
 module.exports = {
   typeDefs,
   resolvers,
+  // TODO enable migrations once clobbering issue in pubsweet is resolved
+  // https://gitlab.coko.foundation/pubsweet/pubsweet/issues/419
+  // migrationsPath: `./schema/migrations`,
 }

--- a/server/xpub/schema/migrations/1533672892-initial.sql
+++ b/server/xpub/schema/migrations/1533672892-initial.sql
@@ -1,0 +1,98 @@
+CREATE TABLE organization (
+    id UUID PRIMARY KEY,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMP WITH TIME ZONE,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE journal (
+    id UUID PRIMARY KEY,
+    organization_id UUID NOT NULL REFERENCES organization,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMP WITH TIME ZONE,
+    journal_title TEXT NOT NULL,
+    "meta.publisher_name" TEXT
+);
+
+CREATE TABLE manuscript (
+    id UUID PRIMARY KEY,
+    journal_id UUID NOT NULL REFERENCES journal,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMP WITH TIME ZONE,
+    -- points to "previous" (i.e. older) version of manuscript
+    -- first version has previous_version = null
+    -- id of current version does not change
+    previous_version UUID REFERENCES manuscript,
+    status TEXT NOT NULL,
+    form_state TEXT,
+    decision TEXT,
+    "meta.title" TEXT,
+    "meta.article_type" TEXT,
+    "meta.article_ids" JSONB,
+    "meta.abstract" TEXT,
+    "meta.subjects" JSONB,
+    "meta.publication_dates" JSONB,
+    "meta.notes" JSONB
+);
+
+CREATE TABLE file (
+    id UUID PRIMARY KEY,
+    manuscript_id UUID NOT NULL REFERENCES manuscript,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMP WITH TIME ZONE,
+    type TEXT,
+    label TEXT,
+    filename TEXT NOT NULL,
+    url TEXT NOT NULL,
+    mime_type TEXT,
+    size INTEGER
+);
+
+-- user is a reserved word so table name must always be quoted
+CREATE TABLE "user" (
+    id UUID PRIMARY KEY,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMP WITH TIME ZONE,
+    default_identity TEXT
+);
+
+CREATE TABLE review (
+    id UUID PRIMARY KEY,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMP WITH TIME ZONE,
+    comments JSONB,
+    recommendation TEXT,
+    open BOOLEAN,
+    user_id UUID NOT NULL REFERENCES "user"
+);
+
+CREATE TABLE audit_log (
+    id UUID PRIMARY KEY,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    user_id UUID REFERENCES "user",
+    action TEXT NOT NULL,
+    object_id UUID,
+    object_type TEXT
+);
+
+CREATE TABLE team (
+    id UUID PRIMARY KEY,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMP WITH TIME ZONE,
+    team_members JSONB NOT NULL,
+    role TEXT NOT NULL,
+    object_id UUID NOT NULL,
+    object_type TEXT NOT NULL
+);
+
+CREATE TABLE identity (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES "user",
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMP WITH TIME ZONE,
+    type TEXT NOT NULL, -- e.g. local, orcid
+    identifier TEXT, -- e.g. orcid ID
+    display_name TEXT, -- used in the UI
+    email TEXT, -- used for contacting user
+    meta JSONB -- anything else, e.g. password, oauth tokens
+);

--- a/server/xpub/schema/migrations/1533830042-elife.sql
+++ b/server/xpub/schema/migrations/1533830042-elife.sql
@@ -1,0 +1,7 @@
+ALTER TABLE manuscript
+  ADD COLUMN previously_discussed TEXT,
+  ADD COLUMN previously_submitted JSONB,
+  ADD COLUMN cosubmission JSONB,
+  ADD COLUMN related_manuscripts JSONB,
+  ADD COLUMN suggestions_conflict BOOLEAN,
+  ADD COLUMN qc_issues JSONB;

--- a/server/xpub/schema/xpub.graphqls
+++ b/server/xpub/schema/xpub.graphqls
@@ -81,7 +81,7 @@ type Note implements Object {
     content: String
 }
 
-type File implements Object  {
+type File implements Object {
     id: ID!
     created: DateTime!
     updated: DateTime
@@ -93,7 +93,7 @@ type File implements Object  {
     size: Int
 }
 
-type Review implements Object  {
+type Review implements Object {
     id: ID!
     created: DateTime!
     updated: DateTime
@@ -112,7 +112,6 @@ type Comment {
 type AuditLog {
     id: ID!
     created: DateTime!
-    updated: DateTime
     user: User
     action: String
     object: Object


### PR DESCRIPTION
#### Background

First stab at a SQL schema corresponding to the GraphQL schema already in use.

There's also [a MR open in PubSweet](https://gitlab.coko.foundation/xpub/shared-data-model/merge_requests/8) for this.

#### Any relevant tickets

Closes #423 

#### How has this been tested?

Manually in Postgres and through pubsweet migrations.