### PR TITLE
fix: move custom environment variables into correct location

### DIFF
--- a/config/custom-environment-variables.js
+++ b/config/custom-environment-variables.js
@@ -1,7 +1,9 @@
 module.exports = {
-  'pubsweet-client': {
+  'pubsweet-server': {
     baseUrl: 'PUBSWEET_BASEURL',
     secret: 'PUBSWEET_SECRET',
+  },
+  'pubsweet-client': {
     sha: 'CI_COMMIT_SHA',
   },
   'auth-orcid': {


### PR DESCRIPTION
#### Background

- These were accidentally added under "client" instead of "server"