### PR TITLE
Update co-submission input labelling and author step title

### DIFF
--- a/app/components/pages/SubmissionWizard/index.js
+++ b/app/components/pages/SubmissionWizard/index.js
@@ -83,7 +83,7 @@ const SubmissionPage = ({ match, history }) => (
               initialValues={initialValues}
               nextUrl={`${match.path}/upload`}
               step={0}
-              title="Who is the corresponding author?"
+              title="Your details"
               validationSchema={authorDetailsSchema}
             />
           )}

--- a/app/components/pages/SubmissionWizard/steps/Submission/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Submission/index.js
@@ -63,7 +63,7 @@ const ManuscriptMetadata = ({ values, setFieldValue, setFieldTouched }) => (
       onOpen={() => setFieldValue('previouslySubmitted', [''])}
       open={values.previouslySubmitted.length}
     >
-      <ValidatedField label="Article title" name="previouslySubmitted.0" />
+      <ValidatedField label="Previous article title" name="previouslySubmitted.0" />
     </OptionalSection>
 
     <OptionalSection
@@ -75,7 +75,7 @@ const ManuscriptMetadata = ({ values, setFieldValue, setFieldTouched }) => (
     >
       <Box mb={2}>
         <ValidatedField
-          label="Second article title"
+          label="Title of co-submitted article"
           name="firstCosubmissionTitle"
         />
       </Box>
@@ -89,15 +89,15 @@ const ManuscriptMetadata = ({ values, setFieldValue, setFieldTouched }) => (
             onClick={() => setFieldValue('secondCosubmissionTitle', '', false)}
             type="button"
           >
-            include
+            add
           </Action>{' '}
-          another cosubmission
+          another co-submission
         </Box>
       ) : (
         // the second title is not null so show it
         <Box mb={2}>
           <ValidatedField
-            label="Third article title (optional)"
+            label="Title of co-submitted article (optional)"
             name="secondCosubmissionTitle"
           />
         </Box>


### PR DESCRIPTION
#### Background

- Makes minor amendments to the labelling of text input fields on the Submission screen.
- Updates title of Step 1 of the wizard. This is because we are dropping the corresponding author delegation feature from the first release. The application now only records the details of one person, who fulfills both the roles of submitter and corresponding author.


