### PR TITLE
leave space in person pod if institution is null

### DIFF
--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -139,7 +139,7 @@ const PodIcon = ({ iconType }) => {
 
 const PersonText = ({
   name,
-  institution,
+  institution = '',
   keywords,
   isKeywordClickable,
   onKeywordClick = null,
@@ -174,7 +174,8 @@ const PersonText = ({
   return (
     <CollapsibleBox m={2} {...props}>
       <RegularP>{name}</RegularP>
-      <RegularP>{institution}</RegularP>
+      {institution && <RegularP>{institution}</RegularP>}
+      {!institution && <Box mb={3} />}
       <SmallP>{separatedKeywords}</SmallP>
       {isStatusShown && <SmallP>{status}</SmallP>}
     </CollapsibleBox>
@@ -227,7 +228,7 @@ PodIcon.propTypes = {
 
 PersonText.propTypes = {
   name: PropTypes.string.isRequired,
-  institution: PropTypes.string.isRequired,
+  institution: PropTypes.string,
   keywords: PropTypes.arrayOf(PropTypes.string.isRequired),
   isKeywordClickable: PropTypes.bool.isRequired,
   onKeywordClick: PropTypes.func,
@@ -236,6 +237,7 @@ PersonText.propTypes = {
 }
 
 PersonText.defaultProps = {
+  institution: '',
   keywords: [],
   onKeywordClick: null,
   isStatusShown: false,


### PR DESCRIPTION
#### What does this PR do?
- removes prop-types warning about `institution` in `PersonPod` (by no longer making this prop required)
- in the situation where institution comes back null, display a placeholder space in the Person Pod

#### Any relevant tickets
fixes #404 "Keep space for missing items in person pod"
fixes #403 "Handle editors with no institution"

#### How has this been tested?
Visually & no more warning when running tests