### PR TITLE
add data disclosure info to db migration file

### DIFF
--- a/server/xpub/schema/migrations/1533830042-elife.sql
+++ b/server/xpub/schema/migrations/1533830042-elife.sql
@@ -4,4 +4,6 @@ ALTER TABLE manuscript
   ADD COLUMN cosubmission JSONB,
   ADD COLUMN related_manuscripts JSONB,
   ADD COLUMN suggestions_conflict BOOLEAN,
+  ADD COLUMN submitter_signature TEXT,
+  ADD COLUMN disclosure_consent BOOLEAN,
   ADD COLUMN qc_issues JSONB;


### PR DESCRIPTION
#### Background
I have already added `submitterSignature` & `disclosureConsent` to the `elife.graphqls` schema in PR #496 

See [these lines of code](https://github.com/elifesciences/elife-xpub/blob/develop/server/xpub/schema/elife.graphqls#L5-L6) already in `develop`

#### What does this PR do?
Add these values to the db migration file

#### Any relevant tickets
Fixes #490 

#### How has this been tested?
N/A