### PR TITLE
remove/reduce scope of 2nd end to end test

### DIFF
--- a/app/components/pages/SubmissionWizard/WizardStep.js
+++ b/app/components/pages/SubmissionWizard/WizardStep.js
@@ -41,7 +41,9 @@ const WizardStep = ({
             <Flex mt={6}>
               {previousUrl && (
                 <Box mr={3}>
-                  <ButtonLink to={previousUrl}>Back</ButtonLink>
+                  <ButtonLink data-test-id="back" to={previousUrl}>
+                    Back
+                  </ButtonLink>
                 </Box>
               )}
               <Box>

--- a/test/pageObjects/index.js
+++ b/test/pageObjects/index.js
@@ -1,5 +1,5 @@
 export { default as dashboard } from './dashboard'
-export { default as submission } from './submission'
+export { default as wizardStep } from './wizardStep'
 export { default as authorDetails } from './author-details'
 export { default as fileUploads } from './file-uploads'
 export { default as metadata } from './metadata'

--- a/test/pageObjects/submission.js
+++ b/test/pageObjects/submission.js
@@ -1,6 +1,7 @@
 import { Selector } from 'testcafe'
 
 const fileUploads = {
+  back: Selector('[data-test-id=back]'),
   next: Selector('[data-test-id=next]'),
 }
 

--- a/test/pageObjects/suggestions.js
+++ b/test/pageObjects/suggestions.js
@@ -1,5 +1,5 @@
 import config from 'config'
-import { Selector, t } from 'testcafe'
+import { Selector } from 'testcafe'
 
 const suggestions = {
   url: `${config.get('pubsweet-server.baseUrl')}/submit/suggestions`,
@@ -13,22 +13,18 @@ const suggestions = {
     '[data-test-id="people-picker-body"] [data-test-id="person-pod-button"]',
   ),
   peoplePickerSubmit: Selector('[data-test-id="people-picker-add"]'),
-  fillWithDummyData: () =>
-    t
-      .click(suggestions.suggestedSeniorEditorSelection)
-      .click(suggestions.peoplePickerOptions.nth(0))
-      .click(suggestions.peoplePickerOptions.nth(2))
-      .click(suggestions.peoplePickerSubmit)
-      .click(suggestions.suggestedReviewingEditorSelection)
-      .click(suggestions.peoplePickerOptions.nth(1))
-      .click(suggestions.peoplePickerOptions.nth(4))
-      .click(suggestions.peoplePickerSubmit)
-      .typeText('[name="suggestedReviewers.0.name"]', 'Edward')
-      .typeText('[name="suggestedReviewers.0.email"]', 'edward@example.com')
-      .typeText('[name="suggestedReviewers.1.name"]', 'Frances')
-      .typeText('[name="suggestedReviewers.1.email"]', 'frances@example.net')
-      .typeText('[name="suggestedReviewers.2.name"]', 'George')
-      .typeText('[name="suggestedReviewers.2.email"]', 'george@example.org'),
+  firstReviewerName: Selector('[name="suggestedReviewers.0.name"]'),
+  firstReviewerEmail: Selector('[name="suggestedReviewers.0.email"]'),
+  secondReviewerName: Selector('[name="suggestedReviewers.1.name"]'),
+  secondReviewerEmail: Selector('[name="suggestedReviewers.1.email"]'),
+  thirdReviewerName: Selector('[name="suggestedReviewers.2.name"]'),
+  thirdReviewerEmail: Selector('[name="suggestedReviewers.2.email"]'),
+  fourthReviewerName: Selector('[name="suggestedReviewers.3.name"]'),
+  fourthReviewerEmail: Selector('[name="suggestedReviewers.3.email"]'),
+  fifthReviewerName: Selector('[name="suggestedReviewers.4.name"]'),
+  fifthReviewerEmail: Selector('[name="suggestedReviewers.4.email"]'),
+  sixthReviewerName: Selector('[name="suggestedReviewers.5.name"]'),
+  sixthReviewerEmail: Selector('[name="suggestedReviewers.5.email"]'),
   conflictOfInterest: Selector('[name=suggestionsConflict]').parent(),
 }
 

--- a/test/pageObjects/wizardStep.js
+++ b/test/pageObjects/wizardStep.js
@@ -1,8 +1,8 @@
 import { Selector } from 'testcafe'
 
-const fileUploads = {
+const wizardStep = {
   back: Selector('[data-test-id=back]'),
   next: Selector('[data-test-id=next]'),
 }
 
-export default fileUploads
+export default wizardStep

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -2,7 +2,7 @@ import { ClientFunction, Selector } from 'testcafe'
 import replaySetup from './helpers/replay-setup'
 import {
   dashboard,
-  submission,
+  wizardStep,
   authorDetails,
   fileUploads,
   metadata,
@@ -52,7 +52,7 @@ test('Happy path', async t => {
       'University of eLife',
       'Institution is populated by query to the Orchid API',
     )
-    .click(submission.next)
+    .click(wizardStep.next)
 
   // file uploads
   await t
@@ -66,7 +66,7 @@ test('Happy path', async t => {
     .eql(manuscript.title)
   // only way to get back to wizard is with browser back button at the moment
   await goBack()
-  await t.click(submission.next)
+  await t.click(wizardStep.next)
 
   // metadata
   await t
@@ -86,8 +86,8 @@ test('Happy path', async t => {
     .typeText(metadata.firstCosubmissionTitle, 'Another title')
     .click(metadata.moreSubmission)
     .typeText(metadata.secondCosubmissionTitle, 'Yet another title')
-    .click(submission.next)
-    .click(submission.next)
+    .click(wizardStep.next)
+    .click(wizardStep.next)
 
   // reviewer suggestions
   await t
@@ -112,13 +112,13 @@ test('Happy path', async t => {
     .typeText(suggestions.sixthReviewerName, 'Emily')
     .typeText(suggestions.sixthReviewerEmail, 'emily@example.org')
     .click(suggestions.conflictOfInterest)
-    .click(submission.next)
+    .click(wizardStep.next)
 
   // data disclosure
   await t
     .typeText(disclosure.submitterName, 'Joe Bloggs')
     .click(disclosure.consentCheckbox)
-    .click(submission.next)
+    .click(wizardStep.next)
 
   // dashboard
   await t
@@ -144,7 +144,7 @@ test('Ability to progress through the wizard is tied to validation', async t => 
       'Must be a valid email address',
       'Error is displayed when user enters invalid email',
     )
-    .click(submission.next)
+    .click(wizardStep.next)
     // without this wait the tests sometimes fail on CI ¯\_(ツ)_/¯
     .wait(1000)
     .expect(getPageUrl())
@@ -153,7 +153,7 @@ test('Ability to progress through the wizard is tied to validation', async t => 
       'Validation errors prevent progress to the next page',
     )
     .typeText(authorDetails.emailField, '.ac.uk')
-    .click(submission.next)
+    .click(wizardStep.next)
     .expect(getPageUrl())
     .eql(
       fileUploads.url,
@@ -170,11 +170,11 @@ test('Form entries are saved when a user navigates to the next page of the wizar
     .typeText(authorDetails.secondNameField, 'Moggy')
     .typeText(authorDetails.emailField, 'meghan@example.com')
     .typeText(authorDetails.institutionField, 'iTunes U')
-    .click(submission.next)
+    .click(wizardStep.next)
 
   // ensure save completed before reloading
   await fileUploads.editor
-  await t.click(submission.back)
+  await t.click(wizardStep.back)
 
   await t
     .expect(authorDetails.firstNameField.value)


### PR DESCRIPTION
#### What does this PR do?
- Remove wizard steps 2+ from 2nd end-to-end test, as these were largely duplicating the happy path test
- Add the following to the happy path test (which was only covered in test 2 before):
  - visit manuscript preview page during step 2 of wizard
  - enter all info on step 3 of wizard, including ticking the checkboxes & entering info into their children
- Enter info for all 6 reviewers on step 4 of wizard
- Rename 2nd test - removing all the "happy path" portions means that this now _only_ checks whether invalid entries prevent progress to next page & then whether entering valid inputs enables wizard progress again

Along the way I've refactored a little:
- Removed `fillWithDummyData` from inside the `PageObjects/suggestions.js` file - for all other wizard steps we use the PageObjects file simply to select elements from the page & the e2e test file itself is where the dummy data is entered
- Separate out usage of `ClientFunction` so that `getPageUrl` & `goBack` are declared at the top of the file rather than inside individual tests
- Rename 3rd test to be slightly more accurate/descriptive
- Select "Back" button from wizard steps & use this in 3rd test, like a user would do, instead of navigating with the URL bar
- Rename `pageObjects/suggestions.js` as `pageObjects/wizardStep.js` to come in line with frontend file renaming

#### Any relevant tickets
fixes #522 
