### PR TITLE
WIP: bring urls in line with the names of our wizard steps

### DIFF
--- a/app/components/pages/SubmissionWizard/index.js
+++ b/app/components/pages/SubmissionWizard/index.js
@@ -24,7 +24,7 @@ const SubmissionPage = ({ match, history }) => (
       <Switch>
         <Route
           exact
-          path={`${match.path}/upload`}
+          path={`${match.path}/files`}
           render={() => (
             <WizardStep
               component={FileUploads}
@@ -32,7 +32,7 @@ const SubmissionPage = ({ match, history }) => (
               handleUpdate={updateSubmission}
               history={history}
               initialValues={initialValues}
-              nextUrl={`${match.path}/metadata`}
+              nextUrl={`${match.path}/submission`}
               previousUrl={`${match.path}`}
               step={1}
               title="Write your cover letter and upload your manuscript"
@@ -41,7 +41,7 @@ const SubmissionPage = ({ match, history }) => (
           )}
         />
         <Route
-          path={`${match.path}/metadata`}
+          path={`${match.path}/submission`}
           render={() => (
             <WizardStep
               component={ManuscriptMetadata}
@@ -49,8 +49,8 @@ const SubmissionPage = ({ match, history }) => (
               handleUpdate={updateSubmission}
               history={history}
               initialValues={initialValues}
-              nextUrl={`${match.path}/suggestions`}
-              previousUrl={`${match.path}/upload`}
+              nextUrl={`${match.path}/editors`}
+              previousUrl={`${match.path}/files`}
               step={2}
               title="Help us get your work seen by the right people"
               validationSchema={manuscriptMetadataSchema}
@@ -58,7 +58,7 @@ const SubmissionPage = ({ match, history }) => (
           )}
         />
         <Route
-          path={`${match.path}/suggestions`}
+          path={`${match.path}/editors`}
           render={() => (
             <WizardStep
               component={ReviewerSuggestions}
@@ -67,7 +67,7 @@ const SubmissionPage = ({ match, history }) => (
               history={history}
               initialValues={initialValues}
               nextUrl={`${match.path}/disclosure`}
-              previousUrl={`${match.path}/metadata`}
+              previousUrl={`${match.path}/submission`}
               step={3}
               title="Who should review your work?"
               validationSchema={reviewerSuggestionsSchema}
@@ -83,8 +83,8 @@ const SubmissionPage = ({ match, history }) => (
               handleUpdate={updateSubmission}
               history={history}
               initialValues={initialValues}
-              nextUrl="/dashboard"
-              previousUrl={`${match.path}/suggestions`}
+              nextUrl="/"
+              previousUrl={`${match.path}/editors`}
               step={4}
               submitButtonText="Submit"
               title="Disclosure of data to editors"
@@ -100,7 +100,7 @@ const SubmissionPage = ({ match, history }) => (
               handleUpdate={updateSubmission}
               history={history}
               initialValues={initialValues}
-              nextUrl={`${match.path}/upload`}
+              nextUrl={`${match.path}/files`}
               step={0}
               title="Your details"
               validationSchema={authorDetailsSchema}

--- a/test/pageObjects/file-uploads.js
+++ b/test/pageObjects/file-uploads.js
@@ -2,7 +2,7 @@ import config from 'config'
 import { Selector } from 'testcafe'
 
 const fileUploads = {
-  url: `${config.get('pubsweet-server.baseUrl')}/submit/upload`,
+  url: `${config.get('pubsweet-server.baseUrl')}/submit/files`,
   editor: Selector('[name="coverLetter"] div[contenteditable=true]'),
   manuscriptUpload: Selector('[data-test-id=upload]>input'),
   preview: Selector('[data-test-id=preview]'),

--- a/test/pageObjects/metadata.js
+++ b/test/pageObjects/metadata.js
@@ -2,7 +2,7 @@ import config from 'config'
 import { Selector } from 'testcafe'
 
 const metadata = {
-  url: `${config.get('pubsweet-server.baseUrl')}/submit/metadata`,
+  url: `${config.get('pubsweet-server.baseUrl')}/submit/submission`,
   title: Selector('[name="meta.title"]'),
   articleType: Selector('[role=listbox] button'),
   articleTypes: Selector('[role=option]'),

--- a/test/pageObjects/suggestions.js
+++ b/test/pageObjects/suggestions.js
@@ -2,7 +2,7 @@ import config from 'config'
 import { Selector, t } from 'testcafe'
 
 const suggestions = {
-  url: `${config.get('pubsweet-server.baseUrl')}/submit/suggestions`,
+  url: `${config.get('pubsweet-server.baseUrl')}/submit/editors`,
   suggestedSeniorEditorSelection: Selector(
     '[data-test-id="suggested-senior-editors"] [data-test-id="person-pod-button"]',
   ),


### PR DESCRIPTION
WIP - This is only the first step in issue #523 

#### What does this PR do?
- change URLs to reflect wizard step names
  - `BASEURL/dashboard` -> `BASEURL/` (both were being used for the same page in our app - changed to just the home root)
  - (wizard step 1 aka "author" is still just `BASEURL/submit/`)
  - `BASEURL/submit/upload` -> `BASEURL/submit/files`
  - `BASEURL/submit/metadata` -> `BASEURL/submit/submission`
  - `BASEURL/submit/suggestions` -> `BASEURL/submit/editors`
  - (step 5 remains `BASEURL/submit/disclosure`)

#### Any relevant tickets
#523 

#### How has this been tested?
No tests for the routing yet