### PR TITLE
feat(DisclosurePage): display current date on disclosure page

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Disclosure/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Disclosure/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { Box } from 'grid-styled'
 import { th } from '@pubsweet/ui-toolkit'
+import { format, parse } from 'date-fns'
 
 import Paragraph from '../../../../ui/atoms/Paragraph'
 import SmallParagraph from '../../../../ui/atoms/SmallParagraph'
@@ -13,6 +14,9 @@ import ControlledCheckbox from '../../../../ui/atoms/ControlledCheckbox'
 const StyledSmallParagraph = styled(SmallParagraph)`
   color: ${th('colorTextSecondary')};
 `
+
+const localDate = parse(new Date())
+const formattedLocalDate = format(localDate, 'MMM D, YYYY')
 
 const DisclosurePage = ({ values, setFieldValue, setFieldTouched }) => {
   const formattedArticleType = values.meta.articleType
@@ -26,7 +30,9 @@ const DisclosurePage = ({ values, setFieldValue, setFieldTouched }) => {
         <Paragraph>
           {values.author.firstName} {values.author.lastName}
         </Paragraph>
-        <StyledSmallParagraph>{formattedArticleType}</StyledSmallParagraph>
+        <StyledSmallParagraph>
+          {formattedArticleType} {formattedLocalDate}
+        </StyledSmallParagraph>
       </Box>
       <Box mb={4}>
         <Paragraph>

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@pubsweet/ui-toolkit": "^1.1.3",
     "apollo-link-state": "^0.4.1",
     "config": "^2.0.1",
+    "date-fns": "^1.29.0",
     "formik": "^1.0.3",
     "graphql-tag": "^2.8.0",
     "grid-styled": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3080,7 +3080,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
-date-fns@^1.27.2:
+date-fns@^1.27.2, date-fns@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
@@ -8994,7 +8994,7 @@ pubsweet-client@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/pubsweet-client/-/pubsweet-client-4.1.3.tgz#696b415e1e8ec2b752580d2c5e07561d0a1da1af"
   dependencies:
-    "@pubsweet/ui" "^8.4.0"
+    "@pubsweet/ui" "^8.5.0"
     "@pubsweet/ui-toolkit" "^1.2.0"
     apollo-cache-inmemory "^1.2.4"
     apollo-client "^2.3.4"


### PR DESCRIPTION
#### What does this PR do?
- Uses `date-fns` to display the current date on the data disclosure page, based on the user's timezone

#### Any relevant tickets
fixes #519 

#### How has this been tested?
Automated tests: N/A - using an external library

Visually:
- The date is **3rd sept** when the timezone of my OS is set to London, UK
![image](https://user-images.githubusercontent.com/15656538/44993899-2d9bb580-af94-11e8-98fb-a52d98d94afa.png)

- The date is **4th sept** when the timezone of my OS is set to Canberra, Australia:
![image](https://user-images.githubusercontent.com/15656538/44993918-44daa300-af94-11e8-9514-8a6e94f7923c.png)
