### PR TITLE
add cross icon that clears search box & refreshes pods

### DIFF
--- a/app/components/ui/molecules/CrossIconButton.js
+++ b/app/components/ui/molecules/CrossIconButton.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import styled from 'styled-components'
+import { th } from '@pubsweet/ui-toolkit'
+
+import Icon from '../atoms/Icon'
+
+const CrossIcon = ({ overrideName, ...props }) => (
+  <Icon iconName="X" overrideName={overrideName} {...props} />
+)
+
+const IconButton = styled.button.attrs({
+  type: 'button',
+})`
+  background-color: ${th('colorBackground')};
+  border: none;
+  line-height: 0;
+  padding: 0;
+`
+
+const CrossIconButton = ({ onClick, iconOverrideName, ...props }) => (
+  <IconButton onClick={onClick} {...props}>
+    <CrossIcon overrideName={iconOverrideName} />
+  </IconButton>
+)
+
+export default CrossIconButton

--- a/app/components/ui/molecules/CrossIconButton.js
+++ b/app/components/ui/molecules/CrossIconButton.js
@@ -4,9 +4,7 @@ import { th } from '@pubsweet/ui-toolkit'
 
 import Icon from '../atoms/Icon'
 
-const CrossIcon = ({ overrideName, ...props }) => (
-  <Icon iconName="X" overrideName={overrideName} {...props} />
-)
+const CrossIcon = props => <Icon iconName="X" {...props} />
 
 const IconButton = styled.button.attrs({
   type: 'button',

--- a/app/components/ui/molecules/CrossIconButton.md
+++ b/app/components/ui/molecules/CrossIconButton.md
@@ -1,0 +1,5 @@
+Clickable cross icon
+
+```js
+<CrossIconButton onClick={() => console.log('clicked')} />
+```

--- a/app/components/ui/molecules/SearchBox.js
+++ b/app/components/ui/molecules/SearchBox.js
@@ -118,9 +118,12 @@ class SearchBox extends React.Component {
     this.props.onSubmit(this.state.value)
   }
   clearSearch = event => {
-    this.setState({
-      value: '',
-    })
+    this.setState(
+      {
+        value: '',
+      },
+      () => this.handleSearch(),
+    )
   }
   renderSuggestion = suggestion => {
     const inputValue = this.state.value.trim().toLowerCase()

--- a/app/components/ui/molecules/SearchBox.js
+++ b/app/components/ui/molecules/SearchBox.js
@@ -5,6 +5,7 @@ import { th } from '@pubsweet/ui-toolkit'
 import { Flex, Box } from 'grid-styled'
 
 import SearchButton from './SearchIconButton'
+import ClearSearchButton from './CrossIconButton'
 
 const AutosuggestWrapper = styled(Box).attrs({
   width: 1,
@@ -116,6 +117,11 @@ class SearchBox extends React.Component {
   handleSearch = event => {
     this.props.onSubmit(this.state.value)
   }
+  clearSearch = event => {
+    this.setState({
+      value: '',
+    })
+  }
   renderSuggestion = suggestion => {
     const inputValue = this.state.value.trim().toLowerCase()
     const matchIndex = this.props.getMatchIndex(inputValue, suggestion.value)
@@ -158,6 +164,10 @@ class SearchBox extends React.Component {
             suggestions={suggestions}
           />
         </AutosuggestWrapper>
+        <ClearSearchButton
+          iconOverrideName="@pubsweet-pending.PeoplePicker.ClearSearch"
+          onClick={this.clearSearch}
+        />
         <SearchButton onClick={this.handleSearch} />
       </Flex>
     )

--- a/app/components/ui/molecules/SearchBox.js
+++ b/app/components/ui/molecules/SearchBox.js
@@ -100,7 +100,7 @@ class SearchBox extends React.Component {
       {
         value: suggestion.value,
       },
-      () => this.props.onSubmit(suggestion.value),
+      () => this.handleSearch(),
     )
   }
   onChange = (_, { newValue }) => {
@@ -111,7 +111,7 @@ class SearchBox extends React.Component {
   onKeyDown = event => {
     // key code for enter is 13
     if (event.keyCode === 13) {
-      this.handleSearch(this.state.value)
+      this.handleSearch()
     }
   }
   handleSearch = event => {

--- a/app/components/ui/molecules/SearchBox.js
+++ b/app/components/ui/molecules/SearchBox.js
@@ -14,7 +14,8 @@ const AutosuggestWrapper = styled(Box).attrs({
 
   .react-autosuggest__input {
     border: ${th('borderWidth')} ${th('borderStyle')} ${th('colorBorder')};
-    border-radius: ${th('borderRadius')};
+    border-right: ${th('colorBackground')};
+    border-radius: ${th('borderRadius')} 0 0 ${th('borderRadius')};
     font-family: ${th('fontInterface')};
     font-size: ${th('fontSizeBase')};
     line-height: ${th('lineHeightBase')};
@@ -66,6 +67,15 @@ const AutosuggestWrapper = styled(Box).attrs({
   .react-autosuggest__suggestion--highlighted {
     background-color: ${th('colorPrimary')};
     color: ${th('colorTextReverse')};
+  }
+`
+
+const StyledClearButton = styled(ClearSearchButton)`
+  fill: ${th('colorTextSecondary')};
+  border: ${th('borderWidth')} ${th('borderStyle')} ${th('colorBorder')};
+  border-left: ${th('colorBackground')};
+  &:focus {
+    border-left: ${th('colorBorder')};
   }
 `
 
@@ -167,7 +177,7 @@ class SearchBox extends React.Component {
             suggestions={suggestions}
           />
         </AutosuggestWrapper>
-        <ClearSearchButton
+        <StyledClearButton
           iconOverrideName="@pubsweet-pending.PeoplePicker.ClearSearch"
           onClick={this.clearSearch}
         />

--- a/client/elife-theme/src/index.js
+++ b/client/elife-theme/src/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/extensions */
-import './global';
+import './global'
 import * as elements from './elements'
 import * as icons from './icons'
 
@@ -88,6 +88,7 @@ export default {
     '@pubsweet-pending.FilesPage.Editor.Subscript': icons.FormatSubscript,
     '@pubsweet-pending.FilesPage.Editor.Superscript': icons.FormatSuperscript,
     '@pubsweet-pending.PeoplePicker.Search': icons.Search,
+    '@pubsweet-pending.PeoplePicker.ClearSearch': icons.Cross,
     '@pubsweet-pending.FileUpload.Upload': icons.Upload,
     '@pubsweet-pending.FileUpload.UploadFailure': icons.UploadFailure,
     '@pubsweet-pending.FileUpload.UploadSuccess': icons.UploadSuccess,


### PR DESCRIPTION
#### What does this PR do?
- create button component using cross icon
- add to searchbox component, in between the input field (react-autosuggest) & the search button
- add CSS styling to make it look like the cross icon sits inside of the input field - make the border of both elements the same, then remove the right-hand border of the input field & the left-hand border of the clear button
- when the button is clicked, the input field is cleared & the person pods are updated

#### Any relevant tickets
fixes #540 

#### How has this been tested?
Pending the addition of the appropriate test files