### PR TITLE
fix: prevent users from accessing or modifying others manuscripts

### DIFF
--- a/config/authsome.js
+++ b/config/authsome.js
@@ -1,3 +1,4 @@
-module.exports = (user, operation, project, version) =>
-  // console.log({ user, operation, project, version })
-  true // TODO
+module.exports = (user, operation, object) => {
+  console.log('Authsome blocked request', { user, operation, object })
+  return false
+}

--- a/server/meca/index.js
+++ b/server/meca/index.js
@@ -10,8 +10,8 @@ const manuscriptGenerator = require('./file-generators/manuscript')
 const transferGenerator = require('./file-generators/transfer')
 const archiveGenerator = require('./file-generators/archive')
 
-async function generate(manuscriptId, clientIp) {
-  const manuscript = await ManuscriptManager.find(manuscriptId)
+async function generate(manuscriptId, userId, clientIp) {
+  const manuscript = await ManuscriptManager.find(manuscriptId, userId)
 
   return archiveGenerator({
     'article.xml': articleGenerator(manuscript),
@@ -34,8 +34,8 @@ async function deliver(file, id) {
   await sftp.end()
 }
 
-async function send(manuscriptId, clientIp) {
-  const archive = await generate(manuscriptId, clientIp)
+async function send(manuscriptId, userId, clientIp) {
+  const archive = await generate(manuscriptId, userId, clientIp)
   await deliver(archive, manuscriptId)
 }
 

--- a/server/meca/index.test.js
+++ b/server/meca/index.test.js
@@ -27,7 +27,7 @@ describe('MECA integration test', () => {
   afterEach(done => server.close(done))
 
   it('generates an archive and uploads it', async () => {
-    await send(manuscriptId)
+    await send(manuscriptId, sampleManuscript.createdBy)
 
     expect(mockFs.readdirSync('/')).toEqual(['test'])
     expect(mockFs.readdirSync('/test')).toEqual([manuscriptId])

--- a/server/xpub/entities/manuscript/data-access.js
+++ b/server/xpub/entities/manuscript/data-access.js
@@ -39,8 +39,10 @@ const joinSelect = buildQuery
   .groupBy('manuscript.id')
 
 const dataAccess = {
-  async selectById(id) {
-    const query = joinSelect.clone().where({ 'manuscript.id': id })
+  async selectById(id, user) {
+    const query = joinSelect
+      .clone()
+      .where({ 'manuscript.id': id, 'manuscript.created_by': user })
     const { rows } = await runQuery(query)
 
     if (!rows.length) {
@@ -57,8 +59,9 @@ const dataAccess = {
     return rows.map(rowToEntity)
   },
 
-  async selectAll() {
-    const { rows } = await runQuery(joinSelect)
+  async selectAll(user) {
+    const query = joinSelect.clone().where({ 'manuscript.created_by': user })
+    const { rows } = await runQuery(query)
     return rows.map(rowToEntity)
   },
 

--- a/server/xpub/entities/manuscript/data-access.test.data.js
+++ b/server/xpub/entities/manuscript/data-access.test.data.js
@@ -15,7 +15,7 @@ const addManuscripts = async count => {
       manu.meta.title = `Title ${number}`
       manu.createdBy = 'me'
       const id = await dataAccess.insert(manu)
-      const result = await dataAccess.selectById(id)
+      const result = await dataAccess.selectById(id, 'me')
       expect(result.id).toBe(id)
       return id
     }),

--- a/server/xpub/entities/manuscript/data-access.test.js
+++ b/server/xpub/entities/manuscript/data-access.test.js
@@ -9,7 +9,6 @@ const initializeDatabase = async () => {
   await createTables(true)
 
   testId = await testData.createSingleManuscript()
-  console.log('Created testId', testId)
 }
 
 describe('ManuscriptAccessLayer', () => {
@@ -18,12 +17,12 @@ describe('ManuscriptAccessLayer', () => {
   })
 
   it('initializes the db', async () => {
-    const result = await dataAccess.selectById(testId)
+    const result = await dataAccess.selectById(testId, 'me')
     expect(result.id).toBe(testId)
   })
 
   async function callSelectManuscript() {
-    await dataAccess.selectById(testId)
+    await dataAccess.selectById(testId, 'me')
   }
 
   it('deletes a manuscript', async () => {
@@ -41,21 +40,21 @@ describe('ManuscriptAccessLayer', () => {
     manu.createdBy = 'me'
 
     const newId = await dataAccess.insert(manu)
-    const retrieved = await dataAccess.selectById(newId)
+    const retrieved = await dataAccess.selectById(newId, 'me')
 
     expect(retrieved.meta.title).toBe('new one')
     expect(retrieved.createdBy).toBe('me')
   })
 
   it('updates a manuscript', async () => {
-    const manu = await dataAccess.selectById(testId)
+    const manu = await dataAccess.selectById(testId, 'me')
     manu.meta.title = 'changed'
 
     let result = await dataAccess.update(manu)
     expect(result.command).toBe('UPDATE')
     expect(result.rowCount).toBe(1)
 
-    result = await dataAccess.selectById(testId)
+    result = await dataAccess.selectById(testId, 'me')
     expect(result.meta.title).toBe('changed')
   })
 
@@ -65,7 +64,7 @@ describe('ManuscriptAccessLayer', () => {
 
     added.push(testId)
     expect(added).toHaveLength(MAX + 1)
-    const returned = await dataAccess.selectAll()
+    const returned = await dataAccess.selectAll('me')
     expect(returned).toHaveLength(MAX + 1)
     expect(returned).toHaveLength(added.length)
 
@@ -84,7 +83,7 @@ describe('ManuscriptAccessLayer', () => {
     // mark as Test
     await Promise.all(
       markedTest.map(async id => {
-        const result = await dataAccess.selectById(id)
+        const result = await dataAccess.selectById(id, 'me')
         expect(result.id).toBe(id)
 
         result.status = 'TEST'

--- a/server/xpub/entities/manuscript/helpers/empty.js
+++ b/server/xpub/entities/manuscript/helpers/empty.js
@@ -24,7 +24,7 @@ const emptyManuscript = {
 <p></p>
 `,
   status: 'INITIAL',
-  createdBy: 'none',
+  createdBy: 'me',
   previouslyDiscussed: null,
   previouslySubmitted: [],
   cosubmission: [],

--- a/server/xpub/entities/manuscript/resolvers.test.js
+++ b/server/xpub/entities/manuscript/resolvers.test.js
@@ -144,7 +144,7 @@ describe('Submission', () => {
         { user: userId },
       )
 
-      const actualManuscript = await Manuscript.find(manuscript.id)
+      const actualManuscript = await Manuscript.find(manuscript.id, userId)
       expect(actualManuscript).toMatchObject(manuscriptInput)
     })
   })
@@ -213,7 +213,7 @@ describe('Submission', () => {
 
       expect(returnedManuscript.status).toBe('QA')
 
-      const storedManuscript = await Manuscript.find(id)
+      const storedManuscript = await Manuscript.find(id, userId)
       expect(storedManuscript.status).toBe('QA')
       expect(storedManuscript.meta.title).toBe('My manuscript')
     })
@@ -237,7 +237,7 @@ describe('Submission', () => {
         { user: userId },
       )
 
-      const storedManuscript = await Manuscript.find(id)
+      const storedManuscript = await Manuscript.find(id, userId)
       const team = storedManuscript.teams.find(
         t => t.role === 'suggestedReviewer',
       )

--- a/server/xpub/entities/manuscript/resolvers.test.js
+++ b/server/xpub/entities/manuscript/resolvers.test.js
@@ -10,34 +10,40 @@ const emptyManuscript = require('./helpers/empty')
 
 const replaySetup = require('../../../../test/helpers/replay-setup')
 
-let initializing = false
-
 const userData = {
   username: 'testuser',
   email: 'test@example.com',
   orcid: '0000-0003-3146-0256',
   oauth: { accessToken: 'f7617529-f46a-40b1-99f4-4181859783ca' },
 }
+const badUserData = {
+  username: 'baduser',
+  email: 'bad@example.com',
+  orcid: '0000-0001-0000-0000',
+  oauth: { accessToken: 'badbadbad-f46a-40b1-99f4-4181859783ca' },
+}
 
 describe('Submission', () => {
   let userId
+  let badUserId
 
   beforeEach(async () => {
-    initializing = true
     replaySetup('success')
     await Promise.all([
       fs.remove(config.get('pubsweet-server.uploads')),
       createTables(true),
     ])
-    const user = await User.save(userData)
+    const [user, badUser] = await Promise.all([
+      User.save(userData),
+      User.save(badUserData),
+    ])
     userId = user.id
+    badUserId = badUser.id
     mailer.clearMails()
-    initializing = false
   })
 
   describe('currentSubmission', () => {
     it('Gets form data', async () => {
-      expect(initializing).toBe(false)
       const expectedManuscript = {
         createdBy: userId,
         meta: {
@@ -51,26 +57,20 @@ describe('Submission', () => {
       expect(manuscript).toMatchObject(expectedManuscript)
     })
 
-    it('Returns empty object when there are no manuscripts in the db', async () => {
-      expect(initializing).toBe(false)
+    it('Returns null when there are no manuscripts in the db', async () => {
       const manuscript = await Query.currentSubmission({}, {}, { user: userId })
       expect(manuscript).toBe(null)
     })
 
-    it('Returns null object when user has no manuscripts in the db (db not empty)', async () => {
-      expect(initializing).toBe(false)
+    it('Returns null when user has no manuscripts in the db (db not empty)', async () => {
       await Manuscript.save({
         createdBy: '9f72f2b8-bb4a-43fa-8b80-c7ac505c8c5f',
-        meta: {
-          title: 'title',
-        },
+        meta: { title: 'title' },
         status: 'INITIAL',
       })
       await Manuscript.save({
         createdBy: 'bcd735c6-9b62-441a-a085-7d1e8a7834c6',
-        meta: {
-          title: 'title 2',
-        },
+        meta: { title: 'title 2' },
         status: 'QA',
       })
 
@@ -79,7 +79,6 @@ describe('Submission', () => {
     })
 
     it('Returns manuscript object when user has one manuscripts in the db (db not empty)', async () => {
-      expect(initializing).toBe(false)
       await Manuscript.save({
         createdBy: '9f72f2b8-bb4a-43fa-8b80-c7ac505c8c5f',
         meta: {
@@ -109,6 +108,12 @@ describe('Submission', () => {
   })
 
   describe('createSubmission', () => {
+    it('fails if no authenticated user', async () => {
+      await expect(Mutation.createSubmission({}, {}, {})).rejects.toThrow(
+        'Not logged in',
+      )
+    })
+
     it('adds new manuscript to the db for current user with status INITIAL', async () => {
       const manuscript = await Mutation.createSubmission(
         {},
@@ -123,6 +128,19 @@ describe('Submission', () => {
   })
 
   describe('updateSubmission', () => {
+    it("fails if manuscript doesn't belong to user", async () => {
+      const blankManuscript = Manuscript.new()
+      const manuscript = await Manuscript.save(blankManuscript)
+      const manuscriptInput = { id: manuscript.id }
+      await expect(
+        Mutation.updateSubmission(
+          {},
+          { data: manuscriptInput },
+          { user: badUserId },
+        ),
+      ).rejects.toThrow('Manuscript not found')
+    })
+
     it('updates the current submission for user with data', async () => {
       const blankManuscript = Manuscript.new()
       blankManuscript.createdBy = userId
@@ -249,21 +267,34 @@ describe('Submission', () => {
       ])
     })
 
+    it("fails if manuscript doesn't belong to user", async () => {
+      const blankManuscript = Manuscript.new()
+      const manuscript = await Manuscript.save(blankManuscript)
+      const manuscriptInput = { id: manuscript.id }
+      await expect(
+        Mutation.finishSubmission(
+          {},
+          { data: manuscriptInput },
+          { user: badUserId },
+        ),
+      ).rejects.toThrow('Manuscript not found')
+    })
+
     // TODO more tests needed here
     it('fails when manuscript has incomplete data', async () => {
       const badManuscript = {
         id,
         title: 'Some Title',
       }
-      await Mutation.finishSubmission(
-        {},
-        {
-          data: badManuscript,
-        },
-        { user: userId },
-      ).catch(err => expect(err).toBeDefined())
-      expect.assertions(1)
+      await expect(
+        Mutation.finishSubmission(
+          {},
+          { data: badManuscript },
+          { user: userId },
+        ),
+      ).rejects.toThrow()
     })
+
     it('fails when manuscript has bad data types', async () => {
       const badManuscript = lodash.cloneDeep(fullManuscript)
       lodash.merge(badManuscript, {
@@ -271,18 +302,31 @@ describe('Submission', () => {
         title: 100,
         manuscriptType: {},
       })
-      await Mutation.finishSubmission(
-        {},
-        {
-          data: badManuscript,
-        },
-        { user: userId },
-      ).catch(err => expect(err).toBeDefined())
-      expect.assertions(1)
+      await expect(
+        Mutation.finishSubmission(
+          {},
+          { data: badManuscript },
+          { user: userId },
+        ),
+      ).rejects.toThrow(
+        '"title" is not allowed. "manuscriptType" is not allowed',
+      )
     })
   })
 
   describe('uploadManuscript', () => {
+    it("fails if manuscript doesn't belong to user", async () => {
+      const blankManuscript = Manuscript.new()
+      const manuscript = await Manuscript.save(blankManuscript)
+      await expect(
+        Mutation.uploadManuscript(
+          {},
+          { id: manuscript.id },
+          { user: badUserId },
+        ),
+      ).rejects.toThrow('Manuscript not found')
+    })
+
     // TODO subscribe to uploadProgress before this or mock
   })
 })

--- a/server/xpub/entities/user/resolvers.test.js
+++ b/server/xpub/entities/user/resolvers.test.js
@@ -1,9 +1,22 @@
+const { createTables } = require('@pubsweet/db-manager')
+const uuid = require('uuid')
 const { Query } = require('./resolvers')
 
 const replaySetup = require('../../../../test/helpers/replay-setup')
 
 describe('User', () => {
-  beforeEach(() => replaySetup('success'))
+  beforeEach(async () => {
+    await createTables(true)
+    replaySetup('success')
+  })
+
+  describe('orcidDetails', () => {
+    it('fails if user not found', async () => {
+      await expect(
+        Query.orcidDetails({}, {}, { user: uuid.v4() }),
+      ).rejects.toThrow('User not found')
+    })
+  })
 
   describe('editors', () => {
     it('returns a list of senior editors', async () => {


### PR DESCRIPTION
#### Background

- Update authsome mode to deny all requests. Authsome is only used by built in PubSweet endpoints and resolvers so this has the effect of disabling these. 
- Update data access functions to only fetch manuscript for current user ID. This means a user can only gain access to a manuscript if they also created it.

Suggestions of alternate approaches welcome.

#### Any relevant tickets

Closes #580 

#### How has this been tested?

Jest integration tests for resolvers and data access tests updated.