### PR TITLE
remove Manuscript preview page from our app

### DIFF
--- a/app/components/pages/Dashboard/Dashboard.js
+++ b/app/components/pages/Dashboard/Dashboard.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Link } from 'react-router-dom'
 import { Box } from 'grid-styled'
 import { Button } from '@pubsweet/ui'
 
 import { FormH2, FormH3 } from '../../ui/atoms/FormHeadings'
 import ButtonLink from '../../ui/atoms/ButtonLink'
+import Paragraph from '../../ui/atoms/Paragraph'
 
 /* Temporary dashboard view pending receipt of designs */
 
@@ -46,9 +46,9 @@ const Dashboard = ({ manuscripts, deleteManuscript }) => (
           {manuscripts.map(manuscript => (
             <tr key={manuscript.id}>
               <Cell data-test-id="title">
-                <Link data-test-id="title" to={`/manuscript/${manuscript.id}`}>
+                <Paragraph data-test-id="title">
                   {manuscript.meta.title || '(Untitled manuscript)'}
-                </Link>
+                </Paragraph>
               </Cell>
               <Cell data-test-id="stage">{manuscript.status}</Cell>
               <Cell>

--- a/app/components/pages/Manuscript/Manuscript.js
+++ b/app/components/pages/Manuscript/Manuscript.js
@@ -1,6 +1,0 @@
-import React from 'react'
-import TextureEditor from '@pubsweet-pending/texture/TextureEditor'
-
-const Manuscript = ({ archiveId }) => <TextureEditor archiveId={archiveId} />
-
-export default Manuscript

--- a/app/components/pages/Manuscript/Manuscript.md
+++ b/app/components/pages/Manuscript/Manuscript.md
@@ -1,6 +1,0 @@
-Display a Texture editor and load the specified DAR archive. This does not
-currently work in the context of the styleguide since there is no DAR server.
-
-```js
-;<Manuscript archiveId={'123'} />
-```

--- a/app/components/pages/Manuscript/index.js
+++ b/app/components/pages/Manuscript/index.js
@@ -1,4 +1,0 @@
-import React from 'react'
-import Manuscript from './Manuscript'
-
-export default ({ match }) => <Manuscript archiveId={match.params.id} />

--- a/app/components/pages/SubmissionWizard/steps/Files/FilesPage.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/FilesPage.js
@@ -64,13 +64,7 @@ const Editor = ({ validationStatus, ...props }) => (
   />
 )
 
-const FilesPage = ({
-  setFieldValue,
-  onDrop,
-  conversion,
-  formError,
-  previewUrl,
-}) => (
+const FilesPage = ({ setFieldValue, onDrop, conversion, formError }) => (
   <React.Fragment>
     <Box mb={3} width={1}>
       <ValidatedField
@@ -87,7 +81,6 @@ const FilesPage = ({
         data-test-id="upload"
         formError={formError}
         onDrop={onDrop}
-        previewUrl={previewUrl}
       />
     </Box>
   </React.Fragment>

--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -56,7 +56,6 @@ const FilesPageContainer = ({
                   setFieldValue(fieldName, data.uploadManuscript.files)
                 })
               }
-              previewUrl={`/manuscript/${values.id}`}
               setFieldValue={setFieldValue}
               {...props}
             />

--- a/app/components/ui/molecules/FileUpload.js
+++ b/app/components/ui/molecules/FileUpload.js
@@ -68,10 +68,6 @@ const StyledParagraph = styled(Paragraph)`
   color: ${th('colorTextSecondary')};
 `
 
-const Instruction = styled.div`
-  margin-top: ${th('space.3')};
-`
-
 const CentredFlex = styled(Flex)`
   text-align: center;
 `
@@ -81,9 +77,9 @@ const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
     return (
       <React.Fragment>
         <StyledUploadIcon />
-        <Instruction data-test-id="dropzoneMessage">
+        <Paragraph data-test-id="dropzoneMessage">
           Manuscript is uploading
-        </Instruction>
+        </Paragraph>
       </React.Fragment>
     )
   }
@@ -117,22 +113,20 @@ const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
     return (
       <React.Fragment>
         <StyledUploadSuccessIcon />
-        <Instruction data-test-id="dropzoneMessage">
-          Success!
-          <br />
-          <br />
+        <Paragraph data-test-id="dropzoneMessage">Success!</Paragraph>
+        <Paragraph>
           <Action onClick={dropzoneOpen}>Replace</Action> your manuscript.
-        </Instruction>
+        </Paragraph>
       </React.Fragment>
     )
   }
   return (
     <React.Fragment>
       <StyledUploadIcon />
-      <Instruction data-test-id="dropzoneMessage">
+      <Paragraph data-test-id="dropzoneMessage">
         <Action onClick={dropzoneOpen}>Upload</Action> your manuscript or drag
         it here.
-      </Instruction>
+      </Paragraph>
       <StyledParagraph>
         Please note that files larger than 10MB may result in review delays.
       </StyledParagraph>

--- a/app/components/ui/molecules/FileUpload.js
+++ b/app/components/ui/molecules/FileUpload.js
@@ -76,12 +76,7 @@ const CentredFlex = styled(Flex)`
   text-align: center;
 `
 
-const DropzoneContent = ({
-  conversion,
-  formError,
-  dropzoneOpen,
-  previewUrl,
-}) => {
+const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
   if (conversion.converting) {
     return (
       <React.Fragment>
@@ -123,11 +118,10 @@ const DropzoneContent = ({
       <React.Fragment>
         <StyledUploadSuccessIcon />
         <Instruction data-test-id="dropzoneMessage">
-          Success!{' '}
-          <Action data-test-id="preview" to={previewUrl}>
-            Preview
-          </Action>{' '}
-          or <Action onClick={dropzoneOpen}>replace</Action> your manuscript.
+          Success!
+          <br />
+          <br />
+          <Action onClick={dropzoneOpen}>Replace</Action> your manuscript.
         </Instruction>
       </React.Fragment>
     )
@@ -146,13 +140,7 @@ const DropzoneContent = ({
   )
 }
 
-const FileUpload = ({
-  onDrop,
-  conversion,
-  formError,
-  previewUrl,
-  ...props
-}) => {
+const FileUpload = ({ onDrop, conversion, formError, ...props }) => {
   let dropzoneRef
   return (
     <StyledDropzone
@@ -171,7 +159,6 @@ const FileUpload = ({
             conversion={conversion}
             dropzoneOpen={() => dropzoneRef.open()}
             formError={formError}
-            previewUrl={previewUrl}
           />
         </Box>
       </CentredFlex>

--- a/app/components/ui/molecules/FileUpload.test.js
+++ b/app/components/ui/molecules/FileUpload.test.js
@@ -21,12 +21,12 @@ function makeCheerioWrapper(props) {
 const manuscriptUpload = 'Upload your manuscript or drag it here.'
 const noManuscriptError = 'Please upload your manuscript.'
 const badManuscriptError = 'Try to upload your manuscript again.'
-const manuscriptUploadSuccess = 'Success!Replace your manuscript.'
+const manuscriptUploadSuccess = 'Success!'
 const manuscriptUploading = 'Manuscript is uploading'
 
 it('displays upload manuscript if nothing is set', () => {
   const dropzoneContentWrapper = makeCheerioWrapper()
-  expect(dropzoneContentWrapper.text()).toBe(manuscriptUpload)
+  expect(dropzoneContentWrapper.text()).toContain(manuscriptUpload)
 })
 
 it('displays error if formError is set', () => {

--- a/app/components/ui/molecules/FileUpload.test.js
+++ b/app/components/ui/molecules/FileUpload.test.js
@@ -21,7 +21,7 @@ function makeCheerioWrapper(props) {
 const manuscriptUpload = 'Upload your manuscript or drag it here.'
 const noManuscriptError = 'Please upload your manuscript.'
 const badManuscriptError = 'Try to upload your manuscript again.'
-const manuscriptUploadSuccess = 'Success! Preview or replace your manuscript.'
+const manuscriptUploadSuccess = 'Success!Replace your manuscript.'
 const manuscriptUploading = 'Manuscript is uploading'
 
 it('displays upload manuscript if nothing is set', () => {

--- a/app/routes.js
+++ b/app/routes.js
@@ -4,7 +4,6 @@ import { Route, Switch } from 'react-router-dom'
 import { AuthenticatedComponent, Layout } from './components/global'
 import LoginPage from './components/pages/Login'
 import SubmissionWizard from './components/pages/SubmissionWizard'
-import ManuscriptPage from './components/pages/Manuscript'
 import DashboardPage from './components/pages/Dashboard'
 
 const Routes = () => (
@@ -14,7 +13,6 @@ const Routes = () => (
       <Layout>
         <Switch>
           <Route component={SubmissionWizard} path="/submit" />
-          <Route component={ManuscriptPage} path="/manuscript/:id" />
           <Route component={DashboardPage} />
         </Switch>
       </Layout>

--- a/test/pageObjects/files.js
+++ b/test/pageObjects/files.js
@@ -5,7 +5,6 @@ const files = {
   url: `${config.get('pubsweet-server.baseUrl')}/submit/files`,
   editor: Selector('[name="coverLetter"] div[contenteditable=true]'),
   manuscriptUpload: Selector('[data-test-id=upload]>input'),
-  preview: Selector('[data-test-id=preview]'),
 }
 
 export default files

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -22,7 +22,6 @@ const manuscript = {
 }
 
 const getPageUrl = ClientFunction(() => window.location.href)
-const goBack = ClientFunction(() => window.history.back())
 
 test('Happy path', async t => {
   const { mockFs, server } = await startSshServer(config.get('meca.sftp.port'))
@@ -64,13 +63,7 @@ test('Happy path', async t => {
     .setFilesToUpload(files.manuscriptUpload, manuscript.file)
     // wait for editor onChange
     .wait(1000)
-    // manuscript preview page
-    .click(files.preview)
-    .expect(Selector('.sc-title-group').textContent)
-    .eql(manuscript.title)
-  // only way to get back to wizard is with browser back button at the moment
-  await goBack()
-  await t.click(wizardStep.next)
+    .click(wizardStep.next)
 
   // adding manuscript metadata
   await t


### PR DESCRIPTION
Planning to do a little refactoring so I'm not using `<br />` before taking this off WIP status

#### What does this PR do?
- Remove Manuscript page
- Remove preview link from FileUpload component
- Remove the clickable link from the dashboard
- Minor refactor to replace `Instruction` with `Paragraph` component in `FileUpload`

Note: design for "success" now looks like this
![image](https://user-images.githubusercontent.com/15656538/45440923-8adee780-b6b5-11e8-85ea-e413f1644646.png)

#### Any relevant tickets
fixes #560 

#### How has this been tested?
Removed tests that refer to this page & use the link
