### PR TITLE
add message about large files to FileUpload component

### DIFF
--- a/app/components/ui/molecules/FileUpload.js
+++ b/app/components/ui/molecules/FileUpload.js
@@ -8,6 +8,7 @@ import { th } from '@pubsweet/ui-toolkit'
 import { get } from 'lodash'
 
 import Icon from '../atoms/Icon'
+import Paragraph from '../atoms/Paragraph'
 
 const UploadIcon = props => (
   <Icon
@@ -61,6 +62,10 @@ const StyledDropzone = styled(({ hasError, saveInnerRef, ...rest }) => (
     hasError ? th('colorError') : th('colorBorder')};
   border-width: 2px;
   padding: ${th('space.4')};
+`
+
+const StyledParagraph = styled(Paragraph)`
+  color: ${th('colorTextSecondary')};
 `
 
 const Instruction = styled.div`
@@ -134,6 +139,9 @@ const DropzoneContent = ({
         <Action onClick={dropzoneOpen}>Upload</Action> your manuscript or drag
         it here.
       </Instruction>
+      <StyledParagraph>
+        Please note that files larger than 10MB may result in review delays.
+      </StyledParagraph>
     </React.Fragment>
   )
 }


### PR DESCRIPTION
#### What does this PR do?
Add new line about files larger than 10MB to follow new designs:
![screen shot 2018-09-06 at 12 54 49](https://user-images.githubusercontent.com/17023702/45155803-13e8b100-b1d4-11e8-8e8a-796c8783d1b4.png)

#### Any relevant tickets
#560 

#### How has this been tested?
Visually