### PR TITLE
fix: pass user in manuscript delete mutation

### DIFF
--- a/server/xpub/entities/manuscript/index.js
+++ b/server/xpub/entities/manuscript/index.js
@@ -24,8 +24,8 @@ const Manuscript = {
   all: dataAccess.selectAll,
   findByStatus: dataAccess.selectByStatus,
 
-  delete: async id => {
-    const manuscript = await dataAccess.selectById(id)
+  delete: async (id, user) => {
+    const manuscript = await dataAccess.selectById(id, user)
     await Promise.all(manuscript.files.map(file => FileManager.delete(file.id)))
     await Promise.all(manuscript.teams.map(team => TeamManager.delete(team.id)))
     await dataAccess.delete(id)

--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -63,9 +63,7 @@ const resolvers = {
 
     // TODO restrict this in production
     async deleteManuscript(_, { id }, { user }) {
-      await Manuscript.find(id, user)
-
-      await Manuscript.delete(id)
+      await Manuscript.delete(id, user)
       return id
     },
 

--- a/server/xpub/entities/manuscript/resolvers.test.js
+++ b/server/xpub/entities/manuscript/resolvers.test.js
@@ -352,7 +352,9 @@ describe('Submission', () => {
   describe('uploadManuscript', () => {
     it("fails if manuscript doesn't belong to user", async () => {
       const blankManuscript = Manuscript.new()
+      blankManuscript.createdBy = userId
       const manuscript = await Manuscript.save(blankManuscript)
+
       await expect(
         Mutation.uploadManuscript(
           {},
@@ -363,5 +365,35 @@ describe('Submission', () => {
     })
 
     // TODO subscribe to uploadProgress before this or mock
+  })
+
+  describe('deleteManuscript', () => {
+    it("fails if manuscript doesn't belong to user", async () => {
+      const blankManuscript = Manuscript.new()
+      blankManuscript.createdBy = userId
+      const manuscript = await Manuscript.save(blankManuscript)
+
+      await expect(
+        Mutation.deleteManuscript(
+          {},
+          { id: manuscript.id },
+          { user: badUserId },
+        ),
+      ).rejects.toThrow('Manuscript not found')
+    })
+
+    it('removes manuscript from database', async () => {
+      const blankManuscript = Manuscript.new()
+      blankManuscript.createdBy = userId
+      const manuscript = await Manuscript.save(blankManuscript)
+      await Mutation.deleteManuscript(
+        {},
+        { id: manuscript.id },
+        { user: userId },
+      )
+
+      const manuscripts = await Manuscript.all(userId)
+      expect(manuscripts).toEqual([])
+    })
   })
 })


### PR DESCRIPTION
#### Background

Fixes #591 

#### How has this been tested?

Dashboard functionality is deliberately not covered by tests because it's throw away code. But obviously that was a silly decision.
