### PR TITLE
fix: persist opposed reviewers reason

### DIFF
--- a/app/components/pages/SubmissionWizard/operations.js
+++ b/app/components/pages/SubmissionWizard/operations.js
@@ -41,9 +41,8 @@ const manuscriptFragment = gql`
     suggestedReviewers: assignees(role: "suggestedReviewer") {
       ...ReviewerDetails
     }
-    opposedReviewers {
-      name
-      email
+    opposedReviewers: assignees(role: "opposedReviewer") {
+      ...ReviewerDetails
     }
     opposedReviewersReason
     suggestionsConflict

--- a/server/xpub/entities/manuscript/data-access.js
+++ b/server/xpub/entities/manuscript/data-access.js
@@ -18,7 +18,9 @@ const columnNames = [
   'cover_letter',
   'opposed_senior_editors_reason',
   'opposed_reviewing_editors_reason',
-  'opposed_reviewers',
+  'opposed_reviewers_reason',
+  'submitter_signature',
+  'disclosure_consent',
   'qc_issues',
   'created_by',
 ]

--- a/server/xpub/entities/manuscript/helpers/empty.js
+++ b/server/xpub/entities/manuscript/helpers/empty.js
@@ -9,7 +9,6 @@ const emptyManuscript = {
   },
   opposedSeniorEditorsReason: '',
   opposedReviewingEditorsReason: '',
-  opposedReviewers: [],
   opposedReviewersReason: '',
   suggestionsConflict: false,
   files: [],

--- a/server/xpub/entities/manuscript/index.js
+++ b/server/xpub/entities/manuscript/index.js
@@ -73,7 +73,6 @@ const Manuscript = {
         'previouslyDiscussed',
         'previouslySubmitted',
         'cosubmission',
-        'opposedReviewers',
         'opposedReviewersReason',
         'suggestionsConflict',
         'submitterSignature',

--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -234,6 +234,7 @@ ${err}`,
           return elifeApi.peopleById(assigneeIds)
         }
         case 'suggestedReviewer':
+        case 'opposedReviewer':
           return team.teamMembers.map(member => member.meta)
 
         default:

--- a/server/xpub/entities/manuscript/resolvers.test.data.js
+++ b/server/xpub/entities/manuscript/resolvers.test.data.js
@@ -1,0 +1,77 @@
+exports.userData = {
+  username: 'testuser',
+  email: 'test@example.com',
+  orcid: '0000-0003-3146-0256',
+  oauth: { accessToken: 'f7617529-f46a-40b1-99f4-4181859783ca' },
+}
+
+exports.badUserData = {
+  username: 'baduser',
+  email: 'bad@example.com',
+  orcid: '0000-0001-0000-0000',
+  oauth: { accessToken: 'badbadbad-f46a-40b1-99f4-4181859783ca' },
+}
+
+exports.manuscriptInput = {
+  author: {
+    firstName: 'Firstname',
+    lastName: 'Lastname',
+    email: 'mymail@mail.com',
+    aff: 'Institution Inc',
+  },
+  cosubmission: ['More interesting observations on chickens'],
+  coverLetter: 'my cover letter',
+  disclosureConsent: true,
+  meta: {
+    articleType: 'research-article',
+    subjects: ['cancer-biology'],
+    title: 'My manuscript',
+  },
+  opposedReviewers: [{ name: 'Reviewer 4', email: 'reviewer4@mail.com' }],
+  opposedReviewersReason: 'Reviewer 4 is my wife',
+  opposedReviewingEditors: ['kl12'],
+  opposedReviewingEditorsReason: 'I do not like them, Sam I am',
+  opposedSeniorEditors: ['ij90'],
+  opposedSeniorEditorsReason: 'I do not like green eggs and ham',
+  previouslyDiscussed: 'Discussed this with bob',
+  previouslySubmitted: ['An important finding about ants'],
+  submitterSignature: 'Sneha Berry',
+  suggestedReviewers: [
+    { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
+    { name: 'Reviewer 2', email: 'reviewer2@mail.com' },
+    { name: 'Reviewer 3', email: 'reviewer3@mail.com' },
+  ],
+  suggestedReviewingEditors: ['ef56', 'gh78'],
+  suggestedSeniorEditors: ['ab12', 'cd34'],
+  suggestionsConflict: false,
+}
+
+exports.expectedManuscript = {
+  cosubmission: ['More interesting observations on chickens'],
+  coverLetter: 'my cover letter',
+  decision: null,
+  disclosureConsent: true,
+  formState: null,
+  journalId: null,
+  meta: {
+    abstract: null,
+    articleIds: null,
+    articleType: 'research-article',
+    notes: null,
+    publicationDates: null,
+    subjects: ['cancer-biology'],
+    title: 'My manuscript',
+  },
+  opposedReviewersReason: 'Reviewer 4 is my wife',
+  opposedReviewingEditorsReason: 'I do not like them, Sam I am',
+  opposedSeniorEditorsReason: 'I do not like green eggs and ham',
+  previouslyDiscussed: 'Discussed this with bob',
+  previouslySubmitted: ['An important finding about ants'],
+  previousVersion: null,
+  relatedManuscripts: null,
+  qcIssues: null,
+  status: 'INITIAL',
+  submitterSignature: 'Sneha Berry',
+  suggestionsConflict: false,
+  updated: null,
+}

--- a/server/xpub/entities/manuscript/typeDefs.graphqls
+++ b/server/xpub/entities/manuscript/typeDefs.graphqls
@@ -14,7 +14,6 @@ extend type Mutation {
 
 extend type Manuscript {
   # todo: these should be handled through teams
-  opposedReviewers: [OpposedReviewer]
   author: Alias
 
   # todo: these should be handled through notes

--- a/server/xpub/schema/migrations/1536842027-opposed-reviewers.sql
+++ b/server/xpub/schema/migrations/1536842027-opposed-reviewers.sql
@@ -1,0 +1,3 @@
+ALTER TABLE manuscript
+  ADD COLUMN opposed_reviewers_reason TEXT,
+  DROP COLUMN opposed_reviewers;


### PR DESCRIPTION
#### Background

This fixes the issue I was seeing on iOS Safari preventing submission of the form. 

- Add opposed_reviewers_reason to SQL schema.
- Add test to ensure all manuscript properties are persisted.
- Remove opposedReviewers property now that these are handled through teams.
