### PR TITLE
tweak searchbox button styling

### DIFF
--- a/app/components/ui/molecules/SearchBox.js
+++ b/app/components/ui/molecules/SearchBox.js
@@ -19,15 +19,18 @@ const SearchIcon = props => (
 const StyledSearchButton = styled(Button).attrs({
   primary: true,
 })`
+  border-radius: 0 ${th('borderRadius')} ${th('borderRadius')} 0;
   fill: ${th('colorTextReverse')};
   line-height: 0;
   min-width: 0;
+  width: ${th('space.5')};
   padding: ${th('space.1')};
   margin: 0;
 `
 
 const StyledClearButton = styled(ClearSearchButton)`
   fill: ${th('colorTextSecondary')};
+  width: ${th('space.5')};
   border: ${th('borderWidth')} ${th('borderStyle')} ${th('colorBorder')};
   border-left: ${th('colorBackground')};
   &:focus {


### PR DESCRIPTION
#### What does this PR do?
- make top-left & bottom-left corners of search box square, but top-right and bottom-right = border-radius variable
- fix width of search & clear buttons to 48px

#### Any relevant tickets
fixes #614 

#### How has this been tested?
Visually