### PR TITLE
fix: remove double submit and race condition

### DIFF
--- a/test/pageObjects/editors.js
+++ b/test/pageObjects/editors.js
@@ -26,6 +26,7 @@ const editors = {
   sixthReviewerName: Selector('[name="suggestedReviewers.5.name"]'),
   sixthReviewerEmail: Selector('[name="suggestedReviewers.5.email"]'),
   conflictOfInterest: Selector('[name=suggestionsConflict]').parent(),
+  validationErrors: Selector('[data-test-id^="error-"]'),
 }
 
 export default editors


### PR DESCRIPTION
- One test was clicking *Next* twice causing validation errors to be displayed prematurely.
- Added regression test to check that validation errors are not displayed.
- Asserting on the result of the SFTP upload occasionally failed due to the time it took to upload, now it automatically retries.
