### PR TITLE
feat: store manuscripts in S3

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -39,17 +39,22 @@ module.exports = {
     from: 'dev@example.com',
     path: `${__dirname}/mailer`,
   },
+  aws: {
+    credentials: {
+      region: '',
+      accessKeyId: '',
+      secretAccessKey: '',
+    },
+    s3: {
+      s3ForcePathStyle: true,
+      params: {
+        Bucket: 'demo-elife-xpub',
+      },
+    },
+  },
   meca: {
     s3: {
-      params: {
-        Bucket: '',
-      },
-      connectionOptions: {
-        s3ForcePathStyle: true,
-        region: '',
-        accessKeyId: '',
-        secretAccessKey: '',
-      },
+      remotePath: 'meca-archive/',
       disableUpload: false,
     },
     sftp: {

--- a/config/test-e2e.js
+++ b/config/test-e2e.js
@@ -1,7 +1,0 @@
-module.exports = {
-  meca: {
-    s3: {
-      disableUpload: true,
-    },
-  },
-}

--- a/config/test.js
+++ b/config/test.js
@@ -28,7 +28,10 @@ module.exports = {
       params: {
         Bucket: 'test',
       },
-      endpoint: new AWS.Endpoint('http://localhost:4578'),
+      endpoint: new AWS.Endpoint(
+        // randomise port to avoid conflicts in parallel test runs
+        `http://localhost:${Math.floor(Math.random() * 50000) + 15000}`,
+      ),
     },
   },
   meca: {

--- a/config/test.js
+++ b/config/test.js
@@ -18,20 +18,20 @@ module.exports = {
     url: '/mock-token-exchange/ewwboc7m',
     enableMock: true,
   },
-  meca: {
+  aws: {
+    credentials: {
+      region: 'eu-west-1',
+      accessKeyId: 'test',
+      secretAccessKey: 'test',
+    },
     s3: {
       params: {
         Bucket: 'test',
       },
-      connectionOptions: {
-        endpoint: new AWS.Endpoint('http://localhost:4578'),
-        s3ForcePathStyle: true,
-        region: 'eu-west-1',
-        accessKeyId: 'test',
-        secretAccessKey: 'test',
-      },
-      disableUpload: false,
+      endpoint: new AWS.Endpoint('http://localhost:4578'),
     },
+  },
+  meca: {
     sftp: {
       connectionOptions: {
         host: 'localhost',
@@ -40,7 +40,6 @@ module.exports = {
         password: 'tset',
       },
       remotePath: '/test',
-      disableUpload: false,
     },
     notificationEmail: 'test@example.com',
   },

--- a/server/meca/file-generators/manuscript.js
+++ b/server/meca/file-generators/manuscript.js
@@ -1,9 +1,0 @@
-const FileManager = require('@elifesciences/xpub-server/entities/file')
-const ManuscriptManager = require('@elifesciences/xpub-server/entities/manuscript')
-
-function generateManuscript(manuscript) {
-  const fileInfo = ManuscriptManager.getSource(manuscript)
-  return FileManager.getContent(fileInfo)
-}
-
-module.exports = generateManuscript

--- a/server/meca/index.js
+++ b/server/meca/index.js
@@ -1,33 +1,29 @@
 const logger = require('@pubsweet/logger')
-const ManuscriptManager = require('@elifesciences/xpub-server/entities/manuscript')
 
 const articleGenerator = require('./file-generators/article')
 const coverLetterGenerator = require('./file-generators/coverLetter')
 const disclosureGenerator = require('./file-generators/disclosure')
 const manifestGenerator = require('./file-generators/manifest')
-const manuscriptGenerator = require('./file-generators/manuscript')
 const transferGenerator = require('./file-generators/transfer')
 const archiveGenerator = require('./file-generators/archive')
 
 const upload = require('./upload')
 
-async function generate(manuscriptId, userId, clientIp) {
-  const manuscript = await ManuscriptManager.find(manuscriptId, userId)
-
+async function generate(manuscript, content, clientIp) {
   return archiveGenerator({
     'article.xml': articleGenerator(manuscript),
     'cover_letter.html': coverLetterGenerator(manuscript),
     'disclosure.pdf': disclosureGenerator(manuscript, clientIp),
     'manifest.xml': manifestGenerator(),
-    'manuscript.pdf': manuscriptGenerator(manuscript),
+    'manuscript.pdf': content,
     'transfer.xml': transferGenerator(''), // auth code not currently used
   })
 }
 
-async function mecaExport(manuscriptId, userId, clientIp) {
-  logger.info(`Starting meca export for manuscript ${manuscriptId}`)
-  const archive = await generate(manuscriptId, userId, clientIp)
-  await upload(archive, manuscriptId)
+async function mecaExport(manuscript, content, clientIp) {
+  logger.info(`Starting meca export for manuscript ${manuscript}`)
+  const archive = await generate(manuscript, content, clientIp)
+  await upload(archive, manuscript.id)
 }
 
 module.exports = mecaExport

--- a/server/meca/index.test.data.json
+++ b/server/meca/index.test.data.json
@@ -1,4 +1,5 @@
 {
+  "id": "6d8cd1ce-15b6-46c1-b901-bc91598c8f2f",
   "journalId": null,
   "updated": null,
   "createdBy": "6d8cd1ce-15b6-46c1-b901-bc91598c8f2d",

--- a/server/meca/index.test.js
+++ b/server/meca/index.test.js
@@ -41,10 +41,11 @@ describe('MECA integration test', () => {
     await mecaExport(sampleManuscript, '')
 
     expect(sftp.mockFs.readdirSync('/')).toEqual(['test'])
-    expect(sftp.mockFs.readdirSync('/test')).toEqual([sampleManuscript.id])
+    const finalName = `${sampleManuscript.id}.zip`
+    expect(sftp.mockFs.readdirSync('/test')).toEqual([finalName])
 
     const zip = await JsZip.loadAsync(
-      sftp.mockFs.readFileSync(`/test/${sampleManuscript.id}`),
+      sftp.mockFs.readFileSync(`/test/${finalName}`),
     )
 
     expect(getFilenames(zip)).toEqual([

--- a/server/meca/index.test.js
+++ b/server/meca/index.test.js
@@ -67,7 +67,7 @@ describe('MECA integration test', () => {
       expect(getFileSizes(zip)).toEqual({
         'article.xml': 6109,
         'cover_letter.html': 743,
-        'disclosure.pdf': 3458,
+        'disclosure.pdf': expect.any(Number),
         'manifest.xml': 919,
         'manuscript.pdf': 14,
         'transfer.xml': 1958,

--- a/server/meca/index.test.js
+++ b/server/meca/index.test.js
@@ -16,12 +16,13 @@ const getFilenames = zip =>
     .sort()
 
 const getFileSizes = zip =>
-  zip
-    .file(/./)
-    .reduce((accum, file) => {
-      accum[file.name] = file['_data'].uncompressedSize
-      return accum
-    }, {})
+  zip.file(/./).reduce(
+    (accum, file) => ({
+      ...accum,
+      [file.name]: file._data.uncompressedSize,
+    }),
+    {},
+  )
 
 describe('MECA integration test', () => {
   let sftp, s3Server, s3
@@ -50,7 +51,7 @@ describe('MECA integration test', () => {
 
     it('should contain the correct files', async () => {
       global.Date = class extends RealDate {
-        constructor () {
+        constructor() {
           super()
           return new RealDate(1538059378578)
         }
@@ -64,12 +65,12 @@ describe('MECA integration test', () => {
       )
 
       expect(getFileSizes(zip)).toEqual({
-       "article.xml": 6109,
-       "cover_letter.html": 743,
-       "disclosure.pdf": 3458,
-       "manifest.xml": 919,
-       "manuscript.pdf": 14,
-       "transfer.xml": 1958,
+        'article.xml': 6109,
+        'cover_letter.html': 743,
+        'disclosure.pdf': 3458,
+        'manifest.xml': 919,
+        'manuscript.pdf': 14,
+        'transfer.xml': 1958,
       })
 
       expect(getFilenames(zip)).toEqual([
@@ -81,7 +82,6 @@ describe('MECA integration test', () => {
         'transfer.xml',
       ])
     })
-
   })
 
   it('uploads archive to SFTP', async () => {

--- a/server/meca/test/mock-sftp-server.js
+++ b/server/meca/test/mock-sftp-server.js
@@ -16,6 +16,11 @@ function startServer(port) {
     }
 
     auth.accept(session => {
+      session.on('rename', (oldPath, newPath, context) => {
+        mockFs.writeFileSync(newPath, mockFs.readFileSync(oldPath))
+        mockFs.unlinkSync(oldPath)
+        context.ok()
+      })
       session.on('writefile', (path, readstream) => {
         const stream = mockFs.createWriteStream(path)
         readstream.pipe(stream)

--- a/server/meca/upload/client/s3.js
+++ b/server/meca/upload/client/s3.js
@@ -2,7 +2,8 @@ const AWS = require('aws-sdk')
 const config = require('config')
 
 const S3 = new AWS.S3({
-  ...config.get('meca.s3.connectionOptions'),
+  ...config.get('aws.credentials'),
+  ...config.get('aws.s3'),
   apiVersion: '2006-03-01',
 })
 

--- a/server/meca/upload/index.js
+++ b/server/meca/upload/index.js
@@ -9,21 +9,14 @@ async function uploadToS3(file, id) {
     return
   }
   const params = {
-    ...config.get('meca.s3.params'),
     Body: file,
-    Key: id,
+    Key: `${config.get('meca.s3.remotePath')}/${id}.zip`,
     ACL: 'private',
     ContentType: 'application/zip',
   }
 
-  await new Promise((resolve, reject) => {
-    logger.info(`Uploading to S3`)
-    s3.putObject(params, (err, data) => {
-      logger.info(`S3 data: ${data}`)
-      if (err) reject(err)
-      resolve()
-    })
-  })
+  logger.info(`Uploading to S3`)
+  await s3.putObject(params).promise()
 }
 
 async function uploadToSFTP(file, id) {

--- a/server/meca/upload/index.js
+++ b/server/meca/upload/index.js
@@ -28,7 +28,10 @@ async function uploadToSFTP(file, id) {
   const sftp = await SFTP()
   const remotePath = config.get('meca.sftp.remotePath')
   await sftp.mkdir(remotePath, true)
-  await sftp.put(file, `${remotePath}/${id}`)
+  const transferName = `${remotePath}/${id}.transfer`
+  const finalName = `${remotePath}/${id}.zip`
+  await sftp.put(file, transferName)
+  await sftp.rename(transferName, finalName)
   await sftp.end()
 }
 

--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -99,7 +99,8 @@ const resolvers = {
       manuscript.status = ManuscriptManager.statuses.MECA_EXPORT_PENDING
       await ManuscriptManager.save(manuscript)
 
-      const content = 'dummy content'
+      const sourceFile = ManuscriptManager.getSource(manuscript)
+      const content = await FileManager.getContent(sourceFile)
       mecaExport(manuscript, content, ip)
         .then(() => {
           logger.info(`Manuscript ${manuscript.id} successfully exported`)

--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -8,9 +8,6 @@ const logger = require('@pubsweet/logger')
 const request = require('request-promise-native')
 const { promisify } = require('util')
 const xml2js = require('xml2js')
-const fs = require('fs-extra')
-const path = require('path')
-const crypto = require('crypto')
 const Joi = require('joi')
 const { Transform } = require('stream')
 const mecaExport = require('@elifesciences/xpub-meca-export')
@@ -18,29 +15,19 @@ const mecaExport = require('@elifesciences/xpub-meca-export')
 const { ON_UPLOAD_PROGRESS } = asyncIterators
 
 const parseString = promisify(xml2js.parseString)
-const randomBytes = promisify(crypto.randomBytes)
-const uploadsPath = config.get('pubsweet-server').uploads
 
-const Manuscript = require('.')
+const ManuscriptManager = require('.')
+const FileManager = require('../file')
 const UserManager = require('../user')
 const manuscriptInputSchema = require('./helpers/manuscriptInputValidationSchema')
 const elifeApi = require('../user/helpers/elife-api')
-
-const darManifest = `<dar>
-  <documents>
-    <document id="manuscript" type="article" path="manuscript.xml" />
-  </documents>
-  <assets>
-  </assets>
-</dar>
-`
 
 const resolvers = {
   Query: {
     async currentSubmission(_, vars, { user }) {
       const userUuid = await UserManager.getUuidForProfile(user)
-      const manuscripts = await Manuscript.findByStatus(
-        Manuscript.statuses.INITIAL,
+      const manuscripts = await ManuscriptManager.findByStatus(
+        ManuscriptManager.statuses.INITIAL,
         userUuid,
       )
       if (!manuscripts.length) {
@@ -51,11 +38,11 @@ const resolvers = {
     },
     async manuscript(_, { id }, { user }) {
       const userUuid = await UserManager.getUuidForProfile(user)
-      return Manuscript.find(id, userUuid)
+      return ManuscriptManager.find(id, userUuid)
     },
     async manuscripts(_, vars, { user }) {
       const userUuid = await UserManager.getUuidForProfile(user)
-      return Manuscript.all(userUuid)
+      return ManuscriptManager.all(userUuid)
     },
   },
 
@@ -65,24 +52,24 @@ const resolvers = {
         throw new Error('Not logged in')
       }
       const userUuid = await UserManager.getUuidForProfile(user)
-      const manuscript = Manuscript.new()
+      const manuscript = ManuscriptManager.new()
       manuscript.createdBy = userUuid
-      return Manuscript.save(manuscript)
+      return ManuscriptManager.save(manuscript)
     },
 
     // TODO restrict this in production
     async deleteManuscript(_, { id }, { user }) {
       const userUuid = await UserManager.getUuidForProfile(user)
-      await Manuscript.delete(id, userUuid)
+      await ManuscriptManager.delete(id, userUuid)
       return id
     },
 
     async updateSubmission(_, { data }, { user }) {
       const userUuid = await UserManager.getUuidForProfile(user)
-      const originalManuscript = await Manuscript.find(data.id, userUuid)
-      const manuscript = Manuscript.applyInput(originalManuscript, data)
+      const originalManuscript = await ManuscriptManager.find(data.id, userUuid)
+      const manuscript = ManuscriptManager.applyInput(originalManuscript, data)
 
-      await Manuscript.save(manuscript)
+      await ManuscriptManager.save(manuscript)
       logger.debug(`Updated Submission ${data.id} by user ${userUuid}`)
 
       return manuscript
@@ -90,9 +77,11 @@ const resolvers = {
 
     async finishSubmission(_, { data }, { user, ip }) {
       const userUuid = await UserManager.getUuidForProfile(user)
-      const originalManuscript = await Manuscript.find(data.id, userUuid)
+      const originalManuscript = await ManuscriptManager.find(data.id, userUuid)
 
-      const manuscriptInput = Manuscript.removeOptionalBlankReviewers(data)
+      const manuscriptInput = ManuscriptManager.removeOptionalBlankReviewers(
+        data,
+      )
       const { error: errorManuscript } = Joi.validate(
         manuscriptInput,
         manuscriptInputSchema,
@@ -102,27 +91,28 @@ const resolvers = {
         throw new Error(errorManuscript)
       }
 
-      const manuscript = Manuscript.applyInput(
+      const manuscript = ManuscriptManager.applyInput(
         originalManuscript,
         manuscriptInput,
       )
 
-      manuscript.status = Manuscript.statuses.MECA_EXPORT_PENDING
-      await Manuscript.save(manuscript)
+      manuscript.status = ManuscriptManager.statuses.MECA_EXPORT_PENDING
+      await ManuscriptManager.save(manuscript)
 
-      mecaExport(manuscript.id, userUuid, ip)
+      const content = 'dummy content'
+      mecaExport(manuscript, content, ip)
         .then(() => {
           logger.info(`Manuscript ${manuscript.id} successfully exported`)
-          return Manuscript.save({
+          return ManuscriptManager.save({
             id: manuscript.id,
-            status: Manuscript.statuses.MECA_EXPORT_SUCCEEDED,
+            status: ManuscriptManager.statuses.MECA_EXPORT_SUCCEEDED,
           })
         })
         .catch(async err => {
           logger.error('MECA export failed', err)
-          await Manuscript.save({
+          await ManuscriptManager.save({
             id: manuscript.id,
-            status: Manuscript.statuses.MECA_EXPORT_FAILED,
+            status: ManuscriptManager.statuses.MECA_EXPORT_FAILED,
           })
           return mailer.send({
             to: config.get('meca.notificationEmail'),
@@ -160,25 +150,16 @@ ${err}`,
       }
 
       const userUuid = await UserManager.getUuidForProfile(user)
-      const manuscript = await Manuscript.find(id, userUuid)
+      const manuscript = await ManuscriptManager.find(id, userUuid)
 
       const { stream, filename, mimetype } = await file
-
-      const manuscriptContainer = path.join(uploadsPath, id)
-      await fs.ensureDir(manuscriptContainer)
-      const raw = await randomBytes(16)
-      const generatedFilename = raw.toString('hex') + path.extname(filename)
-      const manuscriptSourcePath = path.join(
-        manuscriptContainer,
-        generatedFilename,
-      )
-      const manuscriptJatsPath = path.join(
-        manuscriptContainer,
-        'manuscript.xml',
-      )
-      const manuscriptManifestPath = path.join(
-        manuscriptContainer,
-        'manifest.xml',
+      const fileEntity = await FileManager.save(
+        FileManager.new({
+          manuscriptId: manuscript.id,
+          url: `manuscripts/${id}`,
+          filename,
+          type: 'MANUSCRIPT_SOURCE',
+        }),
       )
 
       const pubsub = await getPubsub()
@@ -212,13 +193,12 @@ ${err}`,
       })
 
       // save source file locally
-      const saveFileStream = fs.createWriteStream(manuscriptSourcePath)
-      stream.pipe(progressReport).pipe(saveFileStream)
-
-      const saveFilePromise = new Promise((resolve, reject) => {
-        saveFileStream.on('finish', () => resolve(true))
-        saveFileStream.on('error', reject)
-      })
+      const saveFileStream = stream.pipe(progressReport)
+      const saveFilePromise = FileManager.putContent(
+        fileEntity,
+        saveFileStream,
+        { size: fileSize },
+      )
 
       // also send source file to conversion service
       const convertFileRequest = request.post(config.get('scienceBeam.url'), {
@@ -232,8 +212,6 @@ ${err}`,
         const xmlBuffer = await convertFileRequest
         const [xmlData] = await Promise.all([
           parseString(xmlBuffer.toString('utf8')),
-          fs.writeFile(manuscriptJatsPath, xmlBuffer),
-          fs.writeFile(manuscriptManifestPath, darManifest),
           saveFilePromise,
         ])
 
@@ -250,15 +228,10 @@ ${err}`,
         logger.warn('Manuscript conversion failed', err)
       }
 
-      manuscript.files.push({
-        url: manuscriptSourcePath,
-        filename,
-        type: 'MANUSCRIPT_SOURCE',
-      })
       manuscript.meta.title = title
-      await Manuscript.save(manuscript)
+      await ManuscriptManager.save(manuscript)
 
-      return manuscript
+      return ManuscriptManager.find(id, userUuid)
     },
   },
 

--- a/server/xpub/entities/manuscript/resolvers.test.js
+++ b/server/xpub/entities/manuscript/resolvers.test.js
@@ -178,6 +178,13 @@ describe('Submission', () => {
   describe('finishSubmission', () => {
     let id, initialManuscript
 
+    beforeAll(() =>
+      jest
+        .spyOn(FileManager, 'getContent')
+        .mockImplementation(() => 'A real PDF'))
+
+    afterAll(() => FileManager.getContent.mockRestore())
+
     beforeEach(async () => {
       jest.clearAllMocks()
 

--- a/server/xpub/test/mock-s3-server.js
+++ b/server/xpub/test/mock-s3-server.js
@@ -1,13 +1,16 @@
+const config = require('config')
 const S3rver = require('s3rver')
 const AWS = require('aws-sdk')
 
 async function startServer(options) {
-  const instance = await new Promise((resolve, reject) => {
+  const endpoint = config.get('aws.s3.endpoint')
+  const instance = await new Promise(resolve => {
     const server = new S3rver({
       directory: `/tmp/s3rver_test.${Math.random()
         .toString(36)
         .sub(2, 5)}`,
       removeBucketsOnClose: true,
+      port: endpoint.port,
     }).run(() => {
       resolve(server)
     })

--- a/server/xpub/test/mock-s3-server.js
+++ b/server/xpub/test/mock-s3-server.js
@@ -1,10 +1,12 @@
 const S3rver = require('s3rver')
 const AWS = require('aws-sdk')
 
-async function startServer(options, params) {
+async function startServer(options) {
   const instance = await new Promise((resolve, reject) => {
     const server = new S3rver({
-      directory: '/tmp/s3rver_test_directory',
+      directory: `/tmp/s3rver_test.${Math.random()
+        .toString(36)
+        .sub(2, 5)}`,
       removeBucketsOnClose: true,
     }).run(() => {
       resolve(server)
@@ -13,13 +15,8 @@ async function startServer(options, params) {
 
   const s3 = new AWS.S3({ ...options })
 
-  await new Promise((resolve, reject) => {
-    // S3 functions modify parameters, so we clone the parameters
-    s3.createBucket({ ...params }, (err, data) => {
-      if (err) reject(err)
-      resolve(data)
-    })
-  })
+  // S3 functions modify parameters, so we clone the parameters
+  await s3.createBucket({ ...options.params }).promise()
 
   return { instance, s3 }
 }

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -1,11 +1,16 @@
 import { ClientFunction } from 'testcafe'
 import DestinationRequest from 'testcafe-hammerhead/lib/request-pipeline/destination-request'
 import { createTables } from '@pubsweet/db-manager'
-import start from 'pubsweet/src/startup/start'
 import authentication from 'pubsweet-server/src/authentication'
+import config from 'config'
+import startS3Server from '@elifesciences/xpub-server/test/mock-s3-server'
+
+import start from 'pubsweet/src/startup/start'
+// while writing tests, using the following to start the server avoids having to recompile the app
 // import start from 'pubsweet-server'
 
 let server
+let s3rver
 
 const tokenContent = {
   id: 'ewwboc7m',
@@ -25,6 +30,14 @@ export async function setup(t) {
   t.ctx.localStorageSet = ClientFunction(token =>
     localStorage.setItem('token', token),
   )
+
+  // setup mock S3 server
+  s3rver = await startS3Server({
+    ...config.get('aws.credentials'),
+    ...config.get('aws.s3'),
+  })
 }
 
-export function teardown() {}
+export async function teardown() {
+  await new Promise(resolve => s3rver.instance.close(resolve))
+}


### PR DESCRIPTION

#### Background
- Save manuscripts file contents in S3
- Restructure config to share AWS credentials between packages.
- Refactor MECA package to not access the database. This avoids circular dependency between xpub-server and xpub-meca-export packages.


#### Any relevant tickets

Closes #520 

#### How has this been tested?

Integration tests with mock S3 server, end to end tests updated.