### PR TITLE
revert(graphql-subscriptions): remove logging for upload progress

### DIFF
--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -181,10 +181,6 @@ ${err}`,
             }
             startTime = process.hrtime()
           }
-          logger.info(
-            'Sent websocket message to graphql-postgres-subscriptions with uploadProgress ',
-            uploadProgress,
-          )
           pubsub.publish(`${ON_UPLOAD_PROGRESS}.${user}`, {
             uploadProgress,
           })


### PR DESCRIPTION
This is not needed anymore since the issue was solved in https://github.com/elifesciences/elife-xpub-formula/pull/33.