### PR TITLE
refactor: rename manuscript statuses

### DIFF
--- a/server/xpub/entities/manuscript/index.js
+++ b/server/xpub/entities/manuscript/index.js
@@ -17,6 +17,13 @@ const mergeObjects = (...inputs) =>
   )
 
 const Manuscript = {
+  statuses: {
+    INITIAL: 'INITIAL',
+    MECA_EXPORT_PENDING: 'MECA_EXPORT_PENDING',
+    MECA_EXPORT_FAILED: 'MECA_EXPORT_FAILED',
+    MECA_EXPORT_SUCCEEDED: 'MECA_EXPORT_SUCCEEDED',
+  },
+
   MAX_SUGGESTED_REVIEWERS: 6,
   MIN_SUGGESTED_REVIEWERS: 3,
 

--- a/server/xpub/entities/manuscript/resolvers.test.js
+++ b/server/xpub/entities/manuscript/resolvers.test.js
@@ -70,7 +70,7 @@ describe('Submission', () => {
       await Manuscript.save({
         createdBy: 'bcd735c6-9b62-441a-a085-7d1e8a7834c6',
         meta: { title: 'title 2' },
-        status: 'QA',
+        status: Manuscript.statuses.MECA_EXPORT_PENDING,
       })
 
       const manuscript = await Query.currentSubmission({}, {}, { user: userId })
@@ -90,7 +90,7 @@ describe('Submission', () => {
         meta: {
           title: 'title 2',
         },
-        status: 'QA',
+        status: Manuscript.statuses.MECA_EXPORT_PENDING,
       })
       await Manuscript.save({
         createdBy: userId,
@@ -178,19 +178,22 @@ describe('Submission', () => {
       id = manuscript.id
     })
 
-    it('stores data with a new status of QA', async () => {
+    it('stores data with new status', async () => {
       const returnedManuscript = await Mutation.finishSubmission(
         {},
         { data: { ...manuscriptInput, id } },
         { user: userId },
       )
 
-      expect(returnedManuscript.status).toBe('QA')
+      expect(returnedManuscript.status).toBe(
+        Manuscript.statuses.MECA_EXPORT_PENDING,
+      )
 
       const storedManuscript = await Manuscript.find(id, userId)
       expect(storedManuscript).toMatchObject({
         ...expectedManuscript,
-        status: 'QA',
+        // TODO this might cause a race condition
+        status: Manuscript.statuses.MECA_EXPORT_SUCCEEDED,
       })
     })
 
@@ -296,7 +299,9 @@ describe('Submission', () => {
       ])
       expect(logger.error).toHaveBeenCalled()
       const updatedManuscript = await Manuscript.find(manuscript.id, userId)
-      expect(updatedManuscript.status).toBe('FAILED_MECA_EXPORT')
+      expect(updatedManuscript.status).toBe(
+        Manuscript.statuses.MECA_EXPORT_FAILED,
+      )
     })
   })
 

--- a/server/xpub/entities/manuscript/typeDefs.graphqls
+++ b/server/xpub/entities/manuscript/typeDefs.graphqls
@@ -50,10 +50,6 @@ input ManuscriptMetaInput {
   articleType: String
   subjects: [String]
 }
-enum SubmissionStage {
-  INITIAL
-  QA
-}
 
 # temporary solution awaiting more clarity on team member metadata in shared data model
 union Assignee = EditorAlias | ReviewerAlias | AuthorAlias

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -1,6 +1,7 @@
 import { ClientFunction, Selector } from 'testcafe'
 import config from 'config'
 import startSshServer from '@elifesciences/xpub-meca-export/test/mock-sftp-server'
+import ManuscriptManager from '@elifesciences/xpub-server/entities/manuscript'
 import replaySetup from './helpers/replay-setup'
 import {
   author,
@@ -149,7 +150,8 @@ test('Happy path', async t => {
     .expect(dashboard.titles.textContent)
     .eql(manuscript.title)
     .expect(dashboard.stages.textContent)
-    .eql('QA')
+    // TODO this might cause a race condition
+    .eql(ManuscriptManager.statuses.MECA_EXPORT_PENDING)
 
   // SFTP server
   await autoRetry(() => t.expect(mockFs.readdirSync('/test').length).eql(1))


### PR DESCRIPTION
#### Background

- Rename `QA` status to `PENDING_MECA_EXPORT`.
- Add a `MECA_EXPORT_SUCCEEDED` status.
- Lookup statuses in a dictionary.

Note since the export happens asynchronously there are a couple of potential race conditions. If these do materialise, they can be fixed by asserting that the status is *either* pending or succeeded.