### PR TITLE
Specify postgres:10.4 for local usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       PGUSER: $USER
 
   postgres:
-    image: postgres:10
+    image: postgres:10.4
     ports:
       - 5432:5432
     environment:


### PR DESCRIPTION
See https://github.com/elifesciences/builder/pull/393 for AWS support reasons: going back to `10.4` from the current default `10.5`.

No idea where to change what is used in building PRs to this repository.