### PR TITLE
Change font weight of button to be consistent with eLife

### DIFF
--- a/client/elife-theme/src/elements/ui/Button.js
+++ b/client/elife-theme/src/elements/ui/Button.js
@@ -38,6 +38,7 @@ export default css`
   min-width: calc(${th('gridUnit')} * 16);
   padding: calc(${th('gridUnit')} * 2);
   font-size: 14px;
+  font-weight: 500;
   text-transform: uppercase;
 
   ${props => props.small && small};


### PR DESCRIPTION
As per discussions with @chugginselifesciences  and @davidcmoulton  ... the font weight in a button should be 500