### PR TITLE
Disable ORCID sandbox in production

### DIFF
--- a/config/ci.js
+++ b/config/ci.js
@@ -1,0 +1,10 @@
+module.exports = {
+  'auth-orcid': {
+    sandbox: true,
+  },
+  meca: {
+    sftp: {
+      disableUpload: true,
+    },
+  },
+}

--- a/config/demo.js
+++ b/config/demo.js
@@ -1,5 +1,5 @@
 module.exports = {
-  auth-orcid: {
+  'auth-orcid': {
     sandbox: true
   },
   meca: {

--- a/config/demo.js
+++ b/config/demo.js
@@ -1,0 +1,10 @@
+module.exports = {
+  auth-orcid: {
+    sandbox: true
+  },
+  meca: {
+    sftp: {
+      disableUpload: true
+    }
+  }
+}

--- a/config/prod.js
+++ b/config/prod.js
@@ -1,10 +1,10 @@
 module.exports = {
   'auth-orcid': {
-    sandbox: false
+    sandbox: false,
   },
   meca: {
     sftp: {
-      disableUpload: true
-    }
-  }
+      disableUpload: true,
+    },
+  },
 }

--- a/config/production.js
+++ b/config/production.js
@@ -1,7 +1,10 @@
 module.exports = {
+  auth-orcid: {
+    sandbox: false
+  },
   meca: {
     sftp: {
-      disableUpload: true,
-    },
-  },
+      disableUpload: true
+    }
+  }
 }

--- a/config/production.js
+++ b/config/production.js
@@ -1,5 +1,5 @@
 module.exports = {
-  auth-orcid: {
+  'auth-orcid': {
     sandbox: false
   },
   meca: {


### PR DESCRIPTION
#### Background

Dependant on the following: 
- https://github.com/elifesciences/elife-xpub-deployment/pull/12
- https://github.com/elifesciences/elife-xpub-formula/pull/36
- https://github.com/elifesciences/builder-configuration/pull/3

Production has ORCID secrets set to allow it to work with the sandbox disabled. Without this, production fails.

#### How has this been tested?
- Verified `config` locally to ensure `NODE_CONFIG_ENV` can be used to load environment specific config files within `/config`
