### PR TITLE
MECA rename

### DIFF
--- a/server/meca/index.test.js
+++ b/server/meca/index.test.js
@@ -41,10 +41,11 @@ describe('MECA integration test', () => {
     await mecaExport(sampleManuscript, '')
 
     expect(sftp.mockFs.readdirSync('/')).toEqual(['test'])
-    expect(sftp.mockFs.readdirSync('/test')).toEqual([sampleManuscript.id])
+    const finalName = `${sampleManuscript.id}.zip`
+    expect(sftp.mockFs.readdirSync('/test')).toEqual([finalName])
 
     const zip = await JsZip.loadAsync(
-      sftp.mockFs.readFileSync(`/test/${sampleManuscript.id}`),
+      sftp.mockFs.readFileSync(`/test/${finalName}`),
     )
 
     expect(getFilenames(zip)).toEqual([

--- a/server/meca/test/mock-sftp-server.js
+++ b/server/meca/test/mock-sftp-server.js
@@ -16,6 +16,11 @@ function startServer(port) {
     }
 
     auth.accept(session => {
+      session.on('rename', (oldPath, newPath, context) => {
+        mockFs.writeFileSync(newPath, mockFs.readFileSync(oldPath))
+        mockFs.unlinkSync(oldPath)
+        context.ok()
+      })
       session.on('writefile', (path, readstream) => {
         const stream = mockFs.createWriteStream(path)
         readstream.pipe(stream)

--- a/server/meca/upload/index.js
+++ b/server/meca/upload/index.js
@@ -28,7 +28,10 @@ async function uploadToSFTP(file, id) {
   const sftp = await SFTP()
   const remotePath = config.get('meca.sftp.remotePath')
   await sftp.mkdir(remotePath, true)
-  await sftp.put(file, `${remotePath}/${id}`)
+  const transferName = `${remotePath}/${id}.transfer`
+  const finalName = `${remotePath}/${id}.zip`
+  await sftp.put(file, transferName)
+  await sftp.rename(transferName, finalName)
   await sftp.end()
 }
 


### PR DESCRIPTION
#### Background
Uploads to SFTP site as a different name, then rename when done - to prevent eJP from prematurely processing

* NOTE *  this is branched from `520-manuscript-s3` #668 ... so please merge after this.

#### Any relevant tickets

#642 

#### How has this been tested?

Locally with mock sftp server
