### PR TITLE
Showing user an error when uploading a manuscripts to S3 fails

### DIFF
--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -194,7 +194,7 @@ ${err}`,
       })
 
       const saveFileStream = stream.pipe(progressReport)
-      const saveFilePromise = FileManager.putContent(
+      await FileManager.putContent(
         fileEntity,
         saveFileStream,
         { size: fileSize },
@@ -210,10 +210,7 @@ ${err}`,
       let title = ''
       try {
         const xmlBuffer = await convertFileRequest
-        const [xmlData] = await Promise.all([
-          parseString(xmlBuffer.toString('utf8')),
-          saveFilePromise,
-        ])
+        const xmlData = await parseString(xmlBuffer.toString('utf8'))
 
         if (xmlData.article) {
           const firstArticle = xmlData.article.front[0]

--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -193,7 +193,6 @@ ${err}`,
         }
       })
 
-      // save source file locally
       const saveFileStream = stream.pipe(progressReport)
       const saveFilePromise = FileManager.putContent(
         fileEntity,


### PR DESCRIPTION
#### Background

No longer show a successful upload when the manuscript fails to upload to S3. This would then fail the MECA ZIP file export.

#### How has this been tested?
Locally

<img width="666" alt="screen shot 2018-09-28 at 12 34 33" src="https://user-images.githubusercontent.com/2573277/46206549-3f1a7800-c31c-11e8-93df-0ee6f7a0951e.png">

