### PR TITLE
feat: exchange journal token for longer lived xpub token

### DIFF
--- a/app/components/pages/Login/index.test.js
+++ b/app/components/pages/Login/index.test.js
@@ -2,19 +2,47 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import LoginPage from '.'
 
-const makeWrapper = props => shallow(<LoginPage {...props} />)
+const clientMock = {
+  mutate: jest.fn(() =>
+    Promise.resolve({ data: { exchangeJournalToken: '345cba' } }),
+  ),
+}
+const historyMock = { location: { hash: '#123abc' }, push: jest.fn() }
+
+const makeWrapper = props => shallow(<LoginPage.WrappedComponent {...props} />)
 
 describe('LoginPage component', () => {
+  beforeEach(() => jest.clearAllMocks())
+
   it('does not redirect if no token', () => {
     const wrapper = makeWrapper()
     expect(wrapper.name()).not.toBe('Redirect')
   })
 
   it('redirects when a token is given', () => {
-    const wrapper = makeWrapper({
-      history: { location: { hash: '#123abc' } },
-    })
+    const wrapper = makeWrapper({ client: clientMock, history: historyMock })
     expect(wrapper.name()).toBe('Redirect')
     expect(localStorage.getItem('token')).toBe('123abc')
+  })
+
+  it('saves exchanged token to storage', async () => {
+    makeWrapper({ client: clientMock, history: historyMock })
+
+    expect(localStorage.getItem('token')).toBe('123abc')
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(localStorage.getItem('token')).toBe('345cba')
+    expect(historyMock.push).not.toHaveBeenCalled()
+  })
+
+  it('redirects when token exchange fails', async () => {
+    jest.spyOn(console, 'error').mockImplementationOnce(jest.fn())
+    clientMock.mutate.mockImplementationOnce(() =>
+      Promise.reject(new Error('Nope')),
+    )
+    makeWrapper({ client: clientMock, history: historyMock })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(historyMock.push).toHaveBeenCalledWith('/login', { error: 'Nope' })
+    expect(console.error).toHaveBeenCalled()
   })
 })

--- a/server/xpub/entities/user/resolvers.js
+++ b/server/xpub/entities/user/resolvers.js
@@ -1,3 +1,5 @@
+const jwt = require('jsonwebtoken')
+const config = require('config')
 const UserManager = require('.')
 const elifeApi = require('./helpers/elife-api')
 
@@ -19,6 +21,20 @@ const resolvers = {
     },
     async editors(_, { role }) {
       return elifeApi.people(role)
+    },
+  },
+  Mutation: {
+    async exchangeJournalToken(_, { token }) {
+      const secret = config.get('pubsweet-server.secret')
+      const tokenContents = jwt.verify(token, secret)
+
+      if (tokenContents.iss === 'xpub') {
+        throw new Error('Cannot exchange xPub issued token')
+      }
+
+      return jwt.sign({ id: tokenContents.id, iss: 'xpub' }, secret, {
+        expiresIn: '1d',
+      })
     },
   },
 }

--- a/server/xpub/entities/user/resolvers.test.js
+++ b/server/xpub/entities/user/resolvers.test.js
@@ -1,5 +1,7 @@
+const jwt = require('jsonwebtoken')
+const config = require('config')
 const { createTables } = require('@pubsweet/db-manager')
-const { Query } = require('./resolvers')
+const { Query, Mutation } = require('./resolvers')
 const UserManager = require('.')
 const replaySetup = require('../../../../test/helpers/replay-setup')
 
@@ -57,6 +59,54 @@ describe('User', () => {
           'Neuroscience',
         ],
       })
+    })
+  })
+
+  describe('exchangeJournalToken', () => {
+    const secret = config.get('pubsweet-server.secret')
+
+    it('fails with expired token', async () => {
+      const expiredToken = jwt.sign(
+        { id: '1234', iss: 'journal', exp: 1538134996 },
+        secret,
+      )
+      await expect(
+        Mutation.exchangeJournalToken({}, { token: expiredToken }),
+      ).rejects.toThrow('jwt expired')
+    })
+
+    it('fails with token from wrong issuer', async () => {
+      const xpubToken = jwt.sign({ id: '1234', iss: 'xpub' }, secret, {
+        expiresIn: '1d',
+      })
+      await expect(
+        Mutation.exchangeJournalToken({}, { token: xpubToken }),
+      ).rejects.toThrow('Cannot exchange xPub issued token')
+    })
+
+    it('fails with token with wrong signature', async () => {
+      const xpubToken = jwt.sign(
+        { id: '1234', iss: 'xpub' },
+        'not the right secret',
+        {
+          expiresIn: '1d',
+        },
+      )
+      await expect(
+        Mutation.exchangeJournalToken({}, { token: xpubToken }),
+      ).rejects.toThrow('invalid signature')
+    })
+
+    it('exchanges valid token and changes issuer', async () => {
+      const journalToken = jwt.sign({ id: '1234', iss: 'journal' }, secret, {
+        expiresIn: '1d',
+      })
+      const xpubToken = await Mutation.exchangeJournalToken(
+        {},
+        { token: journalToken },
+      )
+      const tokenContents = jwt.verify(xpubToken, secret)
+      expect(tokenContents).toMatchObject({ id: '1234', iss: 'xpub' })
     })
   })
 })

--- a/server/xpub/entities/user/routes.js
+++ b/server/xpub/entities/user/routes.js
@@ -9,9 +9,11 @@ module.exports = app => {
     app.get('/mock-token-exchange/:id', async (req, res) => {
       const mockProfileId = req.params.id
       logger.info('Signing mock JWT for profile ID', mockProfileId)
-      const xpubToken = await jwt.sign({ id: mockProfileId }, secret, {
-        expiresIn: '1y',
-      })
+      const xpubToken = await jwt.sign(
+        { id: mockProfileId, iss: 'journal' },
+        secret,
+        { expiresIn: '1m' },
+      )
 
       res.redirect(`/login#${xpubToken}`)
     })

--- a/server/xpub/entities/user/typeDefs.graphqls
+++ b/server/xpub/entities/user/typeDefs.graphqls
@@ -2,3 +2,7 @@ extend type Query {
   orcidDetails: AuthorAlias
   editors(role: String!): [EditorAlias]
 }
+
+extend type Mutation {
+  exchangeJournalToken(token: String): String
+}


### PR DESCRIPTION
#### Background

When a token is passed in the URL, trigger a GraphQL mutation to exchange this for a longer lived token, then save this to local storage. If the token exchange fails (the only likely cause I can think for this is a network issue)then redirect the user to the login page.

#### Any relevant tickets

Closes #678 

#### How has this been tested?

Unit tests.