### PR TITLE
fix: mobile view in production

### DIFF
--- a/app/index-production.html
+++ b/app/index-production.html
@@ -8,6 +8,7 @@
     -->
     <meta charset=utf-8>
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 </head>
 <body>
 <div id="root"></div>


### PR DESCRIPTION
#### Background

Closes #684 

This happened because now we are actually running a production build, it's using the production `index.html` but the meta viewport tag had only been added to the development index.
