### PR TITLE
fix: unsafe piping of streams in upload

### DIFF
--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -192,20 +192,19 @@ ${err}`,
           )
         }
       })
-
-      const saveFileStream = stream.pipe(progressReport)
-      await FileManager.putContent(
-        fileEntity,
-        saveFileStream,
-        { size: fileSize },
-      )
-
       // also send source file to conversion service
       const convertFileRequest = request.post(config.get('scienceBeam.url'), {
         qs: { filename },
         headers: { 'content-type': mimetype },
       })
+
+      // note: if a stream is piped to multiple destinations, ensure the
+      // pipes are set up in the same tick, or else chunks can be lost
+      const saveFileStream = stream.pipe(progressReport)
       stream.pipe(convertFileRequest)
+      await FileManager.putContent(fileEntity, saveFileStream, {
+        size: fileSize,
+      })
 
       let title = ''
       try {


### PR DESCRIPTION
#### Background

Our internet was very slow in the office on Friday and it exposed a bug in the way streams were handled in the upload resolver. Because connecting to S3 took so long, it allowed the stream to be emptied before it had a chance to also pipe the contents to sciencebeam making sciencebeam fail with a `no content` error.