### PR TITLE
fix: add babel-polyfill for ie11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.2",
     "babel-loader": "^7.1.2",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",

--- a/webpack/babel-includes.js
+++ b/webpack/babel-includes.js
@@ -6,6 +6,7 @@ const path = require('path')
 module.exports = [
   // include our code
   path.join(__dirname, '..', 'app'),
+  path.join(__dirname, '..', 'config'),
   path.join(__dirname, '..', 'client'),
   path.join(__dirname, '..', 'styleguide'),
 

--- a/webpack/webpack.production.config.js
+++ b/webpack/webpack.production.config.js
@@ -18,7 +18,7 @@ module.exports = [
     target: 'web',
     context: path.join(__dirname, '..', 'app'),
     entry: {
-      app: ['./index'],
+      app: ['babel-polyfill', './index'],
     },
     output: {
       path: path.join(__dirname, '..', '_build', 'assets'),

--- a/webpack/webpack.test.config.js
+++ b/webpack/webpack.test.config.js
@@ -11,7 +11,7 @@ module.exports = [
     target: 'web',
     context: path.join(__dirname, '..', 'app'),
     entry: {
-      app: ['./index'],
+      app: ['babel-polyfill', './index'],
     },
     output: {
       path: path.join(__dirname, '..', '_build', 'assets'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,6 +1936,15 @@ babel-polyfill@6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-env@^1.1.8, babel-preset-env@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
@@ -12036,7 +12045,7 @@ regenerate@^1.2.1:
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
 
-regenerator-runtime@^0.10.0:
+regenerator-runtime@^0.10.0, regenerator-runtime@^0.10.5:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
   integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=


### PR DESCRIPTION
#### Background

Does the minimum to get the app to load in IE11.

- Add `babel-polyfill`
- Ensure config directory is transpiled

End to end tests now almost pass. Some layout issues to sort on the people picker.

#### Any relevant tickets

Related #612 

#### How has this been tested?

Using a time machine.
