### PR TITLE
Create a local folder for logs in the container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ ARG CI_COMMIT_SHA
 ENV CI_COMMIT_SHA ${CI_COMMIT_SHA}
 RUN echo "{ \"version\": \"${CI_COMMIT_SHA}\", \"date\":\"$(date)\" }" > app/version.json
 
+ENV XPUB_LOG_PATH "/var/log/xpub"
+RUN mkdir -p ${XPUB_LOG_PATH}
+
 RUN [ "npx", "pubsweet", "build"]
 
 EXPOSE 3000


### PR DESCRIPTION
#### Background

What does this PR do?
Creates a folder for logs within the container

#### Any relevant tickets
#693 

#### How has this been tested?
Locally I can build and run the container successfully logging to `/var/log/xpub`
