### PR TITLE
fix: don't use streams in upload resolver

### DIFF
--- a/server/xpub/entities/file/index.js
+++ b/server/xpub/entities/file/index.js
@@ -1,7 +1,6 @@
 const config = require('config')
 const lodash = require('lodash')
 const AWS = require('aws-sdk')
-const fs = require('fs-extra')
 const dataAccess = require('./data-access')
 
 const s3 = new AWS.S3({
@@ -37,31 +36,15 @@ const FileManager = {
       throw new Error('File has no ID, must be saved first')
     }
 
-    // S3 only accepts streams of actual files on disk
-    // so stream to a temp file first
-    const tempFilePath = `/tmp/s3-pass-through/${Math.random()
-      .toString(36)
-      .substr(2)}`
-    await fs.ensureFile(tempFilePath)
-    const writeStream = fs.createWriteStream(tempFilePath)
-    content.pipe(writeStream)
-    await new Promise((resolve, reject) => {
-      writeStream.on('finish', resolve)
-      writeStream.on('error', reject)
-    })
-
-    const readStream = fs.createReadStream(tempFilePath)
-    const response = await s3
+    return s3
       .putObject({
-        Body: readStream,
+        Body: content,
         Key: `${file.url}/${file.id}`,
         ContentType: file.mimetype,
         ContentLength: size,
         ACL: 'private',
       })
       .promise()
-    await fs.remove(tempFilePath)
-    return response
   },
   getContent: async file => {
     const { Body } = await s3


### PR DESCRIPTION
#### Background

We've had several bugs related to the way streams are handled in the upload resolver. I've spent most of today trying to make sense of it but in the end I've opted to read the whole file into a string and pass that around instead. It's not as efficient but it's simpler and less buggy. Optimisation can come later.

I'll try and write up the issues tomorrow.

