### PR TITLE
feat: split reviewer name using rule with list of known exceptions

### DIFF
--- a/config/components.json
+++ b/config/components.json
@@ -1,1 +1,5 @@
-["@elifesciences/xpub-server", "@pubsweet/component-send-email"]
+[
+  "@elifesciences/xpub-meca-export",
+  "@elifesciences/xpub-server",
+  "@pubsweet/component-send-email"
+]

--- a/server/meca/file-generators/article.helpers.js
+++ b/server/meca/file-generators/article.helpers.js
@@ -40,14 +40,17 @@ const contribStructure = {
   },
   'potential-reviewers': {
     keys: ['suggestedReviewer', 'opposedReviewer'],
-    formatter: member => ({
-      name: {
-        // TODO split name?
-        surname: member.meta.name,
-        'given-names': '',
-      },
-      email: member.meta.email,
-    }),
+    formatter: (member, affiliations, editorsById, reviewerMap) => {
+      const { name } = member.meta
+      const surname = reviewerMap[name.toLowerCase()]
+      return {
+        name: {
+          surname,
+          'given-names': name.substring(0, name.length - surname.length - 1),
+        },
+        email: member.meta.email,
+      }
+    },
   },
 }
 

--- a/server/meca/file-generators/article.test.data.json
+++ b/server/meca/file-generators/article.test.data.json
@@ -114,13 +114,13 @@
       "teamMembers": [
         {
           "meta": {
-            "name": "Edward Reviewer",
+            "name": "J. Edward Reviewer",
             "email": "edward@example.com"
           }
         },
         {
           "meta": {
-            "name": "Frances Reviewer",
+            "name": "Frances de Reviewer",
             "email": "frances@example.org"
           }
         },

--- a/server/meca/file-generators/article.test.js
+++ b/server/meca/file-generators/article.test.js
@@ -1,6 +1,10 @@
+const { createTables } = require('@pubsweet/db-manager')
+const { db } = require('pubsweet-server')
 const generateXml = require('./article')
 const Replay = require('replay')
 const sampleManuscript = require('./article.test.data')
+
+const existingNames = [{ id: 1, first: 'J. Edward', last: 'Reviewer' }]
 
 Replay.fixtures = `${__dirname}/../test/http-mocks`
 
@@ -20,6 +24,8 @@ const snippets = [
     '<meta-value>6d8cd1ce-15b6-46c1-b901-bc91598c8f2d</meta-value>',
   ],
   ['author email', '<email>elife@mailinator.com</email>'],
+  ['multipart reviewer forename', '<given-names>J. Edward</given-names>'],
+  ['multipart reviewer surname', '<surname>de Reviewer</surname>'],
   [
     'related article',
     `<related-article related-article-type="companion">
@@ -29,6 +35,11 @@ const snippets = [
 ]
 
 describe('Article XML generator', () => {
+  beforeAll(async () => {
+    await createTables(true)
+    await db.table('ejp_name').insert(existingNames)
+  })
+
   describe('sample output', () => {
     test.each(snippets)('includes %s', async (name, snippet) => {
       const xml = await generateXml(sampleManuscript)

--- a/server/meca/index.test.js
+++ b/server/meca/index.test.js
@@ -65,7 +65,7 @@ describe('MECA integration test', () => {
       )
 
       expect(getFileSizes(zip)).toEqual({
-        'article.xml': 6109,
+        'article.xml': 6145,
         'cover_letter.html': 743,
         'disclosure.pdf': expect.any(Number),
         'manifest.xml': 919,

--- a/server/meca/migrations/1538487310-ejp-name.sql
+++ b/server/meca/migrations/1538487310-ejp-name.sql
@@ -1,0 +1,6 @@
+CREATE TABLE ejp_name (
+  id    INTEGER PRIMARY KEY,
+  first TEXT,
+  last  TEXT
+);
+CREATE INDEX ejp_name_concat ON ejp_name (lower(first || ' ' || last));

--- a/server/meca/nameSplitter.js
+++ b/server/meca/nameSplitter.js
@@ -1,0 +1,14 @@
+const { db } = require('pubsweet-server')
+
+module.exports = async fullName => {
+  const [result] = await db
+    .select()
+    .from('ejp_name')
+    .whereRaw("lower(first || ' ' || last) = ?", [fullName.toLowerCase()])
+
+  if (result) {
+    return result.last
+  }
+
+  return fullName.substring(fullName.indexOf(' ') + 1)
+}

--- a/server/meca/nameSplitter.test.js
+++ b/server/meca/nameSplitter.test.js
@@ -1,0 +1,45 @@
+const { createTables } = require('@pubsweet/db-manager')
+const { db } = require('pubsweet-server')
+const splitter = require('./nameSplitter')
+
+const existingNames = [
+  { id: 1, first: 'J. Richard', last: 'Jones' },
+  { id: 2, first: 'Maria Inês', last: 'Birkegård' },
+]
+
+describe('Name splitter', () => {
+  beforeAll(async () => {
+    await createTables(true)
+    await db.table('ejp_name').insert(existingNames)
+  })
+
+  it('handles single word', async () => {
+    const surname = await splitter('Wrong')
+    expect(surname).toEqual('Wrong')
+  })
+
+  it('handles empty string', async () => {
+    const surname = await splitter('')
+    expect(surname).toEqual('')
+  })
+
+  it('splits known multipart forename', async () => {
+    const surname = await splitter('J. Richard Jones')
+    expect(surname).toEqual('Jones')
+  })
+
+  it('splits known multipart forename with special chars', async () => {
+    const surname = await splitter('Maria Inês Birkegård')
+    expect(surname).toEqual('Birkegård')
+  })
+
+  it('known surnames are case insensitive', async () => {
+    const surname = await splitter('maria INÊS birkegård')
+    expect(surname).toEqual('Birkegård')
+  })
+
+  it('splits unknown name on first space', async () => {
+    const surname = await splitter('Genevieve Abdel Rahman')
+    expect(surname).toEqual('Abdel Rahman')
+  })
+})


### PR DESCRIPTION
#### Background

- Set up a database table to hold list of known authors with spaces in their forenames
- Use this list of exceptions when creating the MECA export to split the reviewer name into its parts

Closes #643 
