### PR TITLE
fix: prevent updating an entity which doesn't exist

### DIFF
--- a/server/xpub/entities/file/index.js
+++ b/server/xpub/entities/file/index.js
@@ -23,12 +23,16 @@ const FileManager = {
   delete: dataAccess.delete,
   new: (props = {}) => lodash.merge({}, empty, props),
   save: async file => {
+    let id = { file }
     if (file.id) {
-      await dataAccess.update(file)
-      return file
+      const updated = await dataAccess.update(file)
+      if (!updated) {
+        throw new Error('File not found')
+      }
+    } else {
+      id = await dataAccess.insert(file)
     }
 
-    const id = await dataAccess.insert(file)
     return { ...file, id }
   },
   putContent: async (file, content, { size } = {}) => {

--- a/server/xpub/entities/identity/index.js
+++ b/server/xpub/entities/identity/index.js
@@ -8,12 +8,16 @@ const IdentityManager = {
   delete: dataAccess.delete,
   new: () => lodash.cloneDeep(empty),
   save: async identity => {
+    let id = { identity }
     if (identity.id) {
-      await dataAccess.update(identity)
-      return identity
+      const updated = await dataAccess.update(identity)
+      if (!updated) {
+        throw new Error('Identity not found')
+      }
+    } else {
+      id = await dataAccess.insert(identity)
     }
 
-    const id = await dataAccess.insert(identity)
     return { ...identity, id }
   },
 }

--- a/server/xpub/entities/manuscript/index.js
+++ b/server/xpub/entities/manuscript/index.js
@@ -44,7 +44,10 @@ const Manuscript = {
     // TODO wrap these queries in a transaction
     let { id } = manuscript
     if (id) {
-      await dataAccess.update(manuscript)
+      const updated = await dataAccess.update(manuscript)
+      if (!updated) {
+        throw new Error('Manuscript not found')
+      }
     } else {
       id = await dataAccess.insert(manuscript)
     }

--- a/server/xpub/entities/manuscript/index.test.js
+++ b/server/xpub/entities/manuscript/index.test.js
@@ -1,6 +1,9 @@
+const { createTables } = require('@pubsweet/db-manager')
 const Manuscript = require('.')
 
 describe('Manuscript', () => {
+  beforeEach(() => createTables(true))
+
   describe('applyInput', () => {
     it('picks only whitelisted properties', () => {
       const originalManuscript = {
@@ -101,5 +104,15 @@ describe('Manuscript', () => {
         { id: 2, role: 'seniorEditor' },
       ])
     })
+  })
+
+  describe('save()', () => {
+    it('fails to update non-existent manuscript', () =>
+      expect(
+        Manuscript.save({
+          id: 'f05bbbf9-ddf4-494f-a8da-84957e2708ee',
+          status: 'INITIAL',
+        }),
+      ).rejects.toThrow('Manuscript not found'))
   })
 })

--- a/server/xpub/entities/team/index.js
+++ b/server/xpub/entities/team/index.js
@@ -8,12 +8,16 @@ const Team = {
   delete: dataAccess.delete,
   new: () => lodash.cloneDeep(empty),
   save: async team => {
+    let id = { team }
     if (team.id) {
-      await dataAccess.update(team)
-      return team
+      const updated = await dataAccess.update(team)
+      if (!updated) {
+        throw new Error('Team not found')
+      }
+    } else {
+      id = await dataAccess.insert(team)
     }
 
-    const id = await dataAccess.insert(team)
     return { ...team, id }
   },
 }

--- a/server/xpub/entities/user/index.js
+++ b/server/xpub/entities/user/index.js
@@ -57,12 +57,15 @@ const UserManager = {
     }
   },
   save: async user => {
+    let id = { user }
     if (user.id) {
-      await dataAccess.update(user)
-      return user
+      const updated = await dataAccess.update(user)
+      if (!updated) {
+        throw new Error('User not found')
+      }
+    } else {
+      id = await dataAccess.insert(user)
     }
-
-    const id = await dataAccess.insert(user)
 
     if (user.identities) {
       await Promise.all(

--- a/server/xpub/entities/user/index.test.js
+++ b/server/xpub/entities/user/index.test.js
@@ -40,4 +40,14 @@ describe('User manager', () => {
       })
     })
   })
+
+  describe('save()', () => {
+    it('fails to update non-existent user', () =>
+      expect(
+        UserManager.save({
+          id: 'f05bbbf9-ddf4-494f-a8da-84957e2708ee',
+          defaultIdentity: 'foo',
+        }),
+      ).rejects.toThrow('User not found'))
+  })
 })


### PR DESCRIPTION
#### Background

Fix a bug in the entity access logic that silently ignored saving an entity which had an ID but didn't exist in the database.

#### How has this been tested?

Jest integration tests.