### PR TITLE
feat: duplicate package checker that works with workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "stop:services": "docker-compose down -v",
     "styleguide": "styleguidist server",
     "test": "jest --runInBand",
-    "test:dependencies": "duplicate-module-test react react-dom styled-components pubsweet-server",
+    "test:dependencies": "check-yarn-dupes react react-dom styled-components pubsweet-server",
     "test:e2e": "NODE_ENV=test NODE_APP_INSTANCE=e2e testcafe \"${BROWSER:-chrome}\" 'test/**/*.e2e.js'",
     "update": "yarn upgrade-interactive --latest"
   },
@@ -113,7 +113,6 @@
     "yup": "^0.26.2"
   },
   "devDependencies": {
-    "@mapbox/duplicate-module-test": "^0.1.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.2",
     "babel-loader": "^7.1.2",

--- a/server/dupes/index.js
+++ b/server/dupes/index.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const lockfile = require('@yarnpkg/lockfile')
+
+if (require.main === module) {
+  const duplicates = check(process.argv.slice(2))
+
+  if (duplicates.length) {
+    console.error(
+      `WARNING: Found ${duplicates.length} unexpected duplicated packages`,
+    )
+    console.info(
+      'Use `yarn list --pattern [package name]` to locate the packages',
+    )
+    console.log(duplicates)
+    process.exit(duplicates.length)
+  } else {
+    console.debug('No unexpected duplicates found')
+  }
+}
+
+function check(packages) {
+  const file = fs.readFileSync('yarn.lock', 'utf8')
+  const json = lockfile.parse(file)
+  const packageVersions = Object.keys(json.object)
+
+  return packages
+    .map(name => {
+      const regExp = new RegExp(`^${name}@(.+)`)
+      const versions = packageVersions.reduce((vs, spec) => {
+        const match = spec.match(regExp)
+        const { version } = json.object[spec]
+        if (match && !vs.includes(version)) {
+          vs.push(version)
+        }
+
+        return vs
+      }, [])
+
+      return { name, versions }
+    })
+    .filter(pkg => pkg.versions.length > 1)
+}
+
+module.exports = check

--- a/server/dupes/package.json
+++ b/server/dupes/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@elifesciences/check-yarn-dupes",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "bin": {"check-yarn-dupes": "./index.js"},
+  "dependencies": {
+    "@yarnpkg/lockfile": "^1.1.0"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,13 +294,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.1.tgz#f3a81587ad8d0ef33cdad6f3b4310774fcc1053e"
   integrity sha512-dEv1n+IFtlvLQ8/FsTOtBCC1aNT4B5abE8ODF5wk2tpWnjvgGNRMvHCeJGbVHjFfer4h8MH2w9c2/6eoJHclMg==
 
-"@mapbox/duplicate-module-test@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/duplicate-module-test/-/duplicate-module-test-0.1.0.tgz#4da68e201989cd0b1f26d25dcd70c57bdb157fb9"
-  integrity sha512-D++rS1e+6z7zx6Iu653p297vltvQAszwS2Tr8edjhLE5qOTr8uUzFYEsDMND2lHrBYQcSmUXxLVhi2rzESMaXA==
-  dependencies:
-    minimist "^1.2.0"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -442,6 +435,11 @@
   integrity sha512-qV2VslV48ECPwyuG7c4O6JpYgjnvdm88YYkMncIXzakXXwVUxhcg6YipXxWK7U+pixHkWWSnDX/8DIOmWeh+PQ==
   dependencies:
     common-tags "^1.7.2"
+
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 abab@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Background

Having duplicates of certain dependencies can cause hard-to-debug problems. The previous solution we had for checking duplicates only looked in `node_modules` and wasn't aware of yarn workspaces. This quick fix looks at the `yarn.lock` file and errors if any of the named packages are present in more than one version.

#### How has this been tested?

Manually.