### PR TITLE
fix: clean up manuscript file after failed upload

### DIFF
--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -189,9 +189,14 @@ ${err}`,
         })
       })
 
-      await FileManager.putContent(fileEntity, fileContents, {
-        size: fileSize,
-      })
+      try {
+        await FileManager.putContent(fileEntity, fileContents, {
+          size: fileSize,
+        })
+      } catch (err) {
+        await FileManager.delete(fileEntity.id)
+        throw err
+      }
 
       // also send source file to conversion service
       let title = ''


### PR DESCRIPTION
#### Background

Fixes #714 by deleting the file entity from the database if saving the content of the file fails.