### PR TITLE
feat: make API gateway url configurable

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -33,6 +33,11 @@ module.exports = {
     API_ENDPOINT: '/api',
     'login-redirect': '/',
   },
+  elife: {
+    api: {
+      url: 'https://api.elifesciences.org/',
+    },
+  },
   login: {
     // TODO swap this mock for the Journal endpoint when available
     url: '/mock-token-exchange/ewwboc7m',

--- a/config/staging.js
+++ b/config/staging.js
@@ -4,4 +4,9 @@ module.exports = {
   'pubsweet-server': {
     logger,
   },
+  elife: {
+    api: {
+      url: 'https://continuumtest--gateway.elifesciences.org/',
+    },
+  },
 }

--- a/server/xpub/entities/user/helpers/elife-api.js
+++ b/server/xpub/entities/user/helpers/elife-api.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-await-in-loop */
 const superagent = require('superagent')
+const config = require('config')
 const logger = require('@pubsweet/logger')
 
-const apiRoot = 'https://api.elifesciences.org/'
+const apiRoot = config.get('elife.api.url')
 
 // request data from orcid API
 const request = (endpoint, query = {}) =>


### PR DESCRIPTION
#### Background

Closes #727 

#### How has this been tested?

Locally by copying the JWT and resigning it.