### PR TITLE
feat: allow concurrent submissions

### DIFF
--- a/app/components/pages/Dashboard/Dashboard.js
+++ b/app/components/pages/Dashboard/Dashboard.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
+import { Link } from 'react-router-dom'
 import { Box } from 'grid-styled'
 import { Button } from '@pubsweet/ui'
 
 import { FormH2, FormH3 } from '../../ui/atoms/FormHeadings'
-import ButtonLink from '../../ui/atoms/ButtonLink'
 import Paragraph from '../../ui/atoms/Paragraph'
 
 /* Temporary dashboard view pending receipt of designs */
@@ -19,14 +19,14 @@ const Cell = styled.td`
   padding: 3px 6px;
 `
 
-const Dashboard = ({ manuscripts, deleteManuscript }) => (
+const Dashboard = ({ manuscripts, deleteManuscript, createSubmission }) => (
   <React.Fragment>
     <FormH2>Dashboard Dummy Page</FormH2>
 
     <Box mb={4}>
-      <ButtonLink data-test-id="submit" primary to="/submit">
+      <Button data-test-id="submit" onClick={createSubmission} primary>
         Submit a manuscript
-      </ButtonLink>
+      </Button>
     </Box>
 
     <FormH3>All manuscripts</FormH3>
@@ -47,7 +47,9 @@ const Dashboard = ({ manuscripts, deleteManuscript }) => (
             <tr key={manuscript.id}>
               <Cell data-test-id="title">
                 <Paragraph data-test-id="title">
-                  {manuscript.meta.title || '(Untitled manuscript)'}
+                  <Link to={`/submit/${manuscript.id}`}>
+                    {manuscript.meta.title || '(Untitled)'}
+                  </Link>
                 </Paragraph>
               </Cell>
               <Cell data-test-id="stage">{manuscript.status}</Cell>

--- a/app/components/pages/Dashboard/index.js
+++ b/app/components/pages/Dashboard/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import gql from 'graphql-tag'
 import { Query, Mutation } from 'react-apollo'
-import { GET_CURRENT_SUBMISSION } from '../SubmissionWizard/operations'
+import { CREATE_SUBMISSION } from '../SubmissionWizard/operations'
 import Dashboard from './Dashboard'
 
 export const MANUSCRIPTS_QUERY = gql`
@@ -22,7 +22,7 @@ export const DELETE_MANUSCRIPT_MUTATION = gql`
   }
 `
 
-const DashboardPage = () => (
+const DashboardPage = ({ history }) => (
   <Query query={MANUSCRIPTS_QUERY}>
     {({ data, loading, error }) => {
       if (loading) {
@@ -36,16 +36,26 @@ const DashboardPage = () => (
       return (
         <Mutation
           mutation={DELETE_MANUSCRIPT_MUTATION}
-          refetchQueries={[
-            { query: MANUSCRIPTS_QUERY },
-            { query: GET_CURRENT_SUBMISSION },
-          ]}
+          refetchQueries={[{ query: MANUSCRIPTS_QUERY }]}
         >
           {deleteManuscript => (
-            <Dashboard
-              deleteManuscript={id => deleteManuscript({ variables: { id } })}
-              manuscripts={data.manuscripts}
-            />
+            <Mutation mutation={CREATE_SUBMISSION}>
+              {createSubmission => (
+                <Dashboard
+                  createSubmission={() =>
+                    createSubmission().then(result =>
+                      history.push(
+                        `/submit/${result.data.createSubmission.id}`,
+                      ),
+                    )
+                  }
+                  deleteManuscript={id =>
+                    deleteManuscript({ variables: { id } })
+                  }
+                  manuscripts={data.manuscripts}
+                />
+              )}
+            </Mutation>
           )}
         </Mutation>
       )

--- a/app/components/pages/SubmissionWizard/index.js
+++ b/app/components/pages/SubmissionWizard/index.js
@@ -14,7 +14,7 @@ import { schema as disclosurePageSchema } from './steps/Disclosure/schema'
 import WizardStep from './WizardStep'
 
 const SubmissionWizard = ({ match, history }) => (
-  <WithCurrentSubmission>
+  <WithCurrentSubmission manuscriptId={match.params.id}>
     {({
       initialValues,
       updateSubmission,
@@ -32,8 +32,8 @@ const SubmissionWizard = ({ match, history }) => (
               handleUpdate={updateSubmission}
               history={history}
               initialValues={initialValues}
-              nextUrl={`${match.path}/submission`}
-              previousUrl={`${match.path}`}
+              nextUrl={`${match.url}/submission`}
+              previousUrl={`${match.url}`}
               step={1}
               title="Write your cover letter and upload your manuscript"
               validationSchema={filesPageSchema}
@@ -49,8 +49,8 @@ const SubmissionWizard = ({ match, history }) => (
               handleUpdate={updateSubmission}
               history={history}
               initialValues={initialValues}
-              nextUrl={`${match.path}/editors`}
-              previousUrl={`${match.path}/files`}
+              nextUrl={`${match.url}/editors`}
+              previousUrl={`${match.url}/files`}
               step={2}
               title="Help us get your work seen by the right people"
               validationSchema={submissionPageSchema}
@@ -66,8 +66,8 @@ const SubmissionWizard = ({ match, history }) => (
               handleUpdate={updateSubmission}
               history={history}
               initialValues={initialValues}
-              nextUrl={`${match.path}/disclosure`}
-              previousUrl={`${match.path}/submission`}
+              nextUrl={`${match.url}/disclosure`}
+              previousUrl={`${match.url}/submission`}
               step={3}
               title="Who should review your work?"
               validationSchema={editorsPageSchema}
@@ -84,7 +84,7 @@ const SubmissionWizard = ({ match, history }) => (
               history={history}
               initialValues={initialValues}
               nextUrl="/"
-              previousUrl={`${match.path}/editors`}
+              previousUrl={`${match.url}/editors`}
               step={4}
               submitButtonText="Submit"
               title="Disclosure of data to editors"
@@ -100,7 +100,7 @@ const SubmissionWizard = ({ match, history }) => (
               handleUpdate={updateSubmission}
               history={history}
               initialValues={initialValues}
-              nextUrl={`${match.path}/files`}
+              nextUrl={`${match.url}/files`}
               step={0}
               title="Your details"
               validationSchema={authorPageSchema}

--- a/app/components/pages/SubmissionWizard/operations.js
+++ b/app/components/pages/SubmissionWizard/operations.js
@@ -67,9 +67,9 @@ const manuscriptFragment = gql`
   ${reviewerFragment}
 `
 
-export const GET_CURRENT_SUBMISSION = gql`
-  query CurrentSubmission {
-    currentSubmission {
+export const GET_MANUSCRIPT = gql`
+  query GetManuscript($id: ID!) {
+    manuscript(id: $id) {
       ...WholeManuscript
     }
   }

--- a/app/routes.js
+++ b/app/routes.js
@@ -12,7 +12,7 @@ const Routes = () => (
       <Route component={LoginPage} path="/login" />
       <AuthenticatedComponent>
         <Switch>
-          <Route component={SubmissionWizard} path="/submit" />
+          <Route component={SubmissionWizard} path="/submit/:id" />
           <Route component={DashboardPage} />
         </Switch>
       </AuthenticatedComponent>

--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -24,18 +24,6 @@ const elifeApi = require('../user/helpers/elife-api')
 
 const resolvers = {
   Query: {
-    async currentSubmission(_, vars, { user }) {
-      const userUuid = await UserManager.getUuidForProfile(user)
-      const manuscripts = await ManuscriptManager.findByStatus(
-        ManuscriptManager.statuses.INITIAL,
-        userUuid,
-      )
-      if (!manuscripts.length) {
-        return null
-      }
-
-      return manuscripts[0]
-    },
     async manuscript(_, { id }, { user }) {
       const userUuid = await UserManager.getUuidForProfile(user)
       return ManuscriptManager.find(id, userUuid)

--- a/server/xpub/entities/manuscript/resolvers.test.js
+++ b/server/xpub/entities/manuscript/resolvers.test.js
@@ -43,84 +43,17 @@ describe('Submission', () => {
     mailer.clearMails()
   })
 
-  describe('currentSubmission', () => {
+  describe('manuscript', () => {
     it('Gets form data', async () => {
       const manuscriptData = {
         createdBy: userId,
-        meta: {
-          title: 'title',
-        },
-        status: 'INITIAL',
-      }
-      await Manuscript.save(manuscriptData)
-
-      const manuscript = await Query.currentSubmission(
-        {},
-        {},
-        { user: profileId },
-      )
-      expect(manuscript).toMatchObject(manuscriptData)
-    })
-
-    it('Returns null when there are no manuscripts in the db', async () => {
-      const manuscript = await Query.currentSubmission(
-        {},
-        {},
-        { user: profileId },
-      )
-      expect(manuscript).toBe(null)
-    })
-
-    it('Returns null when user has no manuscripts in the db (db not empty)', async () => {
-      await Manuscript.save({
-        createdBy: '9f72f2b8-bb4a-43fa-8b80-c7ac505c8c5f',
         meta: { title: 'title' },
         status: 'INITIAL',
-      })
-      await Manuscript.save({
-        createdBy: 'bcd735c6-9b62-441a-a085-7d1e8a7834c6',
-        meta: { title: 'title 2' },
-        status: Manuscript.statuses.MECA_EXPORT_PENDING,
-      })
+      }
+      const { id } = await Manuscript.save(manuscriptData)
 
-      const manuscript = await Query.currentSubmission(
-        {},
-        {},
-        { user: profileId },
-      )
-      expect(manuscript).toBeNull()
-    })
-
-    it('Returns manuscript object when user has one manuscripts in the db (db not empty)', async () => {
-      await Manuscript.save({
-        createdBy: '9f72f2b8-bb4a-43fa-8b80-c7ac505c8c5f',
-        meta: {
-          title: 'title',
-        },
-        status: 'INITIAL',
-      })
-      await Manuscript.save({
-        createdBy: 'bcd735c6-9b62-441a-a085-7d1e8a7834c6',
-        meta: {
-          title: 'title 2',
-        },
-        status: Manuscript.statuses.MECA_EXPORT_PENDING,
-      })
-      await Manuscript.save({
-        createdBy: userId,
-        meta: {
-          title: 'mine',
-        },
-        status: 'INITIAL',
-      })
-
-      const manuscript = await Query.currentSubmission(
-        {},
-        {},
-        { user: profileId },
-      )
-      expect(manuscript).not.toBeNull()
-      expect(manuscript.meta.title).toBe('mine')
+      const manuscript = await Query.manuscript({}, { id }, { user: profileId })
+      expect(manuscript).toMatchObject(manuscriptData)
     })
   })
 

--- a/server/xpub/entities/manuscript/typeDefs.graphqls
+++ b/server/xpub/entities/manuscript/typeDefs.graphqls
@@ -1,5 +1,4 @@
 extend type Query {
-  currentSubmission: Manuscript
   manuscript(id: ID!): Manuscript!
   manuscripts: [Manuscript]!
 }

--- a/test/pageObjects/author.js
+++ b/test/pageObjects/author.js
@@ -2,7 +2,9 @@ import config from 'config'
 import { Selector } from 'testcafe'
 
 const author = {
-  url: `${config.get('pubsweet-server.baseUrl')}/submit`,
+  url: new RegExp(
+    `${config.get('pubsweet-server.baseUrl')}/submit/[a-f0-9-]{36}`,
+  ),
   orcidPrefill: Selector('[data-test-id=orcid-prefill]'),
   firstNameField: Selector('[name="author.firstName"]'),
   secondNameField: Selector('[name="author.lastName"]'),

--- a/test/pageObjects/disclosure.js
+++ b/test/pageObjects/disclosure.js
@@ -2,7 +2,9 @@ import config from 'config'
 import { Selector } from 'testcafe'
 
 const disclosure = {
-  url: `${config.get('pubsweet-server.baseUrl')}/submit/disclosure`,
+  url: new RegExp(
+    `${config.get('pubsweet-server.baseUrl')}/submit/[a-f0-9-]{36}/disclosure`,
+  ),
   submitterName: Selector('[name="submitterSignature"]'),
   consentCheckbox: Selector('[name="disclosureConsent"]').parent(),
 }

--- a/test/pageObjects/editors.js
+++ b/test/pageObjects/editors.js
@@ -2,7 +2,9 @@ import config from 'config'
 import { Selector } from 'testcafe'
 
 const editors = {
-  url: `${config.get('pubsweet-server.baseUrl')}/submit/editors`,
+  url: new RegExp(
+    `${config.get('pubsweet-server.baseUrl')}/submit/[a-f0-9-]{36}/editors`,
+  ),
   suggestedSeniorEditorSelection: Selector(
     '[data-test-id="suggested-senior-editors"] [data-test-id="person-pod-button"]',
   ),

--- a/test/pageObjects/files.js
+++ b/test/pageObjects/files.js
@@ -2,7 +2,9 @@ import config from 'config'
 import { Selector } from 'testcafe'
 
 const files = {
-  url: `${config.get('pubsweet-server.baseUrl')}/submit/files`,
+  url: new RegExp(
+    `${config.get('pubsweet-server.baseUrl')}/submit/[a-f0-9-]{36}/files`,
+  ),
   editor: Selector('[name="coverLetter"] div[contenteditable=true]'),
   manuscriptUpload: Selector('[data-test-id=upload]>input'),
 }

--- a/test/pageObjects/submission.js
+++ b/test/pageObjects/submission.js
@@ -2,7 +2,9 @@ import config from 'config'
 import { Selector } from 'testcafe'
 
 const submission = {
-  url: `${config.get('pubsweet-server.baseUrl')}/submit/submission`,
+  url: new RegExp(
+    `${config.get('pubsweet-server.baseUrl')}/submit/[a-f0-9-]{36}/submission`,
+  ),
   title: Selector('[name="meta.title"]'),
   articleType: Selector('[role=listbox] button'),
   articleTypes: Selector('[role=option]'),

--- a/test/submission.e2e.js
+++ b/test/submission.e2e.js
@@ -184,11 +184,11 @@ test('Ability to progress through the wizard is tied to validation', async t => 
     // without this wait the tests sometimes fail on CI ¯\_(ツ)_/¯
     .wait(1000)
     .expect(getPageUrl())
-    .eql(author.url, 'Validation errors prevent progress to the next page')
+    .match(author.url, 'Validation errors prevent progress to the next page')
     .typeText(author.emailField, '.ac.uk')
     .click(wizardStep.next)
     .expect(getPageUrl())
-    .eql(files.url, 'Entering valid inputs enables progress to the next page')
+    .match(files.url, 'Entering valid inputs enables progress to the next page')
 })
 
 test('Form entries are saved when a user navigates to the next page of the wizard', async t => {


### PR DESCRIPTION
#### Background

- Make the "Submit a manuscript" button always create a new submission
- Update the wizard to include the manuscript UUID in the URL
- Remove `currentSubmission` query and resolver
- Link manuscripts on the dashboard to the in progress submission

#### Any relevant tickets

Closes #730 and addresses most of #732.

#### How has this been tested?

Needs more end to end tests but delaying until Dashboard is available.