### PR TITLE
Copy New Relic configuration into container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,16 @@ RUN yarn install --frozen-lockfile \
     && yarn cache clean \
     && rm -rf /npm-packages-offline-cache
 
-COPY app.js .babelrc .eslintignore .eslintrc .prettierrc .stylelintignore .stylelintrc ./
+COPY \
+    app.js \
+    newrelic.js \
+    .babelrc \
+    .eslintignore \
+    .eslintrc \
+    .prettierrc \
+    .stylelintignore \
+    .stylelintrc \
+    ./
 
 COPY app app
 COPY config config


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/619, it seems it should be included at the top level:

```
elife@staging--xpub:/srv/elife-xpub$ docker-compose exec app /bin/bash
root@2f2e41886e72:~# ls -la
total 768
drwxr-xr-x    1 root root   4096 Oct  9 11:20 .
drwxr-xr-x    1 root root   4096 Jan  8  2018 ..
drwxr-xr-x    2 root root   4096 Oct  9 11:14 .aws
-rw-rw-rw-    1 root root     44 Oct  9 09:21 .babelrc
-rw-------    1 root root      6 Oct  9 11:20 .bash_history
-rw-rw-rw-    1 root root     29 Oct  9 09:21 .eslintignore
-rw-rw-rw-    1 root root    660 Oct  9 09:21 .eslintrc
drwxr-xr-x    3 root root   4096 Oct  9 09:23 .node-gyp
drwxr-xr-x    3 root root   4096 Jan  8  2018 .npm
-rw-rw-rw-    1 root root     69 Oct  9 09:21 .prettierrc
-rw-rw-rw-    1 root root     26 Oct  9 09:21 .stylelintignore
-rw-rw-rw-    1 root root     45 Oct  9 09:21 .stylelintrc
drwxr-xr-x    4 root root   4096 Oct  9 09:25 _build
drwxr-xr-x    1 root root   4096 Oct  9 09:24 app
-rw-rw-rw-    1 root root    217 Oct  9 09:21 app.js
drwxr-xr-x    4 root root   4096 Oct  9 09:22 client
drwxr-xr-x    3 root root   4096 Oct  9 09:24 config
drwxr-xr-x 1623 root root  61440 Oct  9 09:23 node_modules
-rw-rw-rw-    1 root root   4872 Oct  4 15:01 package.json
drwxr-xr-x    3 root root   4096 Oct  9 09:24 scripts
drwxr-xr-x    1 root root   4096 Oct  9 09:22 server
drwxr-xr-x    3 root root   4096 Oct  9 09:24 static
drwxr-xr-x    6 root root   4096 Oct  9 09:24 test
drwxr-xr-x    2 root root   4096 Oct  9 11:14 uploads
drwxr-xr-x    2 root root   4096 Oct  9 09:24 webpack
-rw-rw-rw-    1 root root 616055 Oct  4 15:01 yarn.lock
```