### PR TITLE
Update development docs

### DIFF
--- a/docs/developing/README.md
+++ b/docs/developing/README.md
@@ -1,5 +1,6 @@
 # Developer's Documentation
 
+- [Quick Start](quick-start.md)
 - [Architecture](architecture.md)
 - [Styleguide](styleguide.md)
 - [PubSweet Components](pubsweet.md)

--- a/docs/developing/quick-start.md
+++ b/docs/developing/quick-start.md
@@ -24,11 +24,12 @@ Otherwise the instructions below should be sufficient to get started quickly.
     - This should export an empty (for now) object
     - Use it to hold any configuration that should not be checked into source control
     - Refer to `config/default.js` for a list of possible config keys
-  - Add database configuration if necessary
-    - In most cases the defaults should work without additional configuration
-    - To run postgres within a docker container use the command `docker-compose up -d postgres`
-    - To setup the database, run `npx pubsweet setupdb --clobber`, and `npx pubsweet migrate`
-- Start the app with `npm run server`
+    - In most cases the default settings should work without additional configuration
+- Start any dependencies
+  - All necessary dependencies can be started by running `yarn start:services`
+  - To run dependencies within the background use the command `docker-compose up -d postgres fakes3`
+  - To setup the database, run `npx pubsweet setupdb --clobber`, and `npx pubsweet migrate`
+- Start the app with `yarn server`
   - Visit <http://localhost:3000>
 
 ## Other Dependencies

--- a/docs/developing/quick-start.md
+++ b/docs/developing/quick-start.md
@@ -27,6 +27,7 @@ Otherwise the instructions below should be sufficient to get started quickly.
   - Add database configuration if necessary
     - In most cases the defaults should work without additional configuration
     - To run postgres within a docker container use the command `docker-compose up -d postgres`
+    - To setup the database, run `npx pubsweet setupdb --clobber`, and `npx pubsweet migrate`
 - Start the app with `npm run server`
   - Visit <http://localhost:3000>
 


### PR DESCRIPTION
- Made `docs/development/quick-start.md` easier to find
- Added a section on starting dependencies locally
- Using `yarn` rather than `npm run`, since we're already using yarn to install dependencies