### PR TITLE
feat: add login interstitial

### DIFF
--- a/app/components/global/AppBar.js
+++ b/app/components/global/AppBar.js
@@ -2,10 +2,9 @@ import React from 'react'
 import { Link, withRouter } from 'react-router-dom'
 import { graphql, compose } from 'react-apollo'
 import { AppBar } from '@pubsweet/ui'
-import { withLoader } from 'pubsweet-client'
 import { CURRENT_USER } from './queries'
 
-const ElifeAppBar = ({ history, currentUser }) => (
+const ElifeAppBar = ({ history, data }) => (
   <AppBar
     brand={<img alt="eLife" src="/assets/elife-logo.png" />}
     navLinkComponents={[<Link to="/">Dashboard</Link>]}
@@ -13,10 +12,11 @@ const ElifeAppBar = ({ history, currentUser }) => (
       window.localStorage.removeItem('token')
       history.push('/')
     }}
-    user={currentUser}
+    user={data.currentUser}
   />
 )
 
-export default compose(withRouter, graphql(CURRENT_USER), withLoader())(
-  ElifeAppBar,
-)
+export default compose(
+  withRouter,
+  graphql(CURRENT_USER),
+)(ElifeAppBar)

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,22 +2,24 @@ import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 
 import { AuthenticatedComponent, Layout } from './components/global'
+import ErrorPage from './components/pages/Error'
 import LoginPage from './components/pages/Login'
 import SubmissionWizard from './components/pages/SubmissionWizard'
 import DashboardPage from './components/pages/Dashboard'
 
 const Routes = () => (
-  <Switch>
-    <Layout>
-      <Route component={LoginPage} path="/login" />
+  <Layout>
+    <Switch>
+      <Route component={LoginPage} exact path="/login" />
       <AuthenticatedComponent>
         <Switch>
           <Route component={SubmissionWizard} path="/submit/:id" />
-          <Route component={DashboardPage} />
+          <Route component={DashboardPage} exact path="/" />
+          <ErrorPage error="404: page not found" />
         </Switch>
       </AuthenticatedComponent>
-    </Layout>
-  </Switch>
+    </Switch>
+  </Layout>
 )
 
 export default Routes

--- a/config/default.js
+++ b/config/default.js
@@ -42,6 +42,8 @@ module.exports = {
     // TODO swap this mock for the Journal endpoint when available
     url: '/mock-token-exchange/ewwboc7m',
     enableMock: true,
+    signupUrl: 'https://orcid.org/register',
+    legacySubmissionUrl: 'https://submit.elifesciences.org',
   },
   mailer: {
     from: 'dev@example.com',

--- a/server/xpub/entities/user/routes.js
+++ b/server/xpub/entities/user/routes.js
@@ -10,7 +10,7 @@ module.exports = app => {
       const mockProfileId = req.params.id
       logger.info('Signing mock JWT for profile ID', mockProfileId)
       const xpubToken = jwt.sign(
-        { id: mockProfileId, iss: 'journal' },
+        { id: mockProfileId, iss: 'journal', 'new-session': true },
         secret,
         { expiresIn: '1m' },
       )


### PR DESCRIPTION
#### Background

Closes #735 

- Read JWT on client and respond to `new-session` claim.
   - If `false` this means the user was already logged in to Journal so show interstitial with 'Continue' button
   - If `true` user has already been shown xPub log in screen so redirect straight to dashboard
- Update the login screen text and layout (took a few liberties with the second paragraph of text).

