### PR TITLE
fix: meca article.xml tweaks

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Submission/SubjectAreaDropdown.js
+++ b/app/components/pages/SubmissionWizard/steps/Submission/SubjectAreaDropdown.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled, { withTheme } from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
 import Select, { createFilter, components } from 'react-select'
+import config from 'config'
 
 import Icon from '../../../../ui/atoms/Icon'
 
@@ -24,52 +25,11 @@ const SelectLimitMessage = styled.p`
   color: ${th('colorSuccess')};
 `
 
-const eLifeOptions = [
-  {
-    value: 'biochemistry-chemical-biology',
-    label: 'Biochemistry and Chemical Biology',
-  },
-  { value: 'cancer-biology', label: 'Cancer Biology' },
-  { value: 'cell-biology', label: 'Cell Biology' },
-  {
-    value: 'chromosomes-gene-expression',
-    label: 'Chromosomes and Gene Expression',
-  },
-  {
-    value: 'computational-systems-biology',
-    label: 'Computational and Systems Biology',
-  },
-  {
-    value: 'developmental-biology-stem-cells',
-    label: 'Developmental Biology and Stem Cells',
-  },
-  { value: 'ecology', label: 'Ecology' },
-  {
-    value: 'epidemiology-global-health',
-    label: 'Epidemiology and Global Health',
-  },
-  { value: 'evolutionary-biology', label: 'Evolutionary Biology' },
-  { value: 'genetics-genomics', label: 'Genetics and Genomics' },
-  {
-    value: 'human-biology-medicine',
-    label: 'Human Biology and Medicine',
-  },
-  {
-    value: 'immunology-inflammation',
-    label: 'Immunology and Inflammation',
-  },
-  {
-    value: 'microbiology-infectious-disease',
-    label: 'Microbiology and Infectious Disease',
-  },
-  { value: 'neuroscience', label: 'Neuroscience' },
-  { value: 'physics-living-systems', label: 'Physics of Living Systems' },
-  { value: 'plant-biology', label: 'Plant Biology' },
-  {
-    value: 'structural-biology-molecular-biophysics',
-    label: 'Structural Biology and Molecular Biophysics',
-  },
-]
+const subjectAreas = config.elife.majorSubjectAreas
+const eLifeOptions = Object.keys(subjectAreas).reduce(
+  (options, code) => options.concat({ value: code, label: subjectAreas[code] }),
+  [],
+)
 
 class SubjectAreaDropdown extends React.Component {
   constructor(props) {

--- a/config/default.js
+++ b/config/default.js
@@ -37,6 +37,27 @@ module.exports = {
     api: {
       url: 'https://api.elifesciences.org/',
     },
+    majorSubjectAreas: {
+      'biochemistry-chemical-biology': 'Biochemistry and Chemical Biology',
+      'cancer-biology': 'Cancer Biology',
+      'cell-biology': 'Cell Biology',
+      'chromosomes-gene-expression': 'Chromosomes and Gene Expression',
+      'computational-systems-biology': 'Computational and Systems Biology',
+      'developmental-biology-stem-cells':
+        'Developmental Biology and Stem Cells',
+      ecology: 'Ecology',
+      'epidemiology-global-health': 'Epidemiology and Global Health',
+      'evolutionary-biology': 'Evolutionary Biology',
+      'genetics-genomics': 'Genetics and Genomics',
+      'human-biology-medicine': 'Human Biology and Medicine',
+      'immunology-inflammation': 'Immunology and Inflammation',
+      'microbiology-infectious-disease': 'Microbiology and Infectious Disease',
+      neuroscience: 'Neuroscience',
+      'physics-living-systems': 'Physics of Living Systems',
+      'plant-biology': 'Plant Biology',
+      'structural-biology-molecular-biophysics':
+        'Structural Biology and Molecular Biophysics',
+    },
   },
   login: {
     // TODO swap this mock for the Journal endpoint when available
@@ -95,5 +116,6 @@ module.exports = {
     'validations',
     'fileUpload',
     'login',
+    'elife.majorSubjectAreas',
   ],
 }

--- a/server/meca/__snapshots__/export.test.js.snap
+++ b/server/meca/__snapshots__/export.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MECA integration test when generating an archive should contain the correct files 1`] = `
+Object {
+  "article.xml": 6040,
+  "cover_letter.html": 743,
+  "disclosure.pdf": Any<Number>,
+  "manifest.xml": 1510,
+  "manuscript.pdf": 14,
+  "transfer.xml": 1951,
+}
+`;

--- a/server/meca/export.test.js
+++ b/server/meca/export.test.js
@@ -48,30 +48,16 @@ describe('MECA integration test', () => {
   })
 
   describe('when generating an archive', () => {
-    const RealDate = global.Date
-
     it('should contain the correct files', async () => {
-      global.Date = class extends RealDate {
-        constructor() {
-          super()
-          return new RealDate(1538059378578)
-        }
-      }
       await mecaExport(sampleManuscript, 'This is a test')
-      global.Date = RealDate
 
       const finalName = `${sampleManuscript.id}${mecaPostfix}`
       const zip = await JsZip.loadAsync(
         sftp.mockFs.readFileSync(`/test/${finalName}`),
       )
 
-      expect(getFileSizes(zip)).toEqual({
-        'article.xml': 6145,
-        'cover_letter.html': 743,
+      expect(getFileSizes(zip)).toMatchSnapshot({
         'disclosure.pdf': expect.any(Number),
-        'manifest.xml': 1510,
-        'manuscript.pdf': 14,
-        'transfer.xml': 1951,
       })
 
       expect(getFilenames(zip)).toEqual([

--- a/server/meca/file-generators/__snapshots__/article.test.js.snap
+++ b/server/meca/file-generators/__snapshots__/article.test.js.snap
@@ -1,0 +1,193 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Article XML generator generates expected XML 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
+<!DOCTYPE article SYSTEM \\"JATS-journalpublishing1.dtd\\">
+<article>
+  <front>
+    <journal-meta>
+      <journal-id journal-id-type=\\"pmc\\"/>
+      <journal-id journal-id-type=\\"publisher\\"/>
+      <issn/>
+      <publisher>
+        <publisher-name/>
+      </publisher>
+    </journal-meta>
+    <article-meta>
+      <article-id pub-id-type=\\"manuscript\\">604e06ca-882d-4b5b-a147-e016893e60e9</article-id>
+      <article-categories>
+        <subj-group subj-group-type=\\"article_type\\">
+          <subject>5</subject>
+        </subj-group>
+        <subj-group>
+          <subj-group subj-group-type=\\"subject_areas\\">
+            <subject>Biochemistry and Chemical Biology</subject>
+          </subj-group>
+        </subj-group>
+        <subj-group>
+          <subj-group subj-group-type=\\"subject_areas\\">
+            <subject>Chromosomes and Gene Expression</subject>
+          </subj-group>
+        </subj-group>
+      </article-categories>
+      <title-group>
+        <article-title>Test Manuscript</article-title>
+      </title-group>
+      <contrib-group content-type=\\"authors\\">
+        <contrib contrib-type=\\"author\\" corresp=\\"yes\\">
+          <name>
+            <surname>User</surname>
+            <given-names>Test</given-names>
+          </name>
+          <email>elife@mailinator.com</email>
+          <xref ref-type=\\"aff\\" rid=\\"aff6\\"/>
+        </contrib>
+      </contrib-group>
+      <contrib-group content-type=\\"potential_senior_editors\\">
+        <contrib contrib-type=\\"suggested_senior_editor\\">
+          <name>
+            <surname>Andrea Musacchio</surname>
+            <given-names/>
+          </name>
+          <email/>
+          <xref ref-type=\\"aff\\" rid=\\"aff1\\"/>
+        </contrib>
+        <contrib contrib-type=\\"suggested_senior_editor\\">
+          <name>
+            <surname>Arup K Chakraborty</surname>
+            <given-names/>
+          </name>
+          <email/>
+          <xref ref-type=\\"aff\\" rid=\\"aff1\\"/>
+        </contrib>
+        <contrib contrib-type=\\"opposed_senior_editor\\">
+          <name>
+            <surname>Arup K Chakraborty</surname>
+            <given-names/>
+          </name>
+          <email/>
+          <xref ref-type=\\"aff\\" rid=\\"aff1\\"/>
+        </contrib>
+      </contrib-group>
+      <contrib-group content-type=\\"potential_reviewing_editors\\">
+        <contrib contrib-type=\\"suggested_reviewing_editor\\">
+          <name>
+            <surname>Alan G Hinnebusch</surname>
+            <given-names/>
+          </name>
+          <email/>
+          <xref ref-type=\\"aff\\" rid=\\"aff4\\"/>
+        </contrib>
+        <contrib contrib-type=\\"suggested_reviewing_editor\\">
+          <name>
+            <surname>Alejandro Sanchez Alvarado</surname>
+            <given-names/>
+          </name>
+          <email/>
+          <xref ref-type=\\"aff\\" rid=\\"aff5\\"/>
+        </contrib>
+        <contrib contrib-type=\\"opposed_reviewing_editor\\">
+          <name>
+            <surname>Aleksandra Walczak</surname>
+            <given-names/>
+          </name>
+          <email/>
+          <xref ref-type=\\"aff\\" rid=\\"aff0\\"/>
+        </contrib>
+      </contrib-group>
+      <contrib-group content-type=\\"potential_reviewers\\">
+        <contrib contrib-type=\\"suggested_reviewer\\">
+          <name>
+            <surname>Reviewer</surname>
+            <given-names>J. Edward</given-names>
+          </name>
+          <email>edward@example.com</email>
+        </contrib>
+        <contrib contrib-type=\\"suggested_reviewer\\">
+          <name>
+            <surname>de Reviewer</surname>
+            <given-names>Frances</given-names>
+          </name>
+          <email>frances@example.org</email>
+        </contrib>
+        <contrib contrib-type=\\"suggested_reviewer\\">
+          <name>
+            <surname>Reviewer</surname>
+            <given-names>Gertrude</given-names>
+          </name>
+          <email>gertrude@example.net</email>
+        </contrib>
+        <contrib contrib-type=\\"opposed_reviewer\\">
+          <name>
+            <surname>Hoo</surname>
+            <given-names/>
+          </name>
+          <email>laughing@example.com</email>
+        </contrib>
+        <contrib contrib-type=\\"opposed_reviewer\\">
+          <name>
+            <surname>Who</surname>
+            <given-names/>
+          </name>
+          <email>singing@example.com</email>
+        </contrib>
+      </contrib-group>
+      <aff id=\\"aff0\\">
+        <institution>Ecole normale superieure</institution>
+      </aff>
+      <aff id=\\"aff1\\">
+        <institution/>
+      </aff>
+      <aff id=\\"aff2\\">
+        <institution/>
+      </aff>
+      <aff id=\\"aff3\\">
+        <institution/>
+      </aff>
+      <aff id=\\"aff4\\">
+        <institution>National Institute of Child Health and Human Development</institution>
+      </aff>
+      <aff id=\\"aff5\\">
+        <institution>Stowers Institute for Medical Research</institution>
+      </aff>
+      <aff id=\\"aff6\\">
+        <institution>University of eLife</institution>
+      </aff>
+      <author-notes>
+        <fn>
+          <p/>
+        </fn>
+      </author-notes>
+      <pub-date>
+        <day/>
+        <month/>
+        <year/>
+      </pub-date>
+      <related-article related-article-type=\\"companion\\">
+        <article-title>asdassss</article-title>
+      </related-article>
+      <related-article related-article-type=\\"companion\\">
+        <article-title>Another</article-title>
+      </related-article>
+      <custom-meta-group>
+        <custom-meta>
+          <meta-name>suggestions-conflict</meta-name>
+          <meta-value>true</meta-value>
+        </custom-meta>
+        <custom-meta>
+          <meta-name>previously-discussed</meta-name>
+          <meta-value>Talked to bob about it</meta-value>
+        </custom-meta>
+        <custom-meta>
+          <meta-name>previously-submitted</meta-name>
+          <meta-value>Original Test Title</meta-value>
+        </custom-meta>
+        <custom-meta>
+          <meta-name>created-by</meta-name>
+          <meta-value>6d8cd1ce-15b6-46c1-b901-bc91598c8f2d</meta-value>
+        </custom-meta>
+      </custom-meta-group>
+    </article-meta>
+  </front>
+</article>"
+`;

--- a/server/meca/file-generators/article.helpers.js
+++ b/server/meca/file-generators/article.helpers.js
@@ -30,15 +30,15 @@ const contribStructure = {
       },
     }),
   },
-  'potential-senior-editors': {
+  potential_senior_editors: {
     keys: ['suggestedSeniorEditor', 'opposedSeniorEditor'],
     formatter: editorFormatter,
   },
-  'potential-reviewing-editors': {
+  potential_reviewing_editors: {
     keys: ['suggestedReviewingEditor', 'opposedReviewingEditor'],
     formatter: editorFormatter,
   },
-  'potential-reviewers': {
+  potential_reviewers: {
     keys: ['suggestedReviewer', 'opposedReviewer'],
     formatter: (member, affiliations, editorsById, reviewerMap) => {
       const { name } = member.meta

--- a/server/meca/file-generators/article.js
+++ b/server/meca/file-generators/article.js
@@ -1,5 +1,6 @@
 const xmlbuilder = require('xmlbuilder')
 const lodash = require('lodash')
+const config = require('config')
 const elifeApi = require('@elifesciences/xpub-server/entities/user/helpers/elife-api')
 const {
   articleTypeMap,
@@ -7,6 +8,8 @@ const {
   journalMeta,
 } = require('./article.helpers')
 const nameSplitter = require('../services/nameSplitter')
+
+const subjectAreas = config.get('elife.majorSubjectAreas')
 
 function createXmlObject(manuscript, editorsById, affiliations, reviewerMap) {
   return {
@@ -20,15 +23,14 @@ function createXmlObject(manuscript, editorsById, affiliations, reviewerMap) {
       'article-categories': {
         'subj-group': [].concat(
           {
-            '@subj-group-type': 'article-type',
-            subject: manuscript.meta.articleType,
-          },
-          {
-            '@subj-group-type': 'article-type-id',
+            '@subj-group-type': 'article_type',
             subject: articleTypeMap[manuscript.meta.articleType],
           },
           manuscript.meta.subjects.map(subject => ({
-            'subj-group': { '@subj-group-type': 'keywords', subject },
+            'subj-group': {
+              '@subj-group-type': 'subject_areas',
+              subject: subjectAreas[subject],
+            },
           })),
         ),
       },
@@ -44,7 +46,7 @@ function createXmlObject(manuscript, editorsById, affiliations, reviewerMap) {
             if (team) {
               return contribs.concat(
                 team.teamMembers.map(member => ({
-                  '@contrib-type': lodash.kebabCase(role),
+                  '@contrib-type': lodash.snakeCase(role),
                   ...groupInfo.formatter(
                     member,
                     affiliations,

--- a/server/meca/file-generators/article.test.js
+++ b/server/meca/file-generators/article.test.js
@@ -8,47 +8,19 @@ const existingNames = [{ id: 1, first: 'J. Edward', last: 'Reviewer' }]
 
 Replay.fixtures = `${__dirname}/../test/http-mocks`
 
-const snippets = [
-  ['doctype', '<!DOCTYPE article SYSTEM "JATS-journalpublishing1.dtd">'],
-  [
-    'article id',
-    '<article-id pub-id-type="manuscript">604e06ca-882d-4b5b-a147-e016893e60e9</article-id>',
-  ],
-  ['article type', '<subject>research-article</subject>'],
-  ['article type id', '<subject>5</subject>'],
-  ['subject area ID', '<subject>chromosomes-gene-expression</subject>'],
-  ['title', '<article-title>Test Manuscript</article-title>'],
-  ['previously discussed', '<meta-value>Talked to bob about it</meta-value>'],
-  [
-    'created by',
-    '<meta-value>6d8cd1ce-15b6-46c1-b901-bc91598c8f2d</meta-value>',
-  ],
-  ['author email', '<email>elife@mailinator.com</email>'],
-  ['multipart reviewer forename', '<given-names>J. Edward</given-names>'],
-  ['multipart reviewer surname', '<surname>de Reviewer</surname>'],
-  [
-    'related article',
-    `<related-article related-article-type="companion">
-        <article-title>Another</article-title>
-      </related-article>`,
-  ],
-]
-
 describe('Article XML generator', () => {
   beforeAll(async () => {
     await createTables(true)
     await db.table('ejp_name').insert(existingNames)
   })
 
-  describe('sample output', () => {
-    test.each(snippets)('includes %s', async (name, snippet) => {
-      const xml = await generateXml(sampleManuscript)
-      expect(xml).toContain(snippet)
-    })
-  })
-
   it("doesn't choke on missing teams", async () => {
     const manuscriptWithoutTeams = { ...sampleManuscript, teams: [] }
     await generateXml(manuscriptWithoutTeams)
+  })
+
+  it('generates expected XML', async () => {
+    const xml = await generateXml(sampleManuscript)
+    expect(xml).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
#### Background

Closes #771 

- I made the assumption that the major subject area text eJP matches against is the text label as displayed in the "Major Subject Area(s)" page of the submission form.
- Moved definition of subject areas into config to enable mapping from our internal ID to the external label.
- Swapped the ad-hoc XML testing for a snapshot test as this provides a nicer diff when things change
