### PR TITLE
Create Modal dialog component

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.js
@@ -24,7 +24,7 @@ const MainColumn = styled(Box).attrs({ mx: [0, 0, 0, '16.666%'] })`
 `
 
 const PeoplePickerModal = ({ open, title, ...props }) => (
-  <ModalOverlay open={open}>
+  <ModalOverlay open={open} transparentBackground={false}>
     <PeoplePicker {...props}>
       {innerProps => (
         <React.Fragment>

--- a/app/components/ui/molecules/ModalDialog.js
+++ b/app/components/ui/molecules/ModalDialog.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import { Flex, Box } from 'grid-styled'
+import { th } from '@pubsweet/ui-toolkit'
+import { Button } from '@pubsweet/ui'
+
+import ModalOverlay from './ModalOverlay'
+
+const MiddleAligner = styled(Flex)`
+  height: 100%;
+`
+
+const WhiteBox = styled(Box)`
+  background-color: ${th('colorBackground')};
+  text-align: center;
+`
+
+const ModalDialog = ({
+  acceptText,
+  cancelText,
+  children,
+  onAccept,
+  onCancel,
+  open,
+  transparentBackground,
+  ...props
+}) => (
+  <ModalOverlay
+    open={open}
+    transparentBackground={transparentBackground}
+    {...props}
+  >
+    <MiddleAligner alignItems="center" justifyContent="center">
+      <WhiteBox p={3}>
+        {children}
+        <Flex>
+          <Box mr={3}>
+            <Button onClick={onCancel}>{cancelText}</Button>
+          </Box>
+          <Box>
+            <Button onClick={onAccept} primary>
+              {acceptText}
+            </Button>
+          </Box>
+        </Flex>
+      </WhiteBox>
+    </MiddleAligner>
+  </ModalOverlay>
+)
+
+ModalDialog.propTypes = {
+  acceptText: PropTypes.string.isRequired,
+  cancelText: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  onAccept: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  transparentBackground: PropTypes.bool.isRequired,
+}
+
+export default ModalDialog

--- a/app/components/ui/molecules/ModalDialog.md
+++ b/app/components/ui/molecules/ModalDialog.md
@@ -1,0 +1,24 @@
+White modal dialog in the centre of the viewport, surrounded by greyed-out background
+
+```js
+const FormH2 = require('../atoms/FormHeadings.js').FormH2
+;<div>
+  <button onClick={() => setState({ open: true })}>Open</button>
+  <ModalDialog
+    acceptText="Yeeeeah"
+    cancelText="woah now"
+    onAccept={() => {
+      console.log('accepted')
+    }}
+    onCancel={() => setState({ open: false })}
+    open={state.open}
+    transparentBackground={true}
+  >
+    <FormH2>Title</FormH2>
+    <p>This is a dialog box</p>
+    <p>This is a dialog box</p>
+    <p>This is a dialog box</p>
+    <p>This is a dialog box</p>
+  </ModalDialog>
+</div>
+```

--- a/app/components/ui/molecules/ModalOverlay.js
+++ b/app/components/ui/molecules/ModalOverlay.js
@@ -14,7 +14,10 @@ const Container = styled.div`
   width: 100vw;
   height: 100vh;
   z-index: 1500;
-  background: ${th('colorBackground')};
+  background: ${props =>
+    props.transparentBackground
+      ? `rgba(0, 0, 0, 0.8)`
+      : props.theme.colorBackground};
   transition: opacity ${th('transitionDuration')}
     ${th('transitionTimingFunction')};
   overflow-y: auto;
@@ -43,7 +46,7 @@ function cssTimeToMilliseconds(timeString) {
   }
 }
 
-const ModalOverlay = ({ children, open, theme }) => (
+const ModalOverlay = ({ children, open, theme, transparentBackground }) => (
   <Root aria-live="assertive">
     <CSSTransition
       classNames="modal"
@@ -52,7 +55,7 @@ const ModalOverlay = ({ children, open, theme }) => (
       timeout={cssTimeToMilliseconds(theme.transitionDuration)}
       unmountOnExit
     >
-      <Container>
+      <Container transparentBackground={transparentBackground}>
         {children}
         <ScrollLock />
       </Container>
@@ -63,6 +66,7 @@ const ModalOverlay = ({ children, open, theme }) => (
 ModalOverlay.propTypes = {
   open: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
+  transparentBackground: PropTypes.bool.isRequired,
 }
 
 export default withTheme(ModalOverlay)

--- a/yarn.lock
+++ b/yarn.lock
@@ -13530,7 +13530,7 @@ styled-normalize@^3.0.1:
   resolved "https://registry.yarnpkg.com/styled-normalize/-/styled-normalize-3.0.1.tgz#217efb96598690addd04699ca71af0db3473fea2"
   integrity sha512-EtTwCJDKMoJ+GU0YxklkHukltPGz7Swfq/fKyeP/WEQGF01DXGVXmuo1Rp2kMTQ9kz7o6dVBvvmT+KQyKe8Okw==
 
-"styled-system@>=2.0.0 || >=3.0.0", styled-system@^2.3.1:
+styled-system@2.3.6, "styled-system@>=2.0.0 || >=3.0.0", styled-system@^2.3.1:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-2.3.6.tgz#a38c1ffa04a5c35adec46473984e463c48b16f7c"
   integrity sha512-lGAh/8tC70f5hBUD7w0UOWCKyOBK2AzzWKu9BGzqla/Yjx8PzrvaciA7uATbm493hXTfRrecSdLdrIUET5IYnA==


### PR DESCRIPTION
#### What does this PR do?
- Add prop to `ModalOverlay` for specifying whether background is "transparent" or not i.e. whether backgroundColour should be white (as in PeoplePicker's full-screen modal) or black with opacity 0.8 (as with small modals)
- Use `ModalOverlay` with transparent background to build new `ModalDialog` component i.e.
  - a white box in the middle of the viewport
  - 24px margin round the outside
  - text in the top half
  - 2 buttons at the bottom - "cancel" on the left & "accept" on the right

#### Any relevant tickets
fixes #779 