### PR TITLE
fix: enable login mock on staging

### DIFF
--- a/config/staging.js
+++ b/config/staging.js
@@ -9,8 +9,4 @@ module.exports = {
       url: 'https://continuumtest--gateway.elifesciences.org/',
     },
   },
-  login: {
-    url: 'https://continuumtest--journal.elifesciences.org/submit',
-    enableMock: false,
-  },
 }


### PR DESCRIPTION
Allows users to get past login on Staging while #787 is addressed. Production already has the login mock enabled, which allows us to use it for testing.