### PR TITLE
fix: prevent updating submitted manuscript

### DIFF
--- a/app/components/pages/SubmissionWizard/AutoSave.js
+++ b/app/components/pages/SubmissionWizard/AutoSave.js
@@ -22,7 +22,7 @@ export default class AutoSave extends React.Component {
   }
 
   save() {
-    if (!_.isEqual(this.oldValues, this.props.values)) {
+    if (!this.props.disabled && !_.isEqual(this.oldValues, this.props.values)) {
       this.props.onSave(this.props.values)
       this.oldValues = _.cloneDeep(this.props.values)
     }
@@ -34,7 +34,12 @@ export default class AutoSave extends React.Component {
 }
 
 AutoSave.propTypes = {
+  disabled: PropTypes.bool,
   onSave: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   values: PropTypes.any.isRequired,
+}
+
+AutoSave.defaultProps = {
+  disabled: false,
 }

--- a/app/components/pages/SubmissionWizard/AutoSave.test.js
+++ b/app/components/pages/SubmissionWizard/AutoSave.test.js
@@ -19,6 +19,20 @@ describe('AutoSave', () => {
     expect(onSave).not.toHaveBeenCalled()
   })
 
+  it('does not save when disabled', () => {
+    const onSave = jest.fn()
+    const values = { a: 1 }
+    const wrapper = makeWrapper({
+      disabled: true,
+      onSave,
+      values,
+      children: 'Some text',
+    })
+    wrapper.setProps({ values: { a: 2 } })
+    jest.advanceTimersByTime(6000)
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
   it('saves when values change', () => {
     const onSave = jest.fn()
     const values = { a: 1 }

--- a/app/components/pages/SubmissionWizard/WizardStep.js
+++ b/app/components/pages/SubmissionWizard/WizardStep.js
@@ -36,6 +36,7 @@ const WizardStep = ({
     render={({
       values,
       handleSubmit,
+      isSubmitting,
       setTouched,
       submitForm,
       validateForm,
@@ -44,7 +45,11 @@ const WizardStep = ({
       <Flex>
         <BoxNoMinWidth flex="1 1 auto" mx={[0, 0, 0, '16.666%']}>
           <form noValidate onSubmit={handleSubmit}>
-            <AutoSave onSave={handleAutoSave} values={values} />
+            <AutoSave
+              disabled={isSubmitting}
+              onSave={handleAutoSave}
+              values={values}
+            />
             <Box my={5}>
               <ProgressBar currentStep={step} />
             </Box>

--- a/server/xpub/entities/manuscript/resolvers.js
+++ b/server/xpub/entities/manuscript/resolvers.js
@@ -55,6 +55,13 @@ const resolvers = {
     async updateManuscript(_, { data }, { user }) {
       const userUuid = await UserManager.getUuidForProfile(user)
       const originalManuscript = await ManuscriptManager.find(data.id, userUuid)
+      if (originalManuscript.status !== ManuscriptManager.statuses.INITIAL) {
+        throw new Error(
+          `Cannot update manuscript with status of ${
+            originalManuscript.status
+          }`,
+        )
+      }
       const manuscript = ManuscriptManager.applyInput(originalManuscript, data)
 
       await ManuscriptManager.save(manuscript)
@@ -69,6 +76,13 @@ const resolvers = {
     async submitManuscript(_, { data }, { user, ip }) {
       const userUuid = await UserManager.getUuidForProfile(user)
       const originalManuscript = await ManuscriptManager.find(data.id, userUuid)
+      if (originalManuscript.status !== ManuscriptManager.statuses.INITIAL) {
+        throw new Error(
+          `Cannot submit manuscript with status of ${
+            originalManuscript.status
+          }`,
+        )
+      }
 
       const manuscriptInput = ManuscriptManager.removeOptionalBlankReviewers(
         data,

--- a/server/xpub/entities/manuscript/resolvers.test.js
+++ b/server/xpub/entities/manuscript/resolvers.test.js
@@ -90,6 +90,23 @@ describe('Manuscripts', () => {
       ).rejects.toThrow('Manuscript not found')
     })
 
+    it('fails if manuscript has already been submitted', async () => {
+      const blankManuscript = Manuscript.new({
+        createdBy: userId,
+        status: Manuscript.statuses.MECA_EXPORT_PENDING,
+      })
+      const manuscript = await Manuscript.save(blankManuscript)
+      await expect(
+        Mutation.updateManuscript(
+          {},
+          { data: { id: manuscript.id } },
+          { user: profileId },
+        ),
+      ).rejects.toThrow(
+        'Cannot update manuscript with status of MECA_EXPORT_PENDING',
+      )
+    })
+
     it('updates the current submission for user with data', async () => {
       const blankManuscript = Manuscript.new({ createdBy: userId })
       const manuscript = await Manuscript.save(blankManuscript)
@@ -208,6 +225,23 @@ describe('Manuscripts', () => {
           { user: badProfileId },
         ),
       ).rejects.toThrow('Manuscript not found')
+    })
+
+    it('fails if manuscript has already been submitted', async () => {
+      const blankManuscript = Manuscript.new({
+        createdBy: userId,
+        status: Manuscript.statuses.MECA_EXPORT_PENDING,
+      })
+      const manuscript = await Manuscript.save(blankManuscript)
+      await expect(
+        Mutation.submitManuscript(
+          {},
+          { data: { id: manuscript.id } },
+          { user: profileId },
+        ),
+      ).rejects.toThrow(
+        'Cannot submit manuscript with status of MECA_EXPORT_PENDING',
+      )
     })
 
     // TODO more tests needed here


### PR DESCRIPTION
#### Background

- Throw an error when calling `updateManuscript` or `submitManuscript` on a manuscript with a status other than `INITIAL`
- Disable auto saving of the form while is it submitting to prevent double submit on componentWillUnmount

Closes #800 