### PR TITLE
Disable test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,11 +57,6 @@
     ]
   },
   "jest": {
-    "collectCoverage": true,
-    "collectCoverageFrom": [
-      "<rootDir>/{client,app,server}/**/*.js",
-      "!**/*.{config,test}.js"
-    ],
     "projects": [
       "<rootDir>/client",
       "<rootDir>/app",


### PR DESCRIPTION
We're not using the test coverage as a statistic, and it only serves to make the test output more verbose.