### PR TITLE
Cleaned up test output

### DIFF
--- a/config/non-serializable/mock-logger.js
+++ b/config/non-serializable/mock-logger.js
@@ -1,0 +1,5 @@
+const winston = require('winston')
+
+const logger = new winston.Logger({})
+
+module.exports = logger

--- a/config/test.js
+++ b/config/test.js
@@ -1,5 +1,6 @@
 const { deferConfig } = require('config/defer')
 const AWS = require('aws-sdk')
+const logger = require('./non-serializable/mock-logger')
 
 module.exports = {
   'pubsweet-server': {
@@ -13,6 +14,7 @@ module.exports = {
     ),
     uploads: 'test/temp/uploads',
     secret: 'test',
+    logger
   },
   login: {
     url: '/mock-token-exchange/ewwboc7m',

--- a/server/xpub/entities/file/data-access.test.js
+++ b/server/xpub/entities/file/data-access.test.js
@@ -17,7 +17,6 @@ const initializeDatabase = async () => {
   await createTables(true)
   manuscriptId = await manuscriptTestData.createSingleManuscript()
   testId = await createAFile(manuscriptId, 'testFile')
-  console.log('Created testId', testId)
 }
 
 describe('FileAccessLayer', () => {

--- a/server/xpub/entities/team/data-access.test.js
+++ b/server/xpub/entities/team/data-access.test.js
@@ -23,7 +23,6 @@ async function createATeam(roleName) {
 const initializeDatabase = async () => {
   await createTables(true)
   testId = await createATeam('testTeam')
-  console.log('Created testId', testId)
 }
 
 describe('TeamAccessLayer', () => {

--- a/server/xpub/test/mock-s3-server.js
+++ b/server/xpub/test/mock-s3-server.js
@@ -13,6 +13,7 @@ async function startServer(options) {
       directory,
       removeBucketsOnClose: true,
       port: endpoint.port,
+      silent: true
     }
     const server = new S3rver(serverOptions).run(() => {
       resolve(server)


### PR DESCRIPTION
- Removed `console.log` statements used to debug the data-access tests at the time they were written
- Using a logger which suppresses output during test runs. This still allows us to test out logging, and we can still use `console.log` within the tests or the code for debugging purposes
- Silenced the mock S3 server
