### PR TITLE
ci: fix auto retry assertion mechanism

### DIFF
--- a/config/non-serializable/mock-logger.js
+++ b/config/non-serializable/mock-logger.js
@@ -1,9 +1,7 @@
 const winston = require('winston')
 
 const logger = new winston.Logger({
-  transports: [
-    new winston.transports.Console()
-  ],
+  transports: [new winston.transports.Console()],
 })
 
 logger.transports.console.level = 'warn'

--- a/server/meca/services/upload.js
+++ b/server/meca/services/upload.js
@@ -19,6 +19,7 @@ async function uploadToS3(file, manuscriptId) {
 
   logger.info(`Uploading MECA archive to S3`, { manuscriptId })
   await s3.putObject(params).promise()
+  logger.debug('Finished MECA S3 upload')
 }
 
 async function uploadToSFTP(file, manuscriptId) {
@@ -35,6 +36,7 @@ async function uploadToSFTP(file, manuscriptId) {
   await sftp.put(file, transferName)
   await sftp.rename(transferName, finalName)
   await sftp.end()
+  logger.debug('Finished MECA SFTP upload')
 }
 
 async function upload(file, id) {


### PR DESCRIPTION
#### Background

- Use Node `assert` instead of TestCafe `.expect` in order to avoid strange problems when asserting in a loop
