### PR TITLE
fix: display app bar even if currentUser query fails

### DIFF
--- a/app/components/global/AppBar/index.js
+++ b/app/components/global/AppBar/index.js
@@ -1,10 +1,13 @@
 import React from 'react'
 import { Query } from 'react-apollo'
 import { CURRENT_USER } from '../queries'
+import ErrorBoundary from '../ErrorBoundary'
 import AppBar from './AppBar'
 
 export default () => (
-  <Query query={CURRENT_USER}>
-    {({ data }) => <AppBar user={data.currentUser} />}
-  </Query>
+  <ErrorBoundary>
+    <Query query={CURRENT_USER}>
+      {({ data }) => <AppBar user={data && data.currentUser} />}
+    </Query>
+  </ErrorBoundary>
 )

--- a/app/components/global/ErrorBoundary.js
+++ b/app/components/global/ErrorBoundary.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import ErrorPage from '../pages/Error'
+
+class ErrorBoundary extends React.Component {
+  state = {}
+
+  componentDidCatch(error) {
+    this.setState({ error })
+  }
+
+  render() {
+    if (this.state.error) {
+      return <ErrorPage error={this.state.error} />
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { Route, Switch } from 'react-router-dom'
 
 import { AuthenticatedComponent, Layout } from './components/global'
+import ErrorBoundary from './components/global/ErrorBoundary'
 import ErrorPage from './components/pages/Error'
 import LoginPage from './components/pages/Login'
 import LogoutPage from './components/pages/Logout/index'
@@ -11,18 +12,20 @@ import ThankYouPage from './components/pages/ThankYou'
 
 const Routes = () => (
   <Layout>
-    <Switch>
-      <Route component={LoginPage} exact path="/login" />
-      <Route component={LogoutPage} exact path="/logout" />
-      <AuthenticatedComponent>
-        <Switch>
-          <Route component={ThankYouPage} path="/thankyou/:id" />
-          <Route component={SubmissionWizard} path="/submit/:id" />
-          <Route component={DashboardPage} exact path="/" />
-          <ErrorPage error="404: page not found" />
-        </Switch>
-      </AuthenticatedComponent>
-    </Switch>
+    <ErrorBoundary>
+      <Switch>
+        <Route component={LoginPage} exact path="/login" />
+        <Route component={LogoutPage} exact path="/logout" />
+        <AuthenticatedComponent>
+          <Switch>
+            <Route component={ThankYouPage} path="/thankyou/:id" />
+            <Route component={SubmissionWizard} path="/submit/:id" />
+            <Route component={DashboardPage} exact path="/" />
+            <ErrorPage error="404: page not found" />
+          </Switch>
+        </AuthenticatedComponent>
+      </Switch>
+    </ErrorBoundary>
   </Layout>
 )
 


### PR DESCRIPTION
#### Background

- Also add error boundaries around app bar and main content. This should avoid a white page though it can result in odd output like <img width="586" alt="screen shot 2018-10-18 at 15 36 32" src="https://user-images.githubusercontent.com/115310/47162340-a740f600-d2eb-11e8-853f-4b81e425a9ce.png">