### PR TITLE
Enabling production login and API

### DIFF
--- a/config/prod.js
+++ b/config/prod.js
@@ -4,6 +4,15 @@ module.exports = {
   'pubsweet-server': {
     logger,
   },
+  elife: {
+    api: {
+      url: 'https://api.elifesciences.org/',
+    },
+  },
+  login: {
+    url: 'https://elifesciences.org/submit',
+    enableMock: false,
+  },
   meca: {
     sftp: {
       disableUpload: true,


### PR DESCRIPTION
Disables the mock and uses real endpoints for login and API calls in production.

This change doesn't enable EJP integration/SFTP upload

