### PR TITLE
fix: clean up styleguide errors

### DIFF
--- a/app/components/ui/atoms/CrossIconButton.md
+++ b/app/components/ui/atoms/CrossIconButton.md
@@ -4,7 +4,7 @@ A transparent HTML button (as opposed to our own Button component), whose size i
 
 ```js
 const { X } = require('react-feather')
-;<ButtonAsIconWrapper onClick={() => console.log('clicked')}>
+;<CrossIconButton onClick={() => console.log('clicked')}>
   <X />
-</ButtonAsIconWrapper>
+</CrossIconButton>
 ```

--- a/app/components/ui/atoms/StickyFooter.md
+++ b/app/components/ui/atoms/StickyFooter.md
@@ -3,18 +3,24 @@ Footer which is stuck to the bottom of the viewport.
 ...look to the bottom of the viewport to see this component :)
 
 ```js
+initialState = { show: false }
 const Button = require('@pubsweet/ui').Button
 const { Flex, Box } = require('grid-styled')
-;<StickyFooter>
-  <Flex>
-    <Box mr={3}>
-      <Button onClick={() => console.log('cancelled')}>Never mind</Button>
-    </Box>
-    <Box>
-      <Button primary onClick={() => console.log('accepted')}>
-        Click on me!
-      </Button>
-    </Box>
-  </Flex>
-</StickyFooter>
+;<div>
+  <button onClick={() => setState({ show: !state.show })}>Toggle</button>
+  {state.show && (
+    <StickyFooter>
+      <Flex>
+        <Box mr={3}>
+          <Button onClick={() => console.log('cancelled')}>Never mind</Button>
+        </Box>
+        <Box>
+          <Button primary onClick={() => console.log('accepted')}>
+            Click on me!
+          </Button>
+        </Box>
+      </Flex>
+    </StickyFooter>
+  )}
+</div>
 ```

--- a/app/components/ui/molecules/PeoplePicker.md
+++ b/app/components/ui/molecules/PeoplePicker.md
@@ -8,25 +8,25 @@ const people = [
     id: 1,
     name: 'Annie Badger',
     institution: 'A University',
-    keywords: 'cell biology',
+    subjectAreas: ['Cell biology'],
   },
   {
     id: 2,
     name: 'Bobby Badger',
     institution: 'B College',
-    keywords: 'biochemistry and chemical biology',
+    subjectAreas: ['Biochemistry and chemical biology'],
   },
   {
     id: 3,
     name: 'Chastity Badger',
     institution: 'C Institute',
-    keywords: 'ecology',
+    subjectAreas: ['Ecology'],
   },
   {
     id: 4,
     name: 'Dave Badger',
     institution: 'D Research Lab',
-    keywords: 'neuroscience',
+    subjectAreas: ['Neuroscience', 'Pumpkins', 'Chaffinches'],
   },
 ]
 ;<PeoplePicker

--- a/app/components/ui/molecules/Tabs.md
+++ b/app/components/ui/molecules/Tabs.md
@@ -15,5 +15,6 @@ console.log(`Tabs.name`, Tabs.name)
   <Tabs.Panel>
     <h2>Any content 2</h2>
   </Tabs.Panel>
+  <Tabs.Panel />
 </Tabs>
 ```

--- a/client/texture/TextureEditor.md
+++ b/client/texture/TextureEditor.md
@@ -1,9 +1,8 @@
 A Texture editor for authoring JATS XML
 
-```js
-// Use staging deployment to serve DARs
-;<TextureEditor
-  storageUrl="https://xpub-elife-staging.gateway.xpub.semioticsquares.com/api/dar"
+```text
+<TextureEditor
+  storageUrl="https://example.com/api/dar"
   archiveId="elife-32671"
 />
 ```


### PR DESCRIPTION
#### Background

- Fix the styleguide examples to clean up the console errors.
- Add a button to show/hide the sticky footer example otherwise it's always there.