### PR TITLE
824 - Create StaffCard Component

### DIFF
--- a/app/components/ui/molecules/StaffCard.js
+++ b/app/components/ui/molecules/StaffCard.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropType from 'prop-types'
+import styled from 'styled-components'
+import { th } from '@pubsweet/ui-toolkit'
+
+const StaffImg = styled.img`
+  max-width: 100%;
+  outline: 1px solid #e0e0e0;
+  margin-bottom: ${th('space.1')};
+`
+
+const StaffName = styled.div`
+  font-weight: bold;
+`
+const StaffCard = ({ name, telephone, jobTitle, photoURL }) => (
+  <React.Fragment>
+    {photoURL && <StaffImg alt={`${name}'s profile image`} src={photoURL} />}
+    <StaffName>{name}</StaffName>
+    <div>{jobTitle}</div>
+    <div>{telephone}</div>
+  </React.Fragment>
+)
+
+StaffCard.propTypes = {
+  name: PropType.string.isRequired,
+  telephone: PropType.string.isRequired,
+  jobTitle: PropType.string.isRequired,
+  photoURL: PropType.string,
+}
+
+StaffCard.defaultProps = {
+  photoURL: null,
+}
+export default StaffCard

--- a/app/components/ui/molecules/StaffCard.md
+++ b/app/components/ui/molecules/StaffCard.md
@@ -1,0 +1,31 @@
+Staff Card
+
+```js
+const Flex = require('grid-styled').Flex
+const Box = require('grid-styled').Box
+;<Flex>
+  <Box Box width={1 / 3} px={2}>
+    <StaffCard
+      photoURL="https://prod--journal-cms.elifesciences.org/sites/default/files/iiif/person/2017-07/weimun.jpg"
+      name="Wei Mun Chan"
+      jobTitle="Editorial Manager"
+      telephone="+44 [0]1223 855379"
+    />
+  </Box>
+  <Box Box width={1 / 3} px={2}>
+    <StaffCard
+      photoURL="https://prod--journal-cms.elifesciences.org/sites/default/files/iiif/person/2017-07/maria.jpg"
+      name="Maria Guerreiro"
+      jobTitle="Journal Development Editor"
+      telephone="+44 [0]1223 855376"
+    />
+  </Box>
+  <Box Box width={1 / 3} px={2}>
+    <StaffCard
+      name="John Smith"
+      jobTitle="Journal Editor"
+      telephone="+44 [0]1223 000000"
+    />
+  </Box>
+</Flex>
+```


### PR DESCRIPTION
#### Background
Create a Staff Card component for use on the static content pages.

- photo
- name (required)
- job title (required)
- phone number (required)

This should mimic styling found on https://submit.elifesciences.org/html/contact.html#

What does this PR do?

Adds a StaffCard component that can be nested in a `styled-grid` box and takes the profile info as props.

#### Any relevant tickets

closes #824

#### How has this been tested?

Visually within styleguide
