### PR TITLE
fix: allow TwoColumnLayout to handle single child

### DIFF
--- a/app/components/global/layout/TwoColumnLayout.js
+++ b/app/components/global/layout/TwoColumnLayout.js
@@ -4,7 +4,7 @@ import { Flex, Box } from 'grid-styled'
 
 const TwoColumnLayout = ({ children, bottomSpacing, ...props }) => (
   <Flex flexWrap="wrap" mx={-2} {...props}>
-    {children.map((item, index) => (
+    {React.Children.map(children, (item, index) => (
       <Box
         // try to use the key property of the React element
         key={item.key || index}


### PR DESCRIPTION
#### Background

Use `React.Children.map` to allow layout to handle single, non-array child.