### PR TITLE
857 - Remove link from completed dashboard items

### DIFF
--- a/app/components/ui/molecules/DashboardList.js
+++ b/app/components/ui/molecules/DashboardList.js
@@ -9,6 +9,10 @@ import DashboardListItem from '../../ui/molecules/DashboardListItem'
 const DashboardLink = styled(Link)`
   text-decoration: none;
   color: ${th('colorText')};
+
+  :hover {
+    color: ${th('colorPrimary')};
+  }
 `
 const EmptyListMessage = styled(Box)`
   text-align: center;
@@ -17,6 +21,25 @@ const EmptyListMessage = styled(Box)`
 const EmptyListSmallParagraph = styled(SmallParagraph)`
   font-family: ${th('fontInterface')};
 `
+const renderListItem = manuscript => {
+  const dashboardListItem = (
+    <DashboardListItem
+      date={new Date(manuscript.created)}
+      key={manuscript.id}
+      statusCode={manuscript.clientStatus}
+      title={manuscript.meta.title || '(Untitled)'}
+    />
+  )
+
+  if (manuscript.clientStatus === 'WAITING_FOR_DECISION') {
+    return dashboardListItem
+  }
+  return (
+    <DashboardLink key={manuscript.id} to={`/submit/${manuscript.id}`}>
+      {dashboardListItem}
+    </DashboardLink>
+  )
+}
 
 const DashboardList = ({ manuscripts }) => {
   if (!manuscripts.length) {
@@ -31,19 +54,7 @@ const DashboardList = ({ manuscripts }) => {
     )
   }
 
-  return (
-    <React.Fragment>
-      {manuscripts.map(manuscript => (
-        <DashboardLink key={manuscript.id} to={`/submit/${manuscript.id}`}>
-          <DashboardListItem
-            date={new Date(manuscript.created)}
-            statusCode={manuscript.clientStatus}
-            title={manuscript.meta.title || '(Untitled)'}
-          />
-        </DashboardLink>
-      ))}
-    </React.Fragment>
-  )
+  return manuscripts.map(manuscript => renderListItem(manuscript))
 }
 
 export default DashboardList

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -36,9 +36,6 @@ const Root = styled(Flex)`
   border-bottom-style: solid;
   border-bottom-width: 1px;
   height: 107px;
-  :hover {
-    color: ${th('colorPrimary')}
-  }
 `
 
 const TitleBox = styled(Box)`


### PR DESCRIPTION
#### Background
Currently all submissions on dashboard have a link to the submission wizard, including those that are awaiting decision. Opening these submissions in the wizard throws a graphql error as mutations are blocked on submission data with status "MECA_IMPORT_SUCCEEDED"

What does this PR do?

Removes the Link wrapper around DashboardListItem's that are in the manuscript status of "WAITING_FOR_DECISION"

#### Any relevant tickets

closes #857 

#### How has this been tested?

locally
