### PR TITLE
fix: give each form step a unique key even in production

### DIFF
--- a/app/components/pages/SubmissionWizard/WizardStep.js
+++ b/app/components/pages/SubmissionWizard/WizardStep.js
@@ -30,7 +30,7 @@ const WizardStep = ({
   <Formik
     initialValues={initialValues}
     // ensure each page gets a new form instance otherwise all fields are touched
-    key={FormComponent.name}
+    key={title}
     onSubmit={values => {
       handleButtonClick(values).then(() => history.push(nextUrl))
     }}


### PR DESCRIPTION
#### Background

Each step of the form is conceptually a separate form with its own validation state and submitted state. However due to the structure of the components, when navigating from one step to the next, React re-uses the previous component instance leading to issues where all form fields are already touched and validation messages are shown too soon.

In order to avoid this, we give the `Formik` component in `WizardStep` a `key` prop which is unique for each step. This tell React that they are not the same element and a new instance should be created. Previously we used `FormComponent.name` as the unique key but this name is only available in development builds meaning that in production the key was undefined.

Closes #842 