### PR TITLE
Build image on eLife's infrastructure, run tests

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -3,8 +3,6 @@ IMAGE_TAG=develop
 PORT=3000
 
 # connection details for tests
-# TODO: confusing, should just be PGHOST?
-PGHOSTADDR=postgres
 PGHOST=postgres
 PGUSER=test
 PGPASSWORD=pw

--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,14 @@
+IMAGE_TAG=develop
+PORT=3000
+
+# connection details for tests
+# TODO: confusing, should just be PGHOST?
+PGHOSTADDR=postgres
+PGHOST=postgres
+PGUSER=test
+PGPASSWORD=pw
+NODE_ENV=test
+
+# setup data for postgres image
+POSTGRES_USER=test
+POSTGRES_PASSWORD=pw

--- a/.env.ci
+++ b/.env.ci
@@ -1,3 +1,4 @@
+COMPOSE_PROJECT_NAME=elife-xpub
 IMAGE_TAG=develop
 PORT=3000
 

--- a/.env.ci
+++ b/.env.ci
@@ -9,6 +9,7 @@ PGHOST=postgres
 PGUSER=test
 PGPASSWORD=pw
 NODE_ENV=test
+BROWSER=chrome:headless --no-sandbox
 
 # setup data for postgres image
 POSTGRES_USER=test

--- a/.env.ci
+++ b/.env.ci
@@ -6,6 +6,7 @@ PORT=3000
 PGHOST=postgres
 PGUSER=test
 PGPASSWORD=pw
+PGDATABASE=test
 NODE_ENV=test
 BROWSER=chrome:headless --no-sandbox
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,14 @@
+elifePipeline {
+    node('containers-jenkins-plugin') {
+        def commit
+        stage 'Checkout', {
+            checkout scm
+            commit = elifeGitRevision()
+        }
+
+        stage 'Build image', {
+            sh "docker build --build-arg CI_COMMIT_SHA=${commit} -t elifesciences/elife-xpub:$commit ."
+            //sh "docker push elifesciences/elife-xpub:$commit}"
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ elifePipeline {
             checkout scm
             commit = elifeGitRevision()
             image = "elifesciences/elife-xpub:$commit"
+            sh "ln -s .env.ci .env"
         }
 
         stage 'Build image', {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,13 +30,13 @@ elifePipeline {
                     }, 'test', commit)
                 },
                 // TODO: not sure this can run in parallel with `test`?
-                'test:browser': {
-                    withCommitStatus({
-                        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml up -d"
-                        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml exec app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
-                        // TODO: archive screenshots
-                    }, 'test:browser', commit)
-                },
+                //'test:browser': {
+                //    withCommitStatus({
+                //        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml up -d"
+                //        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml exec app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
+                //        // TODO: archive screenshots
+                //    }, 'test:browser', commit)
+                //},
                 'test:dependencies': {
                     withCommitStatus({
                         sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_dependencies app npm run test:dependencies"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ elifePipeline {
                 'test:browser': {
                     try {
                         withCommitStatus({
-                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
+                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
                         }, 'test:browser', commit)
                     } finally {
                         archiveArtifacts artifacts: "build/screenshots/*", allowEmptyArchive: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ elifePipeline {
 
         stage 'Project tests', {
             sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d postgres"
-            sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done"
+            sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app bash -c 'until echo > /dev/tcp/postgres/5432; do sleep 1; done'"
             def actions = [
                 'lint': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ elifePipeline {
                     withCommitStatus({
                         sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml run --rm app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
                         // TODO: archive screenshots
-                    }, 'test;browser', commit)
+                    }, 'test:browser', commit)
                 },
                 'test:dependencies': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,13 +18,19 @@ elifePipeline {
         stage 'Project tests', {
             def actions = [
                 'lint': {
-                    sh "docker run --rm ${image} npm run lint"
+                    withCommitStatus({
+                        sh "docker run --rm ${image} npm run lint"
+                    }, 'lint', commit)
                 },
                 'test': {
-                    sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm test"
+                    withCommitStatus({
+                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm test"
+                    }, 'test', commit)
                 },
                 'test:dependencies': {
-                    sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm run test:dependencies"
+                    withCommitStatus({
+                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm run test:dependencies"
+                    }, 'test:dependencies', commit)
                 },
             ]
             parallel actions

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,13 @@ elifePipeline {
                         sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm test"
                     }, 'test', commit)
                 },
+                // TODO: not sure this can run in parallel with `test`?
+                'test:browser': {
+                    withCommitStatus({
+                        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml run --rm app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
+                        // TODO: archive screenshots
+                    }, 'test;browser', commit)
+                },
                 'test:dependencies': {
                     withCommitStatus({
                         sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm run test:dependencies"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,9 @@ elifePipeline {
                 'test': {
                     sh "docker-compose -f docker-compose.ci.yml run --rm app npm test"
                 },
+                'test:dependencies': {
+                    sh "docker-compose -f docker-compose.ci.yml run --rm app npm run test:dependencies"
+                },
             ]
             parallel actions
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ elifePipeline {
         }
 
         stage 'Build image', {
+            // TODO: pull existing docker image if caching is not already effective
             sh "docker build --build-arg CI_COMMIT_SHA=${commit} -t elifesciences/elife-xpub:$commit ."
             //sh "docker push elifesciences/elife-xpub:$commit}"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ elifePipeline {
                             sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
                         }, 'test:browser', commit)
                     } finally {
-                        archiveArtifacts artifacts: "build/screenshots/*"
+                        archiveArtifacts artifacts: "build/screenshots/*", allowEmptyArchive: true
                     }
                 },
                 'test:dependencies': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,25 @@
 elifePipeline {
     node('containers-jenkins-plugin') {
         def commit
+        def image
         stage 'Checkout', {
             checkout scm
             commit = elifeGitRevision()
+            image = "elifesciences/elife-xpub:$commit"
         }
 
         stage 'Build image', {
             // TODO: pull existing docker image if caching is not already effective
-            sh "docker build --build-arg CI_COMMIT_SHA=${commit} -t elifesciences/elife-xpub:$commit ."
+            sh "docker build --build-arg CI_COMMIT_SHA=${commit} -t ${image} ."
             //sh "docker push elifesciences/elife-xpub:$commit}"
+        }
+
+        stage 'Project tests', {
+            parallel [
+                'lint': {
+                    sh "docker run ${image} npm run lint"
+                },
+            ]
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ elifePipeline {
                 'test:browser': {
                     try {
                         withCommitStatus({
-                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
+                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app bash -c './scripts/wait-for-it.sh postgres:5432 && npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails'"
                         }, 'test:browser', commit)
                     } finally {
                         archiveArtifacts artifacts: "build/screenshots/*", allowEmptyArchive: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ elifePipeline {
 
         stage 'Build image', {
             // TODO: pull existing docker image if caching is not already effective
-            sh "docker build --build-arg CI_COMMIT_SHA=${commit} -t ${image} ."
+            sh "IMAGE_TAG=${commit} docker-compose build"
             //sh "docker push elifesciences/elife-xpub:$commit}"
         }
 
@@ -19,7 +19,7 @@ elifePipeline {
             def actions = [
                 'lint': {
                     withCommitStatus({
-                        sh "docker run --rm ${image} npm run lint"
+                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_lint app npm run lint"
                     }, 'lint', commit)
                 },
                 'test': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ elifePipeline {
             checkout scm
             commit = elifeGitRevision()
             image = "elifesciences/elife-xpub:$commit"
-            sh "ln -s .env.ci .env"
+            sh "ln -sf .env.ci .env"
         }
 
         stage 'Build image', {
@@ -17,6 +17,7 @@ elifePipeline {
 
         stage 'Project tests', {
             sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d postgres"
+            // TODO: wait for postgres
             def actions = [
                 'lint': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ elifePipeline {
 
         stage 'Build image', {
             // TODO: pull existing docker image if caching is not already effective
-            sh "IMAGE_TAG=${commit} docker-compose build"
+            sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml build"
             //sh "docker push elifesciences/elife-xpub:$commit}"
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,11 @@ elifePipeline {
                     }, 'test:dependencies', commit)
                 },
             ]
-            parallel actions
+            try {
+                parallel actions
+            } finally {
+                sh "docker-compose -f docker-compose.ci.yml down -v"
+            }
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,11 +15,12 @@ elifePipeline {
         }
 
         stage 'Project tests', {
-            parallel [
+            def actions = [
                 'lint': {
                     sh "docker run ${image} npm run lint"
                 },
             ]
+            parallel actions
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ elifePipeline {
                 },
                 'test': {
                     withCommitStatus({
-                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm test"
+                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test app npm test"
                     }, 'test', commit)
                 },
                 // TODO: not sure this can run in parallel with `test`?
@@ -39,7 +39,7 @@ elifePipeline {
                 },
                 'test:dependencies': {
                     withCommitStatus({
-                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm run test:dependencies"
+                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_dependencies app npm run test:dependencies"
                     }, 'test:dependencies', commit)
                 },
             ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,13 @@ elifePipeline {
                 },
                 // TODO: not sure this can run in parallel with `test`?
                 'test:browser': {
-                    withCommitStatus({
-                        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
-                //        // TODO: archive screenshots
-                    }, 'test:browser', commit)
+                    try {
+                        withCommitStatus({
+                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
+                        }, 'test:browser', commit)
+                    } finally {
+                        archiveArtifacts artifacts: "build/screenshots/*"
+                    }
                 },
                 'test:dependencies': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,6 +44,7 @@ elifePipeline {
                 },
             ]
             try {
+                sh "docker-compose -f docker-compose.ci.yml up -d postgres"
                 parallel actions
             } finally {
                 sh "docker-compose -f docker-compose.ci.yml down -v"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ elifePipeline {
         }
 
         stage 'Project tests', {
+            sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d postgres"
             def actions = [
                 'lint': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,10 @@ elifePipeline {
         stage 'Project tests', {
             def actions = [
                 'lint': {
-                    sh "docker run ${image} npm run lint"
+                    sh "docker run --rm ${image} npm run lint"
+                },
+                'test': {
+                    sh "docker-compose -f docker-compose.ci.yml run --rm app npm test"
                 },
             ]
             parallel actions

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,10 +20,10 @@ elifePipeline {
                     sh "docker run --rm ${image} npm run lint"
                 },
                 'test': {
-                    sh "docker-compose -f docker-compose.ci.yml run --rm app npm test"
+                    sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm test"
                 },
                 'test:dependencies': {
-                    sh "docker-compose -f docker-compose.ci.yml run --rm app npm run test:dependencies"
+                    sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app npm run test:dependencies"
                 },
             ]
             parallel actions

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,6 @@ elifePipeline {
         }
 
         stage 'Project tests', {
-            sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d postgres"
-            sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app bash -c 'until echo > /dev/tcp/postgres/5432; do sleep 1; done'"
             def actions = [
                 'lint': {
                     withCommitStatus({
@@ -30,13 +28,12 @@ elifePipeline {
                     }, 'test', commit)
                 },
                 // TODO: not sure this can run in parallel with `test`?
-                //'test:browser': {
-                //    withCommitStatus({
-                //        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml up -d"
-                //        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml exec app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
+                'test:browser': {
+                    withCommitStatus({
+                        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
                 //        // TODO: archive screenshots
-                //    }, 'test:browser', commit)
-                //},
+                    }, 'test:browser', commit)
+                },
                 'test:dependencies': {
                     withCommitStatus({
                         sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_dependencies app npm run test:dependencies"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ elifePipeline {
 
         stage 'Project tests', {
             sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d postgres"
-            // TODO: wait for postgres
+            sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm app bash -c "until echo > /dev/tcp/postgres/5432; do sleep 1; done"
             def actions = [
                 'lint': {
                     withCommitStatus({

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,8 @@ elifePipeline {
                 // TODO: not sure this can run in parallel with `test`?
                 'test:browser': {
                     withCommitStatus({
-                        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml run --rm app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
+                        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml up -d"
+                        sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test docker-compose -f docker-compose.ci.yml exec app npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails"
                         // TODO: archive screenshots
                     }, 'test:browser', commit)
                 },

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,6 +14,7 @@ services:
       - postgres
     environment:
       NODE_ENV:
+      NODE_CONFIG_ENV:
       PGHOSTADDR:
       PGHOST:
       PGUSER:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -32,8 +32,3 @@ services:
       POSTGRES_PASSWORD:
     volumes:
       - ./scripts/test.sql:/docker-entrypoint-initdb.d/test.sql
-
-  fakes3:
-    image: lphoward/fake-s3
-    ports:
-      - 4569:4569

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -21,6 +21,7 @@ services:
       PGHOST:
       PGUSER:
       PGPASSWORD:
+      PGDATABASE:
     volumes:
       - ./build/screenshots:/tmp/screenshots
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -2,10 +2,11 @@ version: '3'
 
 services:
   app:
-      # TODO: uncomment when image is built through docker-compose
-      #build:
-      #  context: .
-      #  dockerfile: ./Dockerfile
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args:
+        CI_COMMIT_SHA: ${IMAGE_TAG}
     image: elifesciences/elife-xpub:${IMAGE_TAG}
     # no need to start the up in any scenario, yet
     command: sh

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -18,7 +18,6 @@ services:
       BROWSER:
       NODE_ENV:
       NODE_CONFIG_ENV:
-      PGHOSTADDR:
       PGHOST:
       PGUSER:
       PGPASSWORD:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,36 @@
+version: '3'
+
+services:
+  app:
+      # TODO: uncomment when image is built through docker-compose
+      #build:
+      #  context: .
+      #  dockerfile: ./Dockerfile
+    image: elifesciences/elife-xpub:${IMAGE_TAG}
+    command: sh
+    ports:
+      - ${PORT}:3000
+    depends_on:
+      - postgres
+    environment:
+      NODE_ENV:
+      # TODO: confusing, should just be PGHOST?
+      PGHOSTADDR:  127.0.0.1
+      PGHOST:
+      PGUSER:
+      PGPASSWORD:
+
+  postgres:
+    image: postgres:10.4
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER:
+      POSTGRES_PASSWORD:
+    volumes:
+      - ./scripts/test.sql:/docker-entrypoint-initdb.d/test.sql
+
+  fakes3:
+    image: lphoward/fake-s3
+    ports:
+      - 4569:4569

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,8 +14,7 @@ services:
       - postgres
     environment:
       NODE_ENV:
-      # TODO: confusing, should just be PGHOST?
-      PGHOSTADDR:  127.0.0.1
+      PGHOSTADDR:
       PGHOST:
       PGUSER:
       PGPASSWORD:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,6 +14,7 @@ services:
     depends_on:
       - postgres
     environment:
+      BROWSER:
       NODE_ENV:
       NODE_CONFIG_ENV:
       PGHOSTADDR:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -32,4 +32,4 @@ services:
       POSTGRES_USER:
       POSTGRES_PASSWORD:
     volumes:
-      - ./scripts/test.sql:/docker-entrypoint-initdb.d/test.sql
+      - ./scripts/test-ci.sql:/docker-entrypoint-initdb.d/test-ci.sql

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -22,6 +22,8 @@ services:
       PGHOST:
       PGUSER:
       PGPASSWORD:
+    volumes:
+      - ./build/screenshots:/tmp/screenshots
 
   postgres:
     image: postgres:10.4

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,6 +7,7 @@ services:
       #  context: .
       #  dockerfile: ./Dockerfile
     image: elifesciences/elife-xpub:${IMAGE_TAG}
+    # no need to start the up in any scenario, yet
     command: sh
     ports:
       - ${PORT}:3000

--- a/scripts/test-ci.sql
+++ b/scripts/test-ci.sql
@@ -1,0 +1,2 @@
+-- CREATE DATABASE test; -- already created via POSTGRES_DATABASE
+CREATE DATABASE test_browser;

--- a/scripts/test.sql
+++ b/scripts/test.sql
@@ -1,2 +1,1 @@
 CREATE DATABASE test;
-


### PR DESCRIPTION
The first step of https://github.com/elifesciences/elife-xpub/issues/675

Ports over the following Gitlab CI jobs, using a `docker-compose` configuration:
- `build`
- `lint`
- `test`
- `test:browser`
- `test:dependencies`

These provide feedback in the form of commit status checks. Execution time seems slightly better (~20-30 seconds less per job) than on Gitlab CI, probably because of lower overhead when running on a single node but possibly also dedicated hardware.

There is more in Gitlab CI, but some of these could be reasonably removed from there once they are stable on this side, reducing the execution time.