### PR TITLE
docs: remove 'Other' section from styleguide

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -14,22 +14,17 @@ module.exports = {
           components: 'app/components/pages/**/*.js',
         },
         {
-          name: 'Other',
-          components: 'app/**/*.js',
-          ignore: ['app/components/{global,pages,ui}/**/*.js'],
-        },
-      ],
-    },
-    {
-      name: 'eLife UI',
-      sections: [
-        {
-          name: 'Atoms',
-          components: 'app/components/ui/atoms/**/*.js',
-        },
-        {
-          name: 'Molecules',
-          components: 'app/components/ui/atoms/**/*.js',
+          name: 'UI',
+          sections: [
+            {
+              name: 'Atoms',
+              components: 'app/components/ui/atoms/**/*.js',
+            },
+            {
+              name: 'Molecules',
+              components: 'app/components/ui/atoms/**/*.js',
+            },
+          ],
         },
       ],
     },
@@ -39,6 +34,7 @@ module.exports = {
     },
     {
       name: 'PubSweet UI (external)',
+      external: true,
       href: 'https://ui-staging-zpqsip.gateway.ps.elifesciences.yld.io/',
     },
   ],


### PR DESCRIPTION
#### Background

- `ignore` glob isn't working (don't know why) which was causing components to be included twice
- just need to remember to add a section to the config if we ever have components in folders other than `app/{global,pages,ui}`.