### PR TITLE
888 - Consolidate AppBar menu config to be passed in one place

### DIFF
--- a/app/components/global/AppBar/AppBar.js
+++ b/app/components/global/AppBar/AppBar.js
@@ -46,28 +46,25 @@ const DesktopView = styled(Flex)`
   `};
 `
 
-const AppBar = ({ user, userMenuItems, defaultMenuItems }) => {
-  const menuItems = [...(user ? userMenuItems : []), ...defaultMenuItems]
-  return (
-    <AppBarContainer>
-      <BurgerMenu menuItems={menuItems} />
-      <LogoLink href="https://elifesciences.org">
-        <img alt="eLife" src="/assets/elife-logo.png" />
-      </LogoLink>
-      <DesktopView>
-        <Separator />
-        <Box flex="1 1 auto">
-          {menuItems &&
-            menuItems.map(item => (
-              <AppBarLink key={item.link} to={item.link}>
-                {item.label}
-              </AppBarLink>
-            ))}
-        </Box>
-      </DesktopView>
-      <ProfileMenu user={user} />
-    </AppBarContainer>
-  )
-}
+const AppBar = ({ user, menuItems }) => (
+  <AppBarContainer>
+    <BurgerMenu menuItems={menuItems} />
+    <LogoLink href="https://elifesciences.org">
+      <img alt="eLife" src="/assets/elife-logo.png" />
+    </LogoLink>
+    <DesktopView>
+      <Separator />
+      <Box flex="1 1 auto">
+        {menuItems &&
+          menuItems.map(item => (
+            <AppBarLink key={item.link} to={item.link}>
+              {item.label}
+            </AppBarLink>
+          ))}
+      </Box>
+    </DesktopView>
+    <ProfileMenu user={user} />
+  </AppBarContainer>
+)
 
 export default AppBar

--- a/app/components/global/AppBar/AppBar.js
+++ b/app/components/global/AppBar/AppBar.js
@@ -46,24 +46,28 @@ const DesktopView = styled(Flex)`
   `};
 `
 
-const AppBar = ({ user }) => (
-  <AppBarContainer>
-    <BurgerMenu menuItems={user && [{ label: 'Dashboard', link: '/' }]} />
-    <LogoLink href="https://elifesciences.org">
-      <img alt="eLife" src="/assets/elife-logo.png" />
-    </LogoLink>
-    <DesktopView>
-      <Separator />
-      <Box flex="1 1 auto">
-        {user && (
-          <AppBarLink exact to="/">
-            Dashboard
-          </AppBarLink>
-        )}
-      </Box>
-    </DesktopView>
-    <ProfileMenu user={user} />
-  </AppBarContainer>
-)
+const AppBar = ({ user, userMenuItems, defaultMenuItems }) => {
+  const menuItems = [...(user ? userMenuItems : []), ...defaultMenuItems]
+  return (
+    <AppBarContainer>
+      <BurgerMenu menuItems={menuItems} />
+      <LogoLink href="https://elifesciences.org">
+        <img alt="eLife" src="/assets/elife-logo.png" />
+      </LogoLink>
+      <DesktopView>
+        <Separator />
+        <Box flex="1 1 auto">
+          {menuItems &&
+            menuItems.map(item => (
+              <AppBarLink key={item.link} to={item.link}>
+                {item.label}
+              </AppBarLink>
+            ))}
+        </Box>
+      </DesktopView>
+      <ProfileMenu user={user} />
+    </AppBarContainer>
+  )
+}
 
 export default AppBar

--- a/app/components/global/AppBar/index.js
+++ b/app/components/global/AppBar/index.js
@@ -7,7 +7,12 @@ import AppBar from './AppBar'
 export default props => (
   <ErrorBoundary>
     <Query query={CURRENT_USER}>
-      {({ data }) => <AppBar user={data && data.currentUser} {...props} />}
+      {({ data }) => {
+        const { userMenuItems, defaultMenuItems } = props
+        const user = data && data.currentUser
+        const menuItems = [...(user ? userMenuItems : []), ...defaultMenuItems]
+        return <AppBar menuItems={menuItems} user={user} />
+      }}
     </Query>
   </ErrorBoundary>
 )

--- a/app/components/global/AppBar/index.js
+++ b/app/components/global/AppBar/index.js
@@ -4,10 +4,10 @@ import { CURRENT_USER } from '../queries'
 import ErrorBoundary from '../ErrorBoundary'
 import AppBar from './AppBar'
 
-export default () => (
+export default props => (
   <ErrorBoundary>
     <Query query={CURRENT_USER}>
-      {({ data }) => <AppBar user={data && data.currentUser} />}
+      {({ data }) => <AppBar user={data && data.currentUser} {...props} />}
     </Query>
   </ErrorBoundary>
 )

--- a/app/components/global/layout/Layout.js
+++ b/app/components/global/layout/Layout.js
@@ -4,7 +4,14 @@ import AppBar from '../AppBar'
 
 const Layout = ({ children }) => (
   <React.Fragment>
-    <AppBar />
+    <AppBar
+      defaultMenuItems={[
+        { label: 'Author guide', link: '/author-guide' },
+        { label: 'Reviewer guide', link: '/reviewer-guide' },
+        { label: 'Contact us', link: '/contact-us' },
+      ]}
+      userMenuItems={[{ label: 'Dashboard', link: '/' }]}
+    />
     <Centerer>{children}</Centerer>
   </React.Fragment>
 )


### PR DESCRIPTION
#### Background

Previously AppBar's Desktop menu was hard coded NavLinks and a seperate set of config was passed to burger menu for the mobile view. This left the possibility of adding to one in the future and forgetting about the other.

What does this PR do?

Allows config for the AppBar menu to be passed in through the Layout Component as `userMenuItems` for signed in users and `defaultMenuITems` for all users. This one entry point for config is then used to generate both mobile and desktop view menus

#### Any relevant tickets

closes#888

#### How has this been tested?
locally
