### PR TITLE
fix: fixed Other section within styleguide

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -16,7 +16,7 @@ module.exports = {
         {
           name: 'Other',
           components: 'app/**/*.js',
-          ignore: ['app/components/{global,pages,ui}/**/*.js'],
+          ignore: ['**/app/components/{global,pages,ui}/**/*.js'],
         },
       ],
     },


### PR DESCRIPTION
#### Background

Styleguide was showing all components within the *Other* section.

[This was due to a bug in styleguidist which was fixed on version 8.0.2](https://github.com/styleguidist/react-styleguidist/commit/a7a6cf410060244f5157b80d3be7d4f12ab10e09#diff-37941dbdd4961cdef0779884f6621f61)

This change fixes the problem until styleguidist gets upgraded on pubsweet.

#### How has this been tested?

The problem can be reproduced using the following snippet: 

```
const glob = require('glob');
const path = require('path');

const rootDir = '/Users/hem/Projects/elife/elife-xpub'
const components = 'app/**/*.js'

const ignore = [
  'app/components/{global,pages,ui}/**/*.js'
]

const componentFiles = glob.sync(
  path.resolve(rootDir, components),
  { ignore }
)

console.log(componentFiles)
```

Changing `ignore` to `**/app/components/{global,pages,ui}/**/*.js` fixes the issue. This is because the first arg to `glob.sync` resolves to an absolute path.