### PR TITLE
886 manuscript status updates

### DIFF
--- a/app/components/ui/atoms/ManuscriptStatus.js
+++ b/app/components/ui/atoms/ManuscriptStatus.js
@@ -15,14 +15,14 @@ const StatusBox = styled(Box)`
 const mapColor = statusCode =>
   ({
     CONTINUE_SUBMISION: 'colorPrimary',
-    WAITING_FOR_DECISION: 'colorPrimary',
+    SUBMITTED: 'colorPrimary',
     REJECTED: 'colorError',
   }[statusCode])
 
 const getText = statusCode =>
   ({
     CONTINUE_SUBMISION: 'Continue Submision',
-    WAITING_FOR_DECISION: 'Waiting for decision',
+    SUBMITTED: 'Submitted',
     REJECTED: 'Rejected',
   }[statusCode])
 

--- a/app/components/ui/atoms/ManuscriptStatus.js
+++ b/app/components/ui/atoms/ManuscriptStatus.js
@@ -15,7 +15,7 @@ const StatusBox = styled(Box)`
 const mapColor = statusCode =>
   ({
     CONTINUE_SUBMISION: 'colorPrimary',
-    SUBMITTED: 'colorPrimary',
+    SUBMITTED: 'colorTextSecondary',
     REJECTED: 'colorError',
   }[statusCode])
 

--- a/app/components/ui/atoms/ManuscriptStatus.md
+++ b/app/components/ui/atoms/ManuscriptStatus.md
@@ -1,7 +1,7 @@
 mapper to display the correct text in base of the server statusCode, allowed statusCodes:
 
 - CONTINUE_SUBMISION
-- WAITING_FOR_DECISION
+- SUBMITTED
 - REJECTED
 
 ```js

--- a/app/components/ui/molecules/DashboardList.js
+++ b/app/components/ui/molecules/DashboardList.js
@@ -31,7 +31,7 @@ const renderListItem = manuscript => {
     />
   )
 
-  if (manuscript.clientStatus === 'WAITING_FOR_DECISION') {
+  if (manuscript.clientStatus === 'SUBMITTED') {
     return dashboardListItem
   }
   return (

--- a/app/components/ui/molecules/DashboardList.md
+++ b/app/components/ui/molecules/DashboardList.md
@@ -9,7 +9,7 @@ Dashboard list of submissions
           'Shearing in flow environment promotes evolution of social behaviour in microbial populations',
       },
       created: '2018-10-09T16:10:00.000Z',
-      clientStatus: 'WAITING_FOR_DECISION',
+      clientStatus: 'SUBMITTED',
       id: '1',
     },
     {

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -85,12 +85,8 @@ const DashboardListItem = ({ statusCode, title, date }) => (
 
 DashboardListItem.propTypes = {
   statusCode: PropTypes.string.isRequired,
-  title: PropTypes.string,
+  title: PropTypes.string.isRequired,
   date: PropTypes.instanceOf(Date).isRequired,
-}
-
-DashboardListItem.defaultProps = {
-  title: 'Untitled manuscript',
 }
 
 export default DashboardListItem

--- a/app/components/ui/molecules/DashboardListItem.md
+++ b/app/components/ui/molecules/DashboardListItem.md
@@ -1,10 +1,43 @@
-List item in the dashboard that links to manuscript. It shows status (e.g. accepted, submitted), manuscript title and date since status last changed.
+List item in the dashboard. It shows the manuscript title, submission status & the date of the last status change.
 
 ```js
+const today = new Date()
 ;<DashboardListItem
   statusCode={'CONTINUE_SUBMISION'}
   title={
     'Shearing in flow environment promotes evolution of social behaviour in microbial populations'
+  }
+  date={today}
+/>
+```
+
+```js
+const today = new Date()
+;<DashboardListItem
+  statusCode={'SUBMITTED'}
+  title={
+    'Cross-talk between PRMT1-mediated methylation and ubiquitylation on RBM15 controls RNA splicing'
+  }
+  date={new Date(today.setDate(today.getDate() - 1))}
+/>
+```
+
+```js
+const today = new Date()
+;<DashboardListItem
+  statusCode={'SUBMITTED'}
+  title={
+    'INAVA-ARNO complexes bridge mucosal barrier function with inflammatory signaling'
+  }
+  date={new Date(today.setDate(today.getDate() - 3))}
+/>
+```
+
+```js
+;<DashboardListItem
+  statusCode={'REJECTED'}
+  title={
+    'Affinity capture of polyribosomes followed by RNAseq (ACAPseq), a discovery platform for protein-protein interactions'
   }
   date={'2018-10-09T16:10:00.000Z'}
 />

--- a/app/components/ui/molecules/DashboardListItem.md
+++ b/app/components/ui/molecules/DashboardListItem.md
@@ -1,4 +1,4 @@
-List item in the dashboard that links to manuscript. It shows status (e.g. accepted, waiting approval), manuscript title and date since status last changed.
+List item in the dashboard that links to manuscript. It shows status (e.g. accepted, submitted), manuscript title and date since status last changed.
 
 ```js
 ;<DashboardListItem

--- a/server/xpub-server/entities/manuscript/resolvers.js
+++ b/server/xpub-server/entities/manuscript/resolvers.js
@@ -278,7 +278,7 @@ ${err}`,
         case 'MECA_EXPORT_SUCCEEDED':
         case 'MECA_IMPORT_FAILED':
         case 'MECA_IMPORT_SUCCEEDED':
-          clientStatus = 'WAITING_FOR_DECISION'
+          clientStatus = 'SUBMITTED'
           break
         default:
           throw new Error(`Unhandled manuscript status ${manuscript.status}`)

--- a/test/submission.browser.js
+++ b/test/submission.browser.js
@@ -158,7 +158,7 @@ test('Happy path', async t => {
     .eql(manuscript.title)
     .expect(dashboard.statuses.textContent)
     // TODO this might cause a race condition
-    .eql('Waiting for decision')
+    .eql('Submitted')
 
   // SFTP server
   await autoRetry(() => {


### PR DESCRIPTION
#### What does this PR do?
- Change all instances of 'waiting for decision' to 'submitted'
- Add all different states of `DashboardListItem` to styleguidist:
  - different titles
  - each of 3 manuscript statuses
  - different dates, to show the various outputs (today, yesterday, x days ago)
- Changed `title` to required prop in DashboardListItem, since it's parent (DashboardList) is actually the one responsible for deciding what title gets sent to it (i.e. decides whether it says 'untiltled' or not)

#### Any relevant tickets
fixes #886 

#### How has this been tested?
Existing test altered