### PR TITLE
fix: removed unused dependencies from yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7897,11 +7897,6 @@ json-stringify-safe@^5.0.0, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json-to-graphql-query@^1.3.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/json-to-graphql-query/-/json-to-graphql-query-1.7.0.tgz#670728e2809ec92fc4c91a50fa0cd457d56fbe51"
-  integrity sha512-UWfroMkWOUwJKnNLVRBSABRMyDii8MKxJEk+pM37Rlx+eb6qJQxe671IZIhMSlrBVSqFdjwq6r+E5Qakiy8DMg==
-
 json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -13754,14 +13749,6 @@ superagent@^3.8.2, superagent@^3.8.3:
     mime "^1.4.1"
     qs "^6.5.1"
     readable-stream "^2.3.5"
-
-supertest@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-3.2.0.tgz#9addd40096135f4fb8f032dd7c3fe3789604aa7a"
-  integrity sha512-f+ANFG17GuXbMAQRveLLtqmodbKBxqfMwAktPRS0w4R7m+OluM0Nl+Ygr/tZ/0u9IbdwqtBoHspam3A17ThTig==
-  dependencies:
-    methods "^1.1.2"
-    superagent "^3.8.3"
 
 supertest@^3.2.0:
   version "3.3.0"


### PR DESCRIPTION
#### Background

Removes the dependencies from `yarn.lock` that were removed as part of #883.

#### How has this been tested?

Ran yarn locally and verified there were no changes locally
