### PR TITLE
fix: showing molecules on styleguide

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -29,7 +29,7 @@ module.exports = {
         },
         {
           name: 'Molecules',
-          components: 'app/components/ui/atoms/**/*.js',
+          components: 'app/components/ui/molecules/**/*.js',
         },
       ],
     },


### PR DESCRIPTION
The molecules section was actually showing atoms rather than molecules.