### PR TITLE
898 & 905 - refactor DashboardListItem to take the whole manuscript

### DIFF
--- a/app/components/ui/molecules/DashboardList.js
+++ b/app/components/ui/molecules/DashboardList.js
@@ -23,12 +23,7 @@ const EmptyListSmallParagraph = styled(SmallParagraph)`
 `
 const renderListItem = manuscript => {
   const dashboardListItem = (
-    <DashboardListItem
-      date={new Date(manuscript.created)}
-      key={manuscript.id}
-      statusCode={manuscript.clientStatus}
-      title={manuscript.meta.title || '(Untitled)'}
-    />
+    <DashboardListItem key={manuscript.id} manuscript={manuscript} />
   )
 
   if (manuscript.clientStatus === 'SUBMITTED') {

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -70,23 +70,30 @@ const AbsoluteDate = styled.time`
   `};
 `
 
-const DashboardListItem = ({ statusCode, title, date }) => (
-  <Root py={3}>
-    <TitleBox data-test-id="title" mb={3}>
-      {title}
-    </TitleBox>
-    <ManuscriptStatus statusCode={statusCode} />
-    <DateBox>
-      <time>{dashboardDateText(date)}</time>
-      <AbsoluteDate>{format(date, 'ddd D MMM YYYY')}</AbsoluteDate>
-    </DateBox>
-  </Root>
-)
+const DashboardListItem = ({ manuscript }) => {
+  const date = new Date(manuscript.created)
+  return (
+    <Root py={3}>
+      <TitleBox data-test-id="title" mb={3}>
+        {manuscript.meta.title || '(Untitled)'}
+      </TitleBox>
+      <ManuscriptStatus statusCode={manuscript.clientStatus} />
+      <DateBox>
+        <time>{dashboardDateText(date)}</time>
+        <AbsoluteDate>{format(date, 'ddd D MMM YYYY')}</AbsoluteDate>
+      </DateBox>
+    </Root>
+  )
+}
 
 DashboardListItem.propTypes = {
-  statusCode: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  date: PropTypes.instanceOf(Date).isRequired,
+  manuscript: PropTypes.shape({
+    meta: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+    }).isRequired,
+    clientStatus: PropTypes.string.isRequired,
+    created: PropTypes.string.isRequired,
+  }).isRequired,
 }
 
 export default DashboardListItem

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -86,7 +86,7 @@ const DashboardListItem = ({ manuscript }) => {
 DashboardListItem.propTypes = {
   manuscript: PropTypes.shape({
     meta: PropTypes.shape({
-      title: PropTypes.string.isRequired,
+      title: PropTypes.string,
     }).isRequired,
     clientStatus: PropTypes.string.isRequired,
     created: PropTypes.string.isRequired,

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -39,9 +39,6 @@ const Root = styled(Flex)`
     align-items: flex-start;
     padding: calc(${th('gridUnit')} * 5) 0;
   `};
-  :hover {
-    color: ${th('colorPrimary')};
-  }
 `
 
 const TitleBox = styled(Box)`

--- a/app/components/ui/molecules/DashboardListItem.md
+++ b/app/components/ui/molecules/DashboardListItem.md
@@ -1,44 +1,49 @@
 List item in the dashboard. It shows the manuscript title, submission status & the date of the last status change.
 
 ```js
-const today = new Date()
-;<DashboardListItem
-  statusCode={'CONTINUE_SUBMISION'}
-  title={
-    'Shearing in flow environment promotes evolution of social behaviour in microbial populations'
-  }
-  date={today}
-/>
+const manuscript = {
+  created: '2018-10-25T14:53:29.857Z',
+  clientStatus: 'CONTINUE_SUBMISION',
+  meta: {
+    title:
+      'Shearing in flow environment promotes evolution of social behaviour in microbial populations',
+  },
+}
+;<DashboardListItem manuscript={manuscript} />
 ```
 
 ```js
-const today = new Date()
-;<DashboardListItem
-  statusCode={'SUBMITTED'}
-  title={
-    'Cross-talk between PRMT1-mediated methylation and ubiquitylation on RBM15 controls RNA splicing'
-  }
-  date={new Date(today.setDate(today.getDate() - 1))}
-/>
+const manuscript = {
+  created: '2018-10-25T14:53:29.857Z',
+  clientStatus: 'SUBMITTED',
+  meta: {
+    title:
+      'Cross-talk between PRMT1-mediated methylation and ubiquitylation on RBM15 controls RNA splicing',
+  },
+}
+;<DashboardListItem manuscript={manuscript} />
 ```
 
 ```js
-const today = new Date()
-;<DashboardListItem
-  statusCode={'SUBMITTED'}
-  title={
-    'INAVA-ARNO complexes bridge mucosal barrier function with inflammatory signaling'
-  }
-  date={new Date(today.setDate(today.getDate() - 3))}
-/>
+const manuscript = {
+  created: '2018-10-25T14:53:29.857Z',
+  clientStatus: 'SUBMITTED',
+  meta: {
+    title:
+      'INAVA-ARNO complexes bridge mucosal barrier function with inflammatory signaling',
+  },
+}
+;<DashboardListItem manuscript={manuscript} />
 ```
 
 ```js
-;<DashboardListItem
-  statusCode={'REJECTED'}
-  title={
-    'Affinity capture of polyribosomes followed by RNAseq (ACAPseq), a discovery platform for protein-protein interactions'
-  }
-  date={'2018-10-09T16:10:00.000Z'}
-/>
+const manuscript = {
+  created: '2018-10-25T14:53:29.857Z',
+  clientStatus: 'REJECTED',
+  meta: {
+    title:
+      'Affinity capture of polyribosomes followed by RNAseq (ACAPseq), a discovery platform for protein-protein interactions',
+  },
+}
+;<DashboardListItem manuscript={manuscript} />
 ```


### PR DESCRIPTION
#### Background

- Currently the data passed to `DashboardListItem` is pre processed (ie: if no title on manuscript object the Dashboard passes '(Untitled)' down. The `DashboardListItem` should have control over how it shows the manuscript data.

- Fix bug with non-link dashboard items still changing to primaryColor on hover.

What does this PR do?

Refactors `DashboardListItem` to take the whole manuscript object as a prop and format things like date and title for display.

#### Any relevant tickets

closes #898
closes #905
#### How has this been tested?

visually
