### PR TITLE
906 - Change mobile menu to colorText

### DIFF
--- a/app/components/ui/molecules/BurgerMenu.js
+++ b/app/components/ui/molecules/BurgerMenu.js
@@ -30,7 +30,7 @@ const BurgerWrapper = styled(Box)`
   `};
 `
 
-const MenuNavLink = styled(NavLink)`
+export const MenuNavLink = styled(NavLink)`
   color: ${th('colorText')};
   ${media.mobileUp`
     color: ${th('colorTextSecondary')};

--- a/app/components/ui/molecules/BurgerMenu.js
+++ b/app/components/ui/molecules/BurgerMenu.js
@@ -30,6 +30,13 @@ const BurgerWrapper = styled(Box)`
   `};
 `
 
+const MenuNavLink = styled(NavLink)`
+  color: ${th('colorText')};
+  ${media.mobileUp`
+    color: ${th('colorTextSecondary')};
+  `};
+`
+
 class BurgerMenu extends React.Component {
   state = {
     menuOpen: false,
@@ -74,13 +81,13 @@ class BurgerMenu extends React.Component {
             {menuItems &&
               menuItems.map(item => (
                 <MenuItem key={item.link}>
-                  <NavLink
+                  <MenuNavLink
                     exact
                     onClick={() => this.setState({ menuOpen: false })}
                     to={item.link}
                   >
                     {item.label}
-                  </NavLink>
+                  </MenuNavLink>
                 </MenuItem>
               ))}
           </MenuPanel>

--- a/app/components/ui/molecules/BurgerMenu.test.js
+++ b/app/components/ui/molecules/BurgerMenu.test.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import BurgerMenu from './BurgerMenu'
-import NavLink from '../atoms/NavLink'
+import BurgerMenu, { MenuNavLink } from './BurgerMenu'
 
 const menuConfig = [
   { label: 'Dashboard', link: '/' },
@@ -32,13 +31,13 @@ describe('BurgerMenu Component', () => {
     menuConfig.forEach((config, index) => {
       expect(
         wrapper
-          .find(NavLink)
+          .find(MenuNavLink)
           .at(index)
           .props().to,
       ).toEqual(config.link)
       expect(
         wrapper
-          .find(NavLink)
+          .find(MenuNavLink)
           .at(index)
           .props().children,
       ).toEqual(config.label)


### PR DESCRIPTION
#### Background

'Burger' menu on the journal site has all NavLinks as `textColor` irrespective of active state.

What does this PR do?

Makes all `BurgerMenu` NavLinks `textColor`

#### Any relevant tickets

closes #906 

#### How has this been tested?

visually
