### PR TITLE
refactor(Staff Pages): use H1 from pubsweet ui components rather than…

### DIFF
--- a/app/components/pages/StaticPages/ContactUs/EditorialStaff.js
+++ b/app/components/pages/StaticPages/ContactUs/EditorialStaff.js
@@ -1,11 +1,12 @@
 import React from 'react'
+import { H1 } from '@pubsweet/ui'
 
 import StaffGrid from '../../../ui/molecules/StaffGrid'
 import StaffCard from '../../../ui/molecules/StaffCard'
 
 const EditorialStaff = () => (
   <React.Fragment>
-    <h1>Editorial Staff</h1>
+    <H1>Editorial Staff</H1>
     <p>
       Our Editorial Staff are happy to help with any enquiries arising before
       acceptance.

--- a/app/components/pages/StaticPages/ContactUs/EditorialStaff.md
+++ b/app/components/pages/StaticPages/ContactUs/EditorialStaff.md
@@ -1,5 +1,5 @@
 Content for Editorial Staff page
 
 ```js
-<EditorialStaffs />
+<EditorialStaff />
 ```

--- a/app/components/pages/StaticPages/ContactUs/ProductionStaff.js
+++ b/app/components/pages/StaticPages/ContactUs/ProductionStaff.js
@@ -1,10 +1,12 @@
 import React from 'react'
+import { H1 } from '@pubsweet/ui'
+
 import StaffGrid from '../../../ui/molecules/StaffGrid'
 import StaffCard from '../../../ui/molecules/StaffCard'
 
-const ProductionPage = () => (
+const ProductionStaff = () => (
   <React.Fragment>
-    <h1>Production Staff</h1>
+    <H1>Production Staff</H1>
     <p>
       Our Editorial Staff are happy to help with any enquiries arising
       post-acceptance.
@@ -26,4 +28,4 @@ const ProductionPage = () => (
   </React.Fragment>
 )
 
-export default ProductionPage
+export default ProductionStaff


### PR DESCRIPTION
#### Background
use H1 from pubsweet UI components rather than the generic H1, updated MD as it was failing on Styleguide

What does this PR do?

closes: #922 

