### PR TITLE
style(StaticPages): fix responsive grid as applied to static page layout

### DIFF
--- a/app/components/pages/StaticPages/SideNav.js
+++ b/app/components/pages/StaticPages/SideNav.js
@@ -12,6 +12,8 @@ const SideNavLink = styled(NavLink)`
   &:first-child {
     padding-top: 0;
   }
+  font-size: ${th('fontSizeBaseSmall')};
+  line-height: ${th('lineHeightBaseSmall')};
 `
 
 const SideNav = ({ navList }) => (

--- a/app/components/pages/StaticPages/SideNav.js
+++ b/app/components/pages/StaticPages/SideNav.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { th } from '@pubsweet/ui-toolkit'
+import { Box } from 'grid-styled'
+
+import NavLink from '../../ui/atoms/NavLink'
+
+const SideNavLink = styled(NavLink)`
+  display: block;
+  padding: ${th('space.1')} 0 ${th('space.1')} 0;
+  &:first-child {
+    padding-top: 0;
+  }
+`
+
+const SideNav = ({ navList }) => (
+  <Box is="nav">
+    {navList &&
+      navList.map(navItem => (
+        <SideNavLink
+          data-test-id={navItem.link}
+          key={navItem.link}
+          to={navItem.link}
+        >
+          {navItem.label}
+        </SideNavLink>
+      ))}
+  </Box>
+)
+
+SideNav.propTypes = {
+  navList: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      link: PropTypes.string.isRequired,
+      component: PropTypes.func.isRequired,
+    }),
+  ).isRequired,
+}
+
+export default SideNav

--- a/app/components/pages/StaticPages/SideNav.js
+++ b/app/components/pages/StaticPages/SideNav.js
@@ -8,9 +8,12 @@ import NavLink from '../../ui/atoms/NavLink'
 
 const SideNavLink = styled(NavLink)`
   display: block;
-  padding: ${th('space.1')} 0 ${th('space.1')} 0;
+  padding: ${th('space.2')} 0 ${th('space.2')} 0;
   &:first-child {
     padding-top: 0;
+  }
+  &:last-child {
+    padding-bottom: 0;
   }
   font-size: ${th('fontSizeBaseSmall')};
   line-height: ${th('lineHeightBaseSmall')};

--- a/app/components/pages/StaticPages/SideNav.md
+++ b/app/components/pages/StaticPages/SideNav.md
@@ -1,0 +1,21 @@
+```js
+<SideNav
+  navList={[
+    {
+      label: 'Contact eLife',
+      link: '/contact-us/contact-elife',
+      component: ContactELife,
+    },
+    {
+      label: 'Editorial Staff',
+      link: '/contact-us/editorial-staff',
+      component: EditorialStaff,
+    },
+    {
+      label: 'Production Staff',
+      link: '/contact-us/production-staff',
+      component: ProductionStaff,
+    },
+  ]}
+/>
+```

--- a/app/components/pages/StaticPages/index.js
+++ b/app/components/pages/StaticPages/index.js
@@ -34,10 +34,10 @@ const StaticPage = ({ navList }) => (
 
       <Flex>
         <SideNavContainer
-          ml={[0, 0, '8.33%']} // 1 column's worth of spacing (in a 12 column grid)
-          pr={3}
+          ml={[0, 0, `8.33vw`, `8.33vw`, `8.33vw`]} // 8.33% of viewport width = 1/12 (i.e. 1 column of spacing in a 12 column grid)
+          mr={3}
           pt={18} // To match the top padding on the H1 in the 'main' component
-          width={[0, 3 / 12, 3 / 12, 2 / 12]}
+          width={[0, 0, 3 / 12, 2 / 12, 2 / 12]}
         >
           <Box is="nav">
             {navList &&
@@ -53,7 +53,10 @@ const StaticPage = ({ navList }) => (
           </Box>
         </SideNavContainer>
 
-        <MainContainer width={[1, 1, 7 / 12, 7 / 12, 8 / 12]}>
+        <MainContainer
+          mr={[0, 0, `8.33vw`, `16.67vw`, `25vw`]} // [0, 0, 1, 2, 3] columns out of a 12 column grid
+          width={[1, 1, 7 / 12, 7 / 12, 6 / 12]}
+        >
           <Switch>
             {navList &&
               navList.map(navItem => (

--- a/app/components/pages/StaticPages/index.js
+++ b/app/components/pages/StaticPages/index.js
@@ -7,7 +7,7 @@ import { th } from '@pubsweet/ui-toolkit'
 
 import ErrorBoundary from '../../global/ErrorBoundary'
 import media from '../../global/layout/media'
-import NavLink from '../../ui/atoms/NavLink'
+import SideNav from './SideNav'
 
 const TopNavContainer = styled.div`
   margin-bottom: ${th('space.3')};
@@ -18,14 +18,6 @@ const SideNavContainer = styled(Box)`
   ${media.tabletPortraitUp`display: block;`};
 `
 const MainContainer = styled(Box)``
-
-const SideNavLink = styled(NavLink)`
-  display: block;
-  padding: ${th('space.1')} 0 ${th('space.1')} 0;
-  &:first-child {
-    padding-top: 0;
-  }
-`
 
 const StaticPage = ({ navList }) => (
   <div>
@@ -39,18 +31,7 @@ const StaticPage = ({ navList }) => (
           pt={18} // To match the top padding on the H1 in the 'main' component
           width={[0, 0, 3 / 12, 2 / 12, 2 / 12]}
         >
-          <Box is="nav">
-            {navList &&
-              navList.map(navItem => (
-                <SideNavLink
-                  data-test-id={navItem.link}
-                  key={navItem.link}
-                  to={navItem.link}
-                >
-                  {navItem.label}
-                </SideNavLink>
-              ))}
-          </Box>
+          <SideNav navList={navList} />
         </SideNavContainer>
 
         <MainContainer


### PR DESCRIPTION
#### Background
- Design uses a 12 column grid on sketch
- Developers use fractions/percentages of viewport width (see [`grid-styled` docs](https://github.com/rebassjs/grid#responsive-styles))

To recap on our use of grid-styled...

We have an array of 4 breakpoints [in our theme](https://github.com/elifesciences/elife-xpub/blob/develop/client/elife-theme/src/index.js#L61): `[480, 768, 1000, 1272]`.

So whenever we add `width={[1stNum, 2ndNum, 3rdNum, 4thNum, 5thNum]}` to one of our `Flex` or `Box` components, it means that those numbers are applied to the component's width as follows:
- `width=1stNum` until viewport width reaches 480px
- `2ndNum` from 480px (inclusive) until 768px
- `3rdNum` from 768px (inclusive) until 1000px
- `4thNum` from 1000px (inclusive) until 1272px
- `5thNum` from 1272px (inclusive)

Similarly, we can use arrays for `p` & `m` on grid-styled components, so that these adhere to the breakpoints.

In the case of our `StaticPage` component, we are using `ml` & `mr` to achieve column-like spacing to the left and right of our content. So we use `${myNumber}vw` because vw = "viewport width"

#### What does this PR do?
- Change `padding-right` on sidebar to `margin-right`, so prevent wrapping of text
- Add missing numbers to the following arrays, so that together they add up to 12 / 12 for each breakpoint:
  - `margin-left` on sidebar (SideNavContainer)
  - `width` on sidebar
  - `width` on MainContainer
  - `margin-right` on MainContainer

This was done using https://invis.io/FDOIB61EKV5 as a guide

#### Any relevant tickets
fixes #920 

#### How has this been tested?
Visually