### PR TITLE
Static pages mobile nav

### DIFF
--- a/app/components/pages/StaticPages/index.js
+++ b/app/components/pages/StaticPages/index.js
@@ -26,12 +26,12 @@ const StaticPage = ({ history, navList }) => (
     <ErrorBoundary>
       <TopNavContainer>
         <NavigationDropdown
-          initialValue={history.location.pathname}
           onSelection={item => history.push(item.value)}
           options={navList.map(navItem => ({
             label: navItem.label,
             value: navItem.link,
           }))}
+          value={history.location.pathname}
         />
       </TopNavContainer>
 

--- a/app/components/pages/StaticPages/index.js
+++ b/app/components/pages/StaticPages/index.js
@@ -8,8 +8,10 @@ import { th } from '@pubsweet/ui-toolkit'
 import ErrorBoundary from '../../global/ErrorBoundary'
 import media from '../../global/layout/media'
 import SideNav from './SideNav'
+import NavigationDropdown from '../../ui/atoms/NavigationDropdown'
 
-const TopNavContainer = styled.div`
+const TopNavContainer = styled(Box).attrs({ mx: -3 })`
+  border-bottom: ${th('borderWidth')} ${th('borderStyle')} ${th('colorBorder')};
   margin-bottom: ${th('space.3')};
   ${media.tabletPortraitUp`display: none;`};
 `
@@ -19,10 +21,19 @@ const SideNavContainer = styled(Box)`
 `
 const MainContainer = styled(Box)``
 
-const StaticPage = ({ navList }) => (
+const StaticPage = ({ history, navList }) => (
   <div>
     <ErrorBoundary>
-      <TopNavContainer>{/* TODO: dropdown goes here */}</TopNavContainer>
+      <TopNavContainer>
+        <NavigationDropdown
+          initialValue={history.location.pathname}
+          onSelection={item => history.push(item.value)}
+          options={navList.map(navItem => ({
+            label: navItem.label,
+            value: navItem.link,
+          }))}
+        />
+      </TopNavContainer>
 
       <Flex>
         <SideNavContainer

--- a/app/components/pages/StaticPages/index.test.js
+++ b/app/components/pages/StaticPages/index.test.js
@@ -1,6 +1,9 @@
 import React from 'react'
 import { mount } from 'enzyme'
-import { NavLink, MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, NavLink, Route } from 'react-router-dom'
+import { ThemeProvider } from 'styled-components'
+import theme from '@elifesciences/elife-theme'
+
 import StaticPage from '.'
 
 const navList = [
@@ -29,9 +32,13 @@ const navList = [
 
 const makeWrapper = ({ path }) =>
   mount(
-    <MemoryRouter initialEntries={[`${path}`]}>
-      <StaticPage navList={navList} />
-    </MemoryRouter>,
+    <ThemeProvider theme={theme}>
+      <MemoryRouter initialEntries={[`${path}`]}>
+        <Route
+          render={history => <StaticPage history={history} navList={navList} />}
+        />
+      </MemoryRouter>
+    </ThemeProvider>,
   )
 
 const MockContentComponent = ({ dataTestId }) => (

--- a/app/components/ui/atoms/NavigationDropdown.js
+++ b/app/components/ui/atoms/NavigationDropdown.js
@@ -7,10 +7,6 @@ class NavigationDropdown extends React.Component {
   constructor(props) {
     super(props)
 
-    this.state = {
-      selectedValue: this.props.initialValue,
-    }
-
     this.customReactSelectStyles = {
       menuList: (base, state) => ({
         ...base,
@@ -63,13 +59,8 @@ class NavigationDropdown extends React.Component {
     }
   }
 
-  handleSelection = selectedOption => {
-    this.setState({ selectedValue: selectedOption.value })
-    this.props.onSelection(selectedOption)
-  }
-
   render() {
-    const { options } = this.props
+    const { options, onSelection, value } = this.props
 
     return (
       <Select
@@ -77,18 +68,16 @@ class NavigationDropdown extends React.Component {
           IndicatorSeparator: null,
           DropdownIndicator: null,
         }}
-        getOptionLabel={({ label }) => label}
-        getOptionValue={({ value }) => value}
+        getOptionLabel={option => option.label}
+        getOptionValue={option => option.value}
         isSearchable={false}
         maxMenuHeight={1200} // longer than any phone screen
         menuShouldScrollIntoView={false}
-        onChange={this.handleSelection}
+        onChange={onSelection}
         options={options}
         placeholder=""
         styles={this.customReactSelectStyles}
-        value={options.filter(
-          ({ value }) => value === this.state.selectedValue,
-        )}
+        value={options.filter(option => option.value === value)}
       />
     )
   }
@@ -101,7 +90,7 @@ NavigationDropdown.propTypes = {
       value: PropTypes.string.isRequired,
     }),
   ).isRequired,
-  initialValue: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
   onSelection: PropTypes.func.isRequired,
 }
 

--- a/app/components/ui/atoms/NavigationDropdown.js
+++ b/app/components/ui/atoms/NavigationDropdown.js
@@ -32,8 +32,7 @@ class NavigationDropdown extends React.Component {
         color: isSelected
           ? this.props.theme.colorText
           : this.props.theme.colorTextSecondary,
-        paddingTop: this.props.theme.space[3],
-        paddingBottom: this.props.theme.space[3],
+        padding: this.props.theme.space[3],
       }),
       control: (base, { isFocused }) => ({
         ...base,
@@ -58,6 +57,9 @@ class NavigationDropdown extends React.Component {
           marginLeft: this.props.theme.space[2],
         },
       }),
+      valueContainer: (base, state) => ({
+        paddingLeft: this.props.theme.space[3],
+      }),
     }
   }
 
@@ -79,6 +81,7 @@ class NavigationDropdown extends React.Component {
         getOptionValue={({ value }) => value}
         isSearchable={false}
         maxMenuHeight={1200} // longer than any phone screen
+        menuShouldScrollIntoView={false}
         onChange={this.handleSelection}
         options={options}
         placeholder=""

--- a/app/components/ui/atoms/NavigationDropdown.js
+++ b/app/components/ui/atoms/NavigationDropdown.js
@@ -42,7 +42,7 @@ class NavigationDropdown extends React.Component {
         '::after': {
           content: `''`,
           display: `inline-block`,
-          verticalAlign: state.selectProps.menuIsOpen ? `text-top` : `middle`,
+          verticalAlign: state.selectProps.menuIsOpen ? `super` : `middle`,
           border: `4px solid transparent`,
           borderTopColor: state.selectProps.menuIsOpen
             ? 'none'

--- a/app/components/ui/atoms/NavigationDropdown.md
+++ b/app/components/ui/atoms/NavigationDropdown.md
@@ -8,7 +8,7 @@ let selectedOption = options[0]
 const handleSelection = selectedItem => (selectedOption = selectedItem)
 ;<NavigationDropdown
   options={options}
-  initialValue={selectedOption.value}
+  value={selectedOption.value}
   onSelection={handleSelection}
 />
 ```


### PR DESCRIPTION
#### What does this PR do?
- Adds the NavigationDropdown to StaticPages
- Removes internal state from NavigationDropdown (again :yum:) & pass info directly from StaticPages into react-select component

#### Any relevant tickets
fixes #820 

#### How has this been tested?
Change `makeWrapper`, to update existing tests. It now:
- wraps everything in `ThemeProvider`
- passes down history from `MemoryRouter` into `Route` component, which then renders `StaticPage`