### PR TITLE
Fix internal page anchor links

### DIFF
--- a/app/components/global/AppBar/ProfileMenu.js
+++ b/app/components/global/AppBar/ProfileMenu.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { Box } from 'grid-styled'
 import { Link } from 'react-router-dom'
 import { th } from '@pubsweet/ui-toolkit'
-import ExternalLink from '../../ui/atoms/ExternalLink'
+import NativeLink from '../../ui/atoms/NativeLink'
 import Icon from '../../ui/atoms/Icon'
 import PopOverPanel from '../../ui/atoms/PopOverPanel'
 
@@ -102,7 +102,7 @@ class ProfileMenu extends React.Component {
     if (!user) {
       return (
         <Box mx={3}>
-          <ExternalLink href={loginUrl}>Login</ExternalLink>
+          <NativeLink href={loginUrl}>Login</NativeLink>
         </Box>
       )
     }

--- a/app/components/pages/Dashboard/index.js
+++ b/app/components/pages/Dashboard/index.js
@@ -7,7 +7,7 @@ import { th } from '@pubsweet/ui-toolkit'
 import { CREATE_MANUSCRIPT } from '../SubmissionWizard/operations'
 import media from '../../global/layout/media'
 import SmallParagraph from '../../ui/atoms/SmallParagraph'
-import ExternalLink from '../../ui/atoms/ExternalLink'
+import NativeLink from '../../ui/atoms/NativeLink'
 import StickyFooter from '../../ui/atoms/StickyFooter'
 import Tabs from '../../ui/molecules/Tabs'
 import Submissions from './panels/Submissions'
@@ -69,9 +69,9 @@ const DashboardPage = ({ history }) => (
 
           <CenterdSmallParagraph>
             Can&#39;t find a submission? You might find it in our full{' '}
-            <ExternalLink href="https://submit.elifesciences.org">
+            <NativeLink href="https://submit.elifesciences.org">
               peer review and submissions
-            </ExternalLink>{' '}
+            </NativeLink>{' '}
             system
           </CenterdSmallParagraph>
         </Box>

--- a/app/components/pages/Login/index.js
+++ b/app/components/pages/Login/index.js
@@ -8,7 +8,7 @@ import { H2 } from '@pubsweet/ui'
 import OrcidButton from '../../ui/atoms/OrcidButton'
 import ButtonLink from '../../ui/atoms/ButtonLink'
 import Paragraph from '../../ui/atoms/Paragraph'
-import ExternalLink from '../../ui/atoms/ExternalLink'
+import NativeLink from '../../ui/atoms/NativeLink'
 
 const { url: loginUrl, signupUrl, legacySubmissionUrl } = config.login
 
@@ -110,16 +110,15 @@ class LoginPage extends React.Component {
               </a>
             </Box>
             <Box>
-              No ORCID? <ExternalLink href={signupUrl}>Sign up</ExternalLink>{' '}
-              now.
+              No ORCID? <NativeLink href={signupUrl}>Sign up</NativeLink> now.
             </Box>
           </Flex>
         )}
         <Paragraph>
           For{' '}
-          <ExternalLink href={legacySubmissionUrl}>
+          <NativeLink href={legacySubmissionUrl}>
             existing manuscripts
-          </ExternalLink>{' '}
+          </NativeLink>{' '}
           go to our full submission and peer review system.
         </Paragraph>
       </Box>

--- a/app/components/pages/StaticPages/AuthorGuide/EditorialProcess.js
+++ b/app/components/pages/StaticPages/AuthorGuide/EditorialProcess.js
@@ -97,8 +97,8 @@ const EditorialProcess = props => (
       >
         this editorial
       </ExternalLink>{' '}
-      and <a href="#scoop_protection">the FAQ</a> below for more details on our
-      policies on preprints and scoop protection.
+      and <ExternalLink href="#scoop_protection">the FAQ</ExternalLink> below
+      for more details on our policies on preprints and scoop protection.
     </Paragraph>
 
     <CalloutTextBox>

--- a/app/components/pages/StaticPages/AuthorGuide/EditorialProcess.js
+++ b/app/components/pages/StaticPages/AuthorGuide/EditorialProcess.js
@@ -3,7 +3,7 @@ import { H1, H2, H3, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
 import CalloutTextBox from '../../../ui/atoms/CalloutTextBox'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import List from '../../../ui/atoms/List'
 
 const EditorialProcess = props => (
@@ -12,12 +12,12 @@ const EditorialProcess = props => (
 
     <Paragraph>
       eLife publishes{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/elife-news/what-are-elife-papers-made-of"
         target="_blank"
       >
         promising research
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       across the life sciences and biomedicine. Before you submit your work,
       please note that eLife is a very selective journal that aims to publish
       work of the highest scientific standards and importance. Leading academic
@@ -30,59 +30,59 @@ const EditorialProcess = props => (
       To help increase the accessibility of research and ensure that it is
       communicated as rapidly as possible, authors are encouraged to make use of
       preprint servers, such as{' '}
-      <ExternalLink href="http://biorxiv.org/" target="_blank">
+      <NativeLink href="http://biorxiv.org/" target="_blank">
         bioRxiv
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       or
-      <ExternalLink href="https://www.authorea.com/" target="_blank">
+      <NativeLink href="https://www.authorea.com/" target="_blank">
         Authorea
-      </ExternalLink>
+      </NativeLink>
       , while their paper is under consideration by eLife. The advantages of
       depositing early versions of an article are summarised on the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/elife-news/what-are-elife-papers-made-of"
         target="_blank"
       >
         ASAPbio
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       website. Authors can upload a preprint to{' '}
-      <ExternalLink href="http://biorxiv.org/" target="_blank">
+      <NativeLink href="http://biorxiv.org/" target="_blank">
         bioRxiv
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       or
-      <ExternalLink href="https://www.authorea.com/" target="_blank">
+      <NativeLink href="https://www.authorea.com/" target="_blank">
         Authorea
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and then transfer their files for consideration by eLife.
     </Paragraph>
 
     <Paragraph>
       Alternatively, authors can submit to eLife directly, or they can submit
       using the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://www.overleaf.com/latex/templates/elife-latex-template/csqxykvsnyxm#.WIs5NLaLRGw"
         target="_blank"
       >
         Overleaf
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       or{' '}
-      <ExternalLink href="https://www.authorea.com/" target="_blank">
+      <NativeLink href="https://www.authorea.com/" target="_blank">
         Authorea
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       authorship tools. Authors working in LaTeX can download and use our{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elife-cdn.s3.amazonaws.com/author-guide/elife-latex-template.zip"
         target="_blank"
       >
         template
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       or{' '}
-      <ExternalLink
+      <NativeLink
         href="https://www.overleaf.com/latex/templates/elife-latex-template/csqxykvsnyxm"
         target="_blank"
       >
         open it directly in Overleaf
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       .
     </Paragraph>
 
@@ -91,14 +91,14 @@ const EditorialProcess = props => (
       possible, and we offer &quot;scoop protection&quot; in the sense that, if
       other researchers publish similar findings after submission, this will not
       be a reason for rejection. Please see{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/articles/30076"
         target="_blank"
       >
         this editorial
-      </ExternalLink>{' '}
-      and <ExternalLink href="#scoop_protection">the FAQ</ExternalLink> below
-      for more details on our policies on preprints and scoop protection.
+      </NativeLink>{' '}
+      and <NativeLink href="#scoop_protection">the FAQ</NativeLink> below for
+      more details on our policies on preprints and scoop protection.
     </Paragraph>
 
     <CalloutTextBox>
@@ -129,12 +129,12 @@ const EditorialProcess = props => (
       guidelines relating to{' '}
       <Link to="/author-guide/initial">Initial Submissions</Link>. During the
       initial submission phase, members of eLife’s{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/about/people?_ga=2.223585432.2069272108.1540132848-2034406101.1537543708"
         target="_blank"
       >
         senior editorial team
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       rapidly assess new submissions, often in consultation with members of the
       Board of Reviewing Editors or with external guest editors where necessary,
       to identify the ones that are appropriate for in-depth peer review.
@@ -162,19 +162,19 @@ const EditorialProcess = props => (
       for example names of co-authors, details of major datasets, and ethics
       statements. Authors are asked to agree to publish their work under the
       terms of the Creative Commons Attribution license (
-      <ExternalLink
+      <NativeLink
         href="https://cdn.elifesciences.org/xpub/guides/CCBY_4.0.pdf"
         target="_blank"
       >
         PDF of the agreement
-      </ExternalLink>
+      </NativeLink>
       ), or the Creative Commons CC0 public domain dedication (
-      <ExternalLink
+      <NativeLink
         href="https://cdn.elifesciences.org/xpub/guides/CC0_1.0.pdf"
         target="_blank"
       >
         PDF of the agreement
-      </ExternalLink>
+      </NativeLink>
       ) if one or more authors are US-government employees.
     </Paragraph>
 
@@ -184,12 +184,12 @@ const EditorialProcess = props => (
       in the decision letter. A response to minor comments is optional. In the
       event of acceptance, the substantive revision requests and the authors’
       response will be published, under the terms of the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://creativecommons.org/licenses/by/4.0/"
         target="_blank"
       >
         Creative Commons Attribution license
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -217,19 +217,19 @@ const EditorialProcess = props => (
       case-by-case basis. However, eLife does not subscribe to a
       &apos;winner-takes-all&apos; philosophy, and does not automatically reject
       papers because they are not &apos;first&apos; (please see{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/articles/05770?_ga=2.156477752.2069272108.1540132848-2034406101.1537543708"
         target="_blank"
       >
         Malhotra and Marder, 2015
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/articles/30076"
         target="_blank"
       >
         Marder, 2017
-      </ExternalLink>
+      </NativeLink>
       ).
     </Paragraph>
 

--- a/app/components/pages/StaticPages/AuthorGuide/EditorialProcess.js
+++ b/app/components/pages/StaticPages/AuthorGuide/EditorialProcess.js
@@ -97,8 +97,8 @@ const EditorialProcess = props => (
       >
         this editorial
       </ExternalLink>{' '}
-      and <Link to="#scoop_protection">the FAQ</Link> below for more details on
-      our policies on preprints and scoop protection.
+      and <a href="#scoop_protection">the FAQ</a> below for more details on our
+      policies on preprints and scoop protection.
     </Paragraph>
 
     <CalloutTextBox>

--- a/app/components/pages/StaticPages/AuthorGuide/Fees.js
+++ b/app/components/pages/StaticPages/AuthorGuide/Fees.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { H1, H2, H3, Link } from '@pubsweet/ui'
+import { H1, H2, H3 } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
 import NativeLink from '../../../ui/atoms/NativeLink'
@@ -91,9 +91,10 @@ const Fees = props => (
     <Paragraph>
       It is very important that our introduction of a publication fee does not
       inhibit the submission of excellent work from labs with insufficient
-      access to funds. We will make <Link to="#waiver">a waiver</Link> available
-      for labs under financial pressure – whether because of local economy,
-      career stage, or state of funding.
+      access to funds. We will make{' '}
+      <NativeLink href="#waiver">a waiver</NativeLink> available for labs under
+      financial pressure – whether because of local economy, career stage, or
+      state of funding.
     </Paragraph>
 
     <H3>3. Will my ability to pay influence consideration of my paper?</H3>

--- a/app/components/pages/StaticPages/AuthorGuide/Fees.js
+++ b/app/components/pages/StaticPages/AuthorGuide/Fees.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { H1, H2, H3, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import List from '../../../ui/atoms/List'
 
 const Fees = props => (
@@ -38,28 +38,28 @@ const Fees = props => (
 
     <List.Unordered>
       <li>
-        <ExternalLink
+        <NativeLink
           href="https://elifesciences.org/elife-news/inside-elife-setting-fee-publication"
           target="_blank"
         >
           Inside eLife: Setting a fee for publication
-        </ExternalLink>
+        </NativeLink>
       </li>
       <li>
-        <ExternalLink
+        <NativeLink
           href="https://elifesciences.org/content/5/e21230"
           target="_blank"
         >
           Editorial: Building a sustainable future for eLife
-        </ExternalLink>
+        </NativeLink>
       </li>
       <li>
-        <ExternalLink
+        <NativeLink
           href="https://elifesciences.org/elife-news/inside-elife-what-it-costs-publish"
           target="_blank"
         >
           Inside eLife: What it costs to publish
-        </ExternalLink>
+        </NativeLink>
       </li>
     </List.Unordered>
 
@@ -77,12 +77,12 @@ const Fees = props => (
 
     <Paragraph>
       A detailed overview of how we arrived at the fee is available at:{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/elife-news/inside-elife-setting-fee-publication"
         target="_blank"
       >
         Inside eLife: Setting a fee for publication
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -211,9 +211,9 @@ const Fees = props => (
 
     <Paragraph>
       Any questions not addressed here may be sent to eLife via{' '}
-      <ExternalLink href="mailto:fees@elifesciences.org" target="_blank">
+      <NativeLink href="mailto:fees@elifesciences.org" target="_blank">
         fees [at] elifesciences [dot] org
-      </ExternalLink>
+      </NativeLink>
     </Paragraph>
 
     <H2 id="waiver">eLife publication fee waiver policy (December 2016)</H2>

--- a/app/components/pages/StaticPages/AuthorGuide/Full.js
+++ b/app/components/pages/StaticPages/AuthorGuide/Full.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { H1, H2, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import List from '../../../ui/atoms/List'
 
 const Full = props => (
@@ -39,12 +39,12 @@ const Full = props => (
 
     <Paragraph>
       Regarding the use of supplementary data, our vision is presented in{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/inside-elife/6f32c567/supplementary-data"
         target="_blank"
       >
         this blog post
-      </ExternalLink>
+      </NativeLink>
       . In short, we strive to make supplementary data, if applicable, easily
       searchable, discoverable, and citable, and made available in the most
       useful format for reuse.
@@ -59,19 +59,19 @@ const Full = props => (
           areas relating to sample-size estimation, replicates, and statistical
           reporting. At the Full Submission step, authors should be ready to
           upload a completed version of this form (
-          <ExternalLink
+          <NativeLink
             href="https://cdn.elifesciences.org/xpub/guides/transparent_reporting.pdf"
             target="_blank"
           >
             PDF
-          </ExternalLink>
+          </NativeLink>
           ;{' '}
-          <ExternalLink
+          <NativeLink
             href="https://cdn.elifesciences.org/xpub/guides/transparent_reporting.docx"
             target="_blank"
           >
             Word
-          </ExternalLink>
+          </NativeLink>
           ), which should describe the places within the submission where this
           information has been included.
         </Paragraph>
@@ -93,12 +93,12 @@ const Full = props => (
           also recognise that some figures are more central to the narrative of
           the paper than others, and so we therefore support ‘child’ figures
           (examples of which can be found in{' '}
-          <ExternalLink
+          <NativeLink
             href="http://elifesciences.org/content/1/e00181#F3"
             traget="_blank"
           >
             eLife 2012;1:e00181
-          </ExternalLink>
+          </NativeLink>
           ). These &quot;Figure Supplements&quot; must be linked to one of the
           primary figures: they can, for example, provide additional examples of
           analyses or data shown in a primary figure.
@@ -132,12 +132,12 @@ const Full = props => (
         <Paragraph>
           When preparing figures, we recommend that authors follow the
           principles of{' '}
-          <ExternalLink
+          <NativeLink
             href="http://jfly.iam.u-tokyo.ac.jp/color/"
             target="_blank"
           >
             Colour Universal Design
-          </ExternalLink>{' '}
+          </NativeLink>{' '}
           (Masataka, Okabe and Kei Ito, J*Fly), whereby colour schemes are
           chosen to ensure maximum accessibility for all types of colour vision.
         </Paragraph>
@@ -154,12 +154,12 @@ const Full = props => (
           eLife encourages authors to provide Source Data files, for example,
           for figures such as histograms or tables showing summary data (as
           shown in{' '}
-          <ExternalLink
+          <NativeLink
             href="http://elifesciences.org/content/1/e00109/#DC1"
             target="_blank"
           >
             eLife 2012;1:e00109
-          </ExternalLink>
+          </NativeLink>
           ). Each Source data file should relate directly to a single figure or
           table, whereas major datasets generated in the course of the work
           should be deposited externally, as explained below. Each source data
@@ -193,23 +193,23 @@ const Full = props => (
           is published, videos are embedded within the main body of the article
           (they are not presented as supplementary files) with the same status
           as primary figures (as shown in{' '}
-          <ExternalLink
+          <NativeLink
             href="http://elifesciences.org/content/1/e00007#media-1"
             target="_blank"
           >
             eLife 2012;1:e00007
-          </ExternalLink>
+          </NativeLink>
           ).
         </Paragraph>
         <Paragraph>
           eLife supports JMOL, a Java viewer for three-dimensional chemical
           structures, and we encourage authors to provide{' '}
-          <ExternalLink
+          <NativeLink
             href="http://wiki.jmol.org/index.php/File_formats/Coordinates"
             target="_blank"
           >
             compatible files
-          </ExternalLink>
+          </NativeLink>
           .
         </Paragraph>
       </li>
@@ -222,12 +222,12 @@ const Full = props => (
           files to the submission system (for example, MATLAB, R, Python, C,
           C++, Java). Any code provided should be properly documented, in line
           with{' '}
-          <ExternalLink
+          <NativeLink
             href="http://journals.plos.org/ploscompbiol/s/materials-and-software-sharing#loc-sharing-software"
             target="_blank"
           >
             these instructions
-          </ExternalLink>{' '}
+          </NativeLink>{' '}
           (courtesy of PLOS). Please also refer to our{' '}
           <Link to="/author-guide/journal-policies">
             Software sharing policy
@@ -282,12 +282,12 @@ const Full = props => (
       researchers and reliably connects you with your research contributions and
       affiliations, to help ensure that your work is properly attributed and
       credited (
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/inside-elife/e2bf15ca/publishers-to-require-orcid-identifiers-for-authors"
         target="_blank"
       >
         learn more
-      </ExternalLink>
+      </NativeLink>
       ).
     </Paragraph>
 
@@ -319,12 +319,12 @@ const Full = props => (
           curation; Writing – original draft preparation; Writing – review &amp;
           editing; Visualization; Supervision; Project administration; Funding
           acquisition (
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/inside-elife/f39cfcf5/enabling-the-contributor-roles-taxonomy-for-author-contributions?_ga=2.172472675.1994204094.1499675694-1424042520.1478607646"
             target="_blank"
           >
             read more
-          </ExternalLink>
+          </NativeLink>
           ).
         </Paragraph>
         <Paragraph>
@@ -375,22 +375,22 @@ const Full = props => (
           and/or URL, Database, License and Accessibility Information. This
           information will be used to create a list of the relevant major
           datasets in the published article (such as{' '}
-          <ExternalLink
+          <NativeLink
             href="http://elifesciences.org/content/1/e00070/article-data"
             target="_blank"
           >
             eLife 2012;1:e00070
-          </ExternalLink>
+          </NativeLink>
           ), to indicate their location along with unique identifiers, and
           licensing information – or any other factors – affecting access to or
           reuse of the datasets. For newly generated datasets, we encourage the
           use of the Creative Commons{' '}
-          <ExternalLink
+          <NativeLink
             href="https://creativecommons.org/publicdomain/zero/1.0/"
             target="_blank"
           >
             CC0 public domain dedication
-          </ExternalLink>
+          </NativeLink>
           .
         </Paragraph>
         <Paragraph>

--- a/app/components/pages/StaticPages/AuthorGuide/Initial.js
+++ b/app/components/pages/StaticPages/AuthorGuide/Initial.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { H1, H2, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import List from '../../../ui/atoms/List'
 import RequiredInfoTable from './RequiredInfoTable'
 
@@ -114,12 +114,12 @@ const Initial = props => (
           step-by-step protocols in addition to the methods described in the
           article, we would encourage authors to also consider submitting a
           detailed protocol to{' '}
-          <ExternalLink
+          <NativeLink
             href="https://bio-protocol.org/login.aspx?in=2"
             target="_blank"
           >
             Bio-protocol
-          </ExternalLink>
+          </NativeLink>
           .
         </Paragraph>
         <Paragraph>
@@ -202,9 +202,9 @@ const Initial = props => (
 
     <Paragraph>
       When preparing figures, we recommend that authors follow the principles of{' '}
-      <ExternalLink href="http://jfly.iam.u-tokyo.ac.jp/color/" target="_blank">
+      <NativeLink href="http://jfly.iam.u-tokyo.ac.jp/color/" target="_blank">
         Colour Universal Design
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (Masataka Okabe and Kei Ito, J*FLY), whereby colour schemes are chosen to
       ensure maximum accessibility for all types of colour vision.
     </Paragraph>
@@ -212,12 +212,12 @@ const Initial = props => (
     <Paragraph>
       When preparing coloured tables, authors should note that we can only
       accomodate schemes as outlined in{' '}
-      <ExternalLink
+      <NativeLink
         href="https://cdn.elifesciences.org/author-guide/tables-colour.pdf?_ga=2.122882312.2069272108.1540132848-2034406101.1537543708"
         target="_blank"
       >
         this guide
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -246,110 +246,110 @@ const Initial = props => (
         <Paragraph>
           A list of major subject areas is provided from which authors should
           select one or two (choosing from:{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/biochemistry-chemical-biology"
             target="_blank"
           >
             Biochemistry
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/structural-biology-molecular-biophysics"
             target="_blank"
           >
             Biophysics & Structural biology
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/cancer-biology"
             target="_blank"
           >
             Cancer Biology
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="http://elifesciences.org/about/people/cell-biology"
             target="_blank"
           >
             Cell Biology
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/developmental-biology-stem-cells"
             target="_blank"
           >
             Developmental Biology & Stem Cells
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/computational-systems-biology"
             target="_blank"
           >
             Computational & Systems Biology
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="http://elifesciences.org/about/people/ecology"
             target="_blank"
           >
             Ecology
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/epidemiology-global-health"
             target="_blank"
           >
             Epidemiology & Global Health
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/genes-chromosomes"
             target="_blank"
           >
             Genes & Chromosomes
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/genomics-evolutionary-biology"
             target="_blank"
           >
             Genomics & Evolutionary Biology
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/human-biology-medicine"
             target="_blank"
           >
             Human Biology & Medicine
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/immunology"
             target="_blank"
           >
             Immunology
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/microbiology-infectious-disease"
             target="_blank"
           >
             Microbiology & Infectious Disease
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/about/people/neuroscience"
             target="_blank"
           >
             Neuroscience
-          </ExternalLink>
+          </NativeLink>
           ,{' '}
-          <ExternalLink
+          <NativeLink
             href="http://elifesciences.org/about/people/plant-biology"
             target="_blank"
           >
             Plant Biology
-          </ExternalLink>
+          </NativeLink>
           ).
         </Paragraph>
       </li>

--- a/app/components/pages/StaticPages/AuthorGuide/JournalMetrics.js
+++ b/app/components/pages/StaticPages/AuthorGuide/JournalMetrics.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { H1, H2 } from '@pubsweet/ui'
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import { BoxChart, ColumnChart } from './JournalCharts'
 import * as data from './JournalCharts.data'
 
@@ -20,9 +20,9 @@ const JournalMetrics = () => (
       This shows the number of initial submissions received each quarter. Please
       note that publication fees were introduced on January 1, 2017 (summary
       table{' '}
-      <ExternalLink href="https://elife-cdn.s3.amazonaws.com/elifechart1.xlsx">
+      <NativeLink href="https://elife-cdn.s3.amazonaws.com/elifechart1.xlsx">
         Excel
-      </ExternalLink>
+      </NativeLink>
       ).
     </Paragraph>
     <ColumnChart color="#2369CB" data={data.chart1} />
@@ -30,9 +30,9 @@ const JournalMetrics = () => (
     <H2>2. Number of research publications</H2>
     <Paragraph>
       This shows the number of research publications each quarter (summary table{' '}
-      <ExternalLink href="https://elife-cdn.s3.amazonaws.com/elifechart2.xlsx">
+      <NativeLink href="https://elife-cdn.s3.amazonaws.com/elifechart2.xlsx">
         Excel
-      </ExternalLink>
+      </NativeLink>
       ).
     </Paragraph>
     <ColumnChart color="#71AC33" data={data.chart2} />
@@ -42,9 +42,9 @@ const JournalMetrics = () => (
       This shows the number of days between receiving the initial submission and
       making a decision on the initial submission (25th, 50th, and 75th
       percentiles; summary table{' '}
-      <ExternalLink href="https://elife-cdn.s3.amazonaws.com/elifechart3.xlsx">
+      <NativeLink href="https://elife-cdn.s3.amazonaws.com/elifechart3.xlsx">
         Excel
-      </ExternalLink>
+      </NativeLink>
       ).
     </Paragraph>
     <BoxChart data={data.chart3} />
@@ -54,9 +54,9 @@ const JournalMetrics = () => (
       This shows the number of days between receiving the full submission and
       making a decision on the full submission, after peer review (25th, 50th,
       and 75th percentiles; summary table{' '}
-      <ExternalLink href="https://elife-cdn.s3.amazonaws.com/elifechart4.xlsx">
+      <NativeLink href="https://elife-cdn.s3.amazonaws.com/elifechart4.xlsx">
         Excel
-      </ExternalLink>
+      </NativeLink>
       ).
     </Paragraph>
     <BoxChart data={data.chart4} />
@@ -65,9 +65,9 @@ const JournalMetrics = () => (
     <Paragraph>
       This shows the number of days between receiving the initial submission and
       publication (25th, 50th, and 75th percentiles; summary table{' '}
-      <ExternalLink href="https://elife-cdn.s3.amazonaws.com/elifechart5.xlsx">
+      <NativeLink href="https://elife-cdn.s3.amazonaws.com/elifechart5.xlsx">
         Excel
-      </ExternalLink>
+      </NativeLink>
       ). Publish on accept was introduced in April 2014, which allows authors to
       have their accepted manuscript PDF published within a few days. About 60%
       of authors opt for this, with the remaining authors preferring to wait for
@@ -77,9 +77,9 @@ const JournalMetrics = () => (
 
     <Paragraph>
       In addition to the summary tables, we have made the{' '}
-      <ExternalLink href="https://elife-cdn.s3.amazonaws.com/eliferawdata.csv">
+      <NativeLink href="https://elife-cdn.s3.amazonaws.com/eliferawdata.csv">
         raw data
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       available to download.
     </Paragraph>
   </React.Fragment>

--- a/app/components/pages/StaticPages/AuthorGuide/JournalPolicies.js
+++ b/app/components/pages/StaticPages/AuthorGuide/JournalPolicies.js
@@ -3,7 +3,7 @@ import { H1, H2, H3 } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
 import CalloutTextBox from '../../../ui/atoms/CalloutTextBox'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import List from '../../../ui/atoms/List'
 
 const JournalPolicies = props => (
@@ -12,24 +12,21 @@ const JournalPolicies = props => (
 
     <Paragraph>
       eLife is a member of the{' '}
-      <ExternalLink href="http://publicationethics.org/" target="_blank">
+      <NativeLink href="http://publicationethics.org/" target="_blank">
         Committee on Publication Ethics
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (COPE), supports their principles, and follows their{' '}
-      <ExternalLink
+      <NativeLink
         href="https://publicationethics.org/resources/flowcharts"
         target="_blank"
       >
         flowcharts
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for dealing with potential breaches of publication ethics. eLife also
       follows, as far as possible, the recommendations outlined in the{' '}
-      <ExternalLink
-        href="http://www.icmje.org/recommendations/"
-        target="_blank"
-      >
+      <NativeLink href="http://www.icmje.org/recommendations/" target="_blank">
         Uniform Requirements for Manuscripts Submitted to Biomedical Journals
-      </ExternalLink>
+      </NativeLink>
       , guidelines established by the ICMJE.
     </Paragraph>
 
@@ -42,16 +39,13 @@ const JournalPolicies = props => (
 
     <Paragraph>
       eLife is a signatory of the{' '}
-      <ExternalLink
-        href="https://centerforopenscience.org/top/"
-        target="_blank"
-      >
+      <NativeLink href="https://centerforopenscience.org/top/" target="_blank">
         Transparency and Openness Promotion (TOP) Guidelines
-      </ExternalLink>
+      </NativeLink>
       , which is an initiative by the{' '}
-      <ExternalLink href="https://centerforopenscience.org" target="_blank">
+      <NativeLink href="https://centerforopenscience.org" target="_blank">
         Center for Open Science
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       that promotes shared standards for increasing openness, transparency, and
       reproducibility.
     </Paragraph>
@@ -67,9 +61,9 @@ const JournalPolicies = props => (
       regulatory body to investigate. If someone has concerns about potential
       misconduct in a paper published by or under consideration by eLife, s/he
       should contact the journal office,{' '}
-      <ExternalLink href="mailto:editorial@elifesciences.org" target="_blank">
+      <NativeLink href="mailto:editorial@elifesciences.org" target="_blank">
         editorial@elifesciences.org
-      </ExternalLink>
+      </NativeLink>
       , with their message addressed to the Editor-in-Chief, Randy Schekman.
     </Paragraph>
 
@@ -79,49 +73,49 @@ const JournalPolicies = props => (
       Work involving human subjects or animal experimentation is expected to be
       conducted to the highest ethical standards, for example in accordance with
       the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://www.wma.net/policies-post/wma-declaration-of-helsinki-ethical-principles-for-medical-research-involving-human-subjects/"
         target="_blank"
       >
         World Medical Association Declaration of Helsinki
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for medical research, and with the relevant legislation and guidance for
       animal research listed by{' '}
-      <ExternalLink href="http://www.nc3rs.org.uk/" target="_blank">
+      <NativeLink href="http://www.nc3rs.org.uk/" target="_blank">
         NC3Rs
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
     <Paragraph>
       For clinical trials, eLife follows the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/"
         target="_blank"
       >
         recommendations of the ICMJE
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       that all trials must be prospectively registered to be considered for
       publication, and the clinical trial registration number will be requested
       during submission. When reporting randomised clinical trials, authors
       should follow the{' '}
-      <ExternalLink href="http://www.consort-statement.org/" target="_blank">
+      <NativeLink href="http://www.consort-statement.org/" target="_blank">
         CONSORT
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       guidelines and upload a CONSORT{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.consort-statement.org/consort-statement/checklist"
         target="_blank"
       >
         checklist
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.consort-statement.org/consort-statement/flow-diagram"
         target="_blank"
       >
         flow diagram
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       with their submission.
     </Paragraph>
 
@@ -130,20 +124,20 @@ const JournalPolicies = props => (
       the reason for lack of consent explained). When this work includes
       identifying, or potentially identifying, information, authors must also
       download the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elife-cdn.s3.amazonaws.com/author-guide/elife_Consent_to_Publish_Form.pdf"
         target="_blank"
       >
         Consent Form for Publication in eLife
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (PDF), which the individual, parent, or guardian must sign once they have
       read the article and been informed about the terms of the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://creativecommons.org/licenses/by/4.0/"
         target="_blank"
       >
         Creative Commons Attribution license
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (form and guidance based on those developed by PLOS). The signed consent
       form should not be submitted alongside the article, but authors should
       file it with the individual&apos;s case notes and the ethics statement
@@ -155,19 +149,19 @@ const JournalPolicies = props => (
     <Paragraph>
       eLife follows the guidelines of the International Committee of Medical
       Journal Editors (ICMJE) for{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html"
         target="_blank"
       >
         authorship and contributorship
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://docs.google.com/document/d/1aJxrQXYHW5U6By3KEAHrx1Iho6ioeh3ohNsRMwsoGPM/edit"
         target="_target"
       >
         Contributor Role Taxonomy
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (CRediT) is used to indicate each author’s contributions.
     </Paragraph>
 
@@ -179,12 +173,12 @@ const JournalPolicies = props => (
 
     <Paragraph>
       Following the recommendations of the ICMJE regarding{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.icmje.org/recommendations/browse/roles-and-responsibilities/defining-the-role-of-authors-and-contributors.html"
         target="_blank"
       >
         authorship and contributorship
-      </ExternalLink>
+      </NativeLink>
       , individuals who have contributed materially to the work, but do not
       satisfy the authorship criteria should be listed in the acknowledgements
       section. Authors should seek permission to mention any individuals listed
@@ -201,31 +195,31 @@ const JournalPolicies = props => (
       per year, and when starting new work or new cell lines confirm that the
       cell lines are free from mycoplasma and other microorganisms. Authors
       should check the list of{' '}
-      <ExternalLink
+      <NativeLink
         href="http://iclac.org/databases/cross-contaminations/"
         target="_blank"
       >
         commonly misidentified cell lines
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       maintained by the{' '}
-      <ExternalLink href="http://iclac.org/" target="_blank">
+      <NativeLink href="http://iclac.org/" target="_blank">
         International Cell Line Authentication Committee
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       before submission and justify the use of any cell lines contained therein.
       Cell line authentication services are offered by{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.lgcstandards-atcc.org/Services/Testing%20Services.aspx"
         target="_blank"
       >
         ATCC
-      </ExternalLink>
+      </NativeLink>
       ,{' '}
-      <ExternalLink
+      <NativeLink
         href="https://www.scienceexchange.com/services/cell-line-authentication"
         target="_blank"
       >
         Science Exchange
-      </ExternalLink>
+      </NativeLink>
       , and others.
     </Paragraph>
 
@@ -236,19 +230,19 @@ const JournalPolicies = props => (
       interests that might be perceived to interfere with the objectivity of the
       presentation or handling of the work. For further information on competing
       interests, see the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.icmje.org/recommendations/browse/roles-and-responsibilities/author-responsibilities--conflicts-of-interest.html"
         target="_blank"
       >
         recommendations of the ICMJE
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and the guidance provided by{' '}
-      <ExternalLink
+      <NativeLink
         href="http://journals.plos.org/plosmedicine/s/competing-interests"
         target="_blank"
       >
         PLOS
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -258,24 +252,24 @@ const JournalPolicies = props => (
       Copyrighted material (in full or in part) should not be included in a
       submission to eLife, unless you have explicit permission from the
       copyright holder that it can be reproduced under the terms of a{' '}
-      <ExternalLink
+      <NativeLink
         href="http://creativecommons.org/licenses/by/4.0/"
         target="_blank"
       >
         Creative Commons Attribution license
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
     <Paragraph>
       Occasionally we have published figures or parts of figures which cannot be
       re-published under a{' '}
-      <ExternalLink
+      <NativeLink
         href="http://creativecommons.org/licenses/by/4.0/"
         target="_blank"
       >
         Creative Commons Attribution license
-      </ExternalLink>
+      </NativeLink>
       . In those instances we ensure the correct attribution is provided within
       the human readable text (HTML and PDF versions of the article) and the
       underlying XML, for machine readability.
@@ -340,34 +334,34 @@ const JournalPolicies = props => (
     <Paragraph>
       Wherever possible, authors should make major datasets available using
       domain-specific public archives (for example,{' '}
-      <ExternalLink href="http://www.ncbi.nlm.nih.gov/genbank/" target="_blank">
+      <NativeLink href="http://www.ncbi.nlm.nih.gov/genbank/" target="_blank">
         GenBank
-      </ExternalLink>
+      </NativeLink>
       ,{' '}
-      <ExternalLink href="http://www.rcsb.org/pdb/home/home.do" target="_blank">
+      <NativeLink href="http://www.rcsb.org/pdb/home/home.do" target="_blank">
         Protein Data Bank
-      </ExternalLink>
+      </NativeLink>
       , and{' '}
-      <ExternalLink href="http://clinicaltrials.gov/" target="_blank">
+      <NativeLink href="http://clinicaltrials.gov/" target="_blank">
         ClinicalTrials.gov
-      </ExternalLink>
+      </NativeLink>
       ), or generic databases (for example,{' '}
-      <ExternalLink href="http://datadryad.org/" target="_blank">
+      <NativeLink href="http://datadryad.org/" target="_blank">
         Dryad
-      </ExternalLink>
+      </NativeLink>
       ,{' '}
-      <ExternalLink href="http://dataverse.org/" target="_blank">
+      <NativeLink href="http://dataverse.org/" target="_blank">
         Dataverse
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       or{' '}
-      <ExternalLink href="http://osf.io/" target="_blank">
+      <NativeLink href="http://osf.io/" target="_blank">
         the Open Science Framework
-      </ExternalLink>
+      </NativeLink>
       ) where a domain specific archive does not exist. A comprehensive
       catalogue of databases has been compiled by the{' '}
-      <ExternalLink href="https://fairsharing.org/" target="_blank">
+      <NativeLink href="https://fairsharing.org/" target="_blank">
         FAIRsharing information resource
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -405,19 +399,19 @@ const JournalPolicies = props => (
       Authors using unpublished datasets must abide by the relevant community
       guidelines for the use and acknowledgment of those data resources
       (including the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.genome.gov/pages/research/wellcomereport0303.pdf"
         target="_blank"
       >
         Fort Lauderdale
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.nature.com/nature/journal/v461/n7261/full/461168a.html"
         target="_blank"
       >
         Toronto
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       agreements in the case of genomic datasets), obtaining permission where
       required (which should be stated in the cover letter), and citing the
       appropriate laboratory, website, and accession numbers.
@@ -427,36 +421,36 @@ const JournalPolicies = props => (
 
     <Paragraph>
       Authors are required to follow the guidelines developed by{' '}
-      <ExternalLink
+      <NativeLink
         href="http://journals.plos.org/ploscompbiol/s/materials-and-software-sharing"
         target="_blank"
       >
         PLOS
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       if new software or a new algorithm is central to the submission; for
       example, authors must confirm that software conforms to the{' '}
-      <ExternalLink href="http://opensource.org/docs/osd" target="_blank">
+      <NativeLink href="http://opensource.org/docs/osd" target="_blank">
         Open Source Definition
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and is deposited in an appropriate public repository. To ensure that
       software can be reproduced without restrictions and that authors are
       properly acknowledged for their work, authors should license their code
       using an{' '}
-      <ExternalLink href="https://opensource.org/licenses" target="_blank">
+      <NativeLink href="https://opensource.org/licenses" target="_blank">
         open source license
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
     <Paragraph>
       Authors are encouraged to use version control services such as GitHub,
       GitLab, and SourceForge. eLife maintains a{' '}
-      <ExternalLink
+      <NativeLink
         href="http://github.com/elifesciences-publications/"
         target="_blank"
       >
         GitHub account
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       to archive code accompanying eLife publications that has been deposited on
       GitHub or another version control service. Binary files (&quot;non-text
       files&quot;, such as images, zip files, or program data) should be kept to
@@ -468,12 +462,12 @@ const JournalPolicies = props => (
 
     <Paragraph>
       In accordance with the principles established in{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.plantphysiol.org/content/132/1/19"
         target="_blank"
       >
         ‘Sharing Publication-Related Data and Materials’
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (doi:10.1104/pp.900068), a condition of publication is that authors must
       make the materials and resources described in their article promptly
       available upon reasonable request from academic researchers.
@@ -483,59 +477,56 @@ const JournalPolicies = props => (
       All biological reagents must be made available to qualified investigators
       upon reasonable request. We strongly encourage authors to deposit copies
       of their plasmids as DNA or bacterial stocks with repositories such as{' '}
-      <ExternalLink href="http://www.addgene.org/" target="_blank">
+      <NativeLink href="http://www.addgene.org/" target="_blank">
         Addgene
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       or{' '}
-      <ExternalLink
+      <NativeLink
         href="http://plasmid.med.harvard.edu/PLASMID/"
         target="_blank"
       >
         PlasmID
-      </ExternalLink>
+      </NativeLink>
       . Other established repositories for biological materials include the{' '}
-      <ExternalLink href="http://www.atcc.org/" target="_blank">
+      <NativeLink href="http://www.atcc.org/" target="_blank">
         American Type Culture Collection
-      </ExternalLink>
+      </NativeLink>
       ,{' '}
-      <ExternalLink href="https://abrc.osu.edu/" target="_blank">
+      <NativeLink href="https://abrc.osu.edu/" target="_blank">
         Arabidopsis Biological Resource Center
-      </ExternalLink>
+      </NativeLink>
       ,{' '}
-      <ExternalLink href="http://flystocks.bio.indiana.edu/" target="_blank">
+      <NativeLink href="http://flystocks.bio.indiana.edu/" target="_blank">
         Bloomington Drosophila Stock Center
-      </ExternalLink>
+      </NativeLink>
       ,{' '}
-      <ExternalLink href="https://cgc.umn.edu/" target="_blank">
+      <NativeLink href="https://cgc.umn.edu/" target="_blank">
         Caenorhabditis Genetics Center
-      </ExternalLink>
+      </NativeLink>
       , the{' '}
-      <ExternalLink href="http://www.eucomm.org/" target="_blank">
+      <NativeLink href="http://www.eucomm.org/" target="_blank">
         European Conditional Mouse Mutagenesis Program
-      </ExternalLink>
+      </NativeLink>
       , the{' '}
-      <ExternalLink href="https://www.infrafrontier.eu/" target="_blank">
+      <NativeLink href="https://www.infrafrontier.eu/" target="_blank">
         European Mouse Mutant Archive
-      </ExternalLink>
+      </NativeLink>
       , the{' '}
-      <ExternalLink href="http://www.komp.org/" target="_blank">
+      <NativeLink href="http://www.komp.org/" target="_blank">
         Knockout Mouse Project
-      </ExternalLink>
+      </NativeLink>
       , the{' '}
-      <ExternalLink href="http://www.jax.org/" target="_blank">
+      <NativeLink href="http://www.jax.org/" target="_blank">
         Jackson Laboratory
-      </ExternalLink>
+      </NativeLink>
       , the{' '}
-      <ExternalLink href="http://www.mmrrc.org/" target="_blank">
+      <NativeLink href="http://www.mmrrc.org/" target="_blank">
         Mutant Mouse Regional Resource Centers
-      </ExternalLink>
+      </NativeLink>
       , and{' '}
-      <ExternalLink
-        href="http://www.brc.riken.go.jp/inf/en/DB/"
-        target="_blank"
-      >
+      <NativeLink href="http://www.brc.riken.go.jp/inf/en/DB/" target="_blank">
         RIKEN Bioresource Centre
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -552,37 +543,37 @@ const JournalPolicies = props => (
       (RRIDs) within the Materials and Methods section to identify the model
       organisms, cells lines, antibodies, and tools (such as software or
       databases) you have used (e.g.{' '}
-      <ExternalLink
+      <NativeLink
         href="https://scicrunch.org/resolver/RRID:AB_2178887"
         target="_blank"
       >
         RRID:AB_2178887
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for an antibody,{' '}
-      <ExternalLink
+      <NativeLink
         href="https://scicrunch.org/resolver/RRID:MGI:3840442"
         target="_blank"
       >
         RRID:MGI:3840442
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for an organism,{' '}
-      <ExternalLink
+      <NativeLink
         href="https://scicrunch.org/resolver/RRID:CVCL_1H60"
         target="_blank"
       >
         RRID:CVCL_1H60
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for a cell line, and{' '}
-      <ExternalLink
+      <NativeLink
         href="https://scicrunch.org/resolver/RRID:SCR_007358"
         target="_blank"
       >
         RRID:SCR_007358
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for a tool). The{' '}
-      <ExternalLink href="https://scicrunch.org/resources" target="_blank">
+      <NativeLink href="https://scicrunch.org/resources" target="_blank">
         RRID Portal
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       lists existing RRIDs, and instructions for creating a new one if an RRID
       matching the resource does not already exist.
     </Paragraph>
@@ -592,12 +583,12 @@ const JournalPolicies = props => (
     <Paragraph>
       Regarding the oversight of dual use life-sciences research, we follow the
       recommendations formulated by the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://osp.od.nih.gov/biotechnology/dual-use-research-of-concern/"
         target="_blank"
       >
         National Science Advisory Board for Biosecurity
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (NSABB). If there are any concerns about dual use life-sciences research
       during submission or review, please bring them to the attention of the
       journal’s editors.
@@ -607,27 +598,24 @@ const JournalPolicies = props => (
 
     <Paragraph>
       eLife follows the guidance of the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.wame.org/policy-statements#Relationship between Editors and Owners"
         target="_blank"
       >
         World Association of Medical Editors
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and the{' '}
-      <ExternalLink
-        href="https://www.councilscienceeditors.org/"
-        target="_blank"
-      >
+      <NativeLink href="https://www.councilscienceeditors.org/" target="_blank">
         Council of Science Editors
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       regarding editorial independence. The editors of <em>eLife,</em> under the
       leadership of the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://elifesciences.org/about#leadership"
         target="_blank"
       >
         Editor-in-Chief
-      </ExternalLink>
+      </NativeLink>
       , have sole responsibility, authority, and accountability for the
       editorial content of the journal. Submissions are judged on their own
       merits, regardless of funding, author affiliations, or author
@@ -652,21 +640,21 @@ const JournalPolicies = props => (
     <Paragraph>
       Image files must not be manipulated or adjusted in any way that could lead
       to misinterpretation of the information present in the original image. See{' '}
-      <ExternalLink
+      <NativeLink
         href="http://jcb.rupress.org/content/166/1/11.full"
         target="_blank"
       >
         &apos;What&apos;s in a picture? The temptation of image
         manipulation&apos;
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (Rossner and Yamada 2004, Journal of Cell Biology, 166:11) and also{' '}
-      <ExternalLink
+      <NativeLink
         href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4114110/"
         target="_blank"
       >
         &apos;Avoiding Twisted Pixels: Ethical Guidelines for the Appropriate
         Use and Manipulation of Scientific Digital Images&apos;
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (Cromey 2010, Sci Eng Ethics, 16-639-667) for valuable guidance on
       acceptable practice and examples of inappropriate manipulation. Please
       take note of the following guidance in particular:
@@ -713,12 +701,12 @@ const JournalPolicies = props => (
 
     <Paragraph>
       Because articles published by eLife are licensed under a{' '}
-      <ExternalLink
+      <NativeLink
         href="https://creativecommons.org/licenses/by/4.0/"
         target="_blank"
       >
         Creative Commons Attribution license
-      </ExternalLink>
+      </NativeLink>
       , others are free to copy, distribute, and reuse them (in part or in
       full), without needing to seek permission, as long as the author and
       original source are properly cited.
@@ -787,12 +775,12 @@ const JournalPolicies = props => (
     <Paragraph>
       More information for institutional press officers and journalists is
       available at{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/for-the-press"
         target="_blank"
       >
         https://elifesciences.org/for-the-press
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -804,71 +792,71 @@ const JournalPolicies = props => (
       appropriate nomenclature databases for correct gene names and symbols
       should be consulted. Helpful reference points for approved nomenclature
       include{' '}
-      <ExternalLink href="http://flybase.org/" target="_blank">
+      <NativeLink href="http://flybase.org/" target="_blank">
         Genetic nomenclature for <em>Drosophila melanogaster</em>
-      </ExternalLink>
+      </NativeLink>
       ;{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.wormbase.org/about/userguide/nomenclature"
         target="_blank"
       >
         Genetic Nomenclature for <em>Caenorhabditis elegans</em>
-      </ExternalLink>
+      </NativeLink>
       ;{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.maizegdb.org/maize_nomenclature.php"
         target="_blank"
       >
         A Standard For Maize Genetics Nomenclature
-      </ExternalLink>
+      </NativeLink>
       ;{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.arabidopsis.org/portals/nomenclature/guidelines.jsp"
         target="_blank"
       >
         Arabidopsis Nomenclature
-      </ExternalLink>
+      </NativeLink>
       ;{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.genenames.org/about/guidelines"
         target="_blank"
       >
         Guidelines for Human Gene Nomenclature
-      </ExternalLink>
+      </NativeLink>
       ;{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.informatics.jax.org/mgihome/nomen/gene.shtml"
         target="_blank"
       >
         Rules for Nomenclature of Genes, Genetic Markers, Alleles, and Mutations
         in Mouse and Rat
-      </ExternalLink>
+      </NativeLink>
       ; the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.xenbase.org/gene/static/geneNomenclature.jsp"
         target="_blank"
       >
         Xenopus Gene Nomenclature Guidelines
-      </ExternalLink>
+      </NativeLink>
       ; and the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://wiki.zfin.org/display/general/ZFIN+Zebrafish+Nomenclature+Guidelines"
         target="_blank"
       >
         Zebrafish Nomenclature Guidelines
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
     <Paragraph>
       Note that in the specific case of a study that reports a new taxon name,
       authors are required to follow the guidelines developed by PLOS for{' '}
-      <ExternalLink
+      <NativeLink
         href="http://journals.plos.org/plosone/s/submission-guidelines"
         target="_blank"
       >
         zoological and botanical names
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -878,12 +866,12 @@ const JournalPolicies = props => (
       Preregistration of studies involves registering the study design,
       variables, and treatment conditions prior to conducting the research. For
       clinical trials, eLife follows the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/"
         target="_blank"
       >
         recommendations of the ICMJE
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       that all trials must be prospectively registered to be considered for
       publication, and the clinical trial registration number will be requested
       during submission.
@@ -891,12 +879,12 @@ const JournalPolicies = props => (
 
     <Paragraph>
       eLife is using the Registered Reports approach as part of the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/collections/reproducibility-project-cancer-biology"
         target="_blank"
       >
         Reproducibility Project: Cancer Biology
-      </ExternalLink>
+      </NativeLink>
       . For other submissions, authors are encouraged to consider whether
       preregistration would be appropriate, noting if they have done so within
       their cover letter.
@@ -907,12 +895,12 @@ const JournalPolicies = props => (
     <Paragraph>
       To facilitate the interpretation and replication of experiments, authors
       are required to complete eLife&apos;s{' '}
-      <ExternalLink
+      <NativeLink
         href="https://cdn.elifesciences.org/xpub/guides/transparent_reporting.pdf"
         target="_blank"
       >
         Transparent Reporting Form
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       before peer review. Authors are also required to adhere to
       well-established reporting standards, such as for microarray experiments,
       clinical trials, and so on.
@@ -924,41 +912,41 @@ const JournalPolicies = props => (
       upload any relevant reporting checklists or documents as a Reporting
       Standards Document to indicate the use of appropriate reporting guidelines
       for health-related research (see{' '}
-      <ExternalLink href="http://www.equator-network.org/" target="_blank">
+      <NativeLink href="http://www.equator-network.org/" target="_blank">
         EQUATOR Network
-      </ExternalLink>
+      </NativeLink>
       ), life science research (see the{' '}
-      <ExternalLink href="https://biosharing.org/" target="_blank">
+      <NativeLink href="https://biosharing.org/" target="_blank">
         BioSharing Information Resource
-      </ExternalLink>
+      </NativeLink>
       ), or the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.plosbiology.org/article/info:doi/10.1371/journal.pbio.1000412"
         target="_blank"
       >
         ARRIVE guidelines
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for reporting work involving animal research.
     </Paragraph>
 
     <Paragraph>
       In the specific case of a study containing an X-ray crystal structure,
       authors are required to upload a validation summary report from one of the{' '}
-      <ExternalLink href="http://www.wwpdb.org/" target="_blank">
+      <NativeLink href="http://www.wwpdb.org/" target="_blank">
         Worldwide Protein Data Bank
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       organisations as a Related Manuscript File.
     </Paragraph>
 
     <Paragraph>
       In the specific case of a study containing functional enzyme data, we
       encourage authors to deposit data to{' '}
-      <ExternalLink
+      <NativeLink
         href="https://www.beilstein-strenda-db.org/strenda/"
         target="_blank"
       >
         STRENDA DB
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and to upload the “Experimental data fact sheet” that accompanies the
       deposition as a Reporting Standards Document in the submission to eLife.
     </Paragraph>
@@ -972,9 +960,9 @@ const JournalPolicies = props => (
         affect the decision on manuscripts under consideration, or our policies
         relating to the confidentiality of the review process. If you would like
         to opt out of eLife&apos;s research and/or surveys, please{' '}
-        <ExternalLink href="mailto:editorial@elifesciences.org" target="_blank">
+        <NativeLink href="mailto:editorial@elifesciences.org" target="_blank">
           contact the journal office
-        </ExternalLink>
+        </NativeLink>
         .
       </Paragraph>
     </CalloutTextBox>

--- a/app/components/pages/StaticPages/AuthorGuide/Post.js
+++ b/app/components/pages/StaticPages/AuthorGuide/Post.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { H1, H2, H3 } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import List from '../../../ui/atoms/List'
 
 const Post = props => (
@@ -14,21 +14,21 @@ const Post = props => (
     <Paragraph>
       eLife is an open-access journal: articles are distributed under the terms
       of the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://creativecommons.org/licenses/by/4.0/"
         target="_blank"
       >
         Creative Commons Attribution License
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (except where otherwise noted), which permits unrestricted use and
       redistribution provided that the original author and source are credited,
       in line with the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.budapestopenaccessinitiative.org/read"
         target="_blank"
       >
         BOAI definition of open access
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 
@@ -37,17 +37,17 @@ const Post = props => (
     <Paragraph>
       If your paper involves a method that would also benefit from the
       publication of a step-by-step protocol (e.g.,{' '}
-      <ExternalLink href="http://bio-protocol.org/e1067" target="_blank">
+      <NativeLink href="http://bio-protocol.org/e1067" target="_blank">
         http://bio-protocol.org/e1067
-      </ExternalLink>
+      </NativeLink>
       ), we would encourage you to consider{' '}
-      <ExternalLink href="http://www.bio-protocol.org/" target="_blank">
+      <NativeLink href="http://www.bio-protocol.org/" target="_blank">
         Bio-protocol
-      </ExternalLink>
+      </NativeLink>
       , which curates high-quality life science protocols, or{' '}
-      <ExternalLink href="https://www.protocols.io/" target="_blank">
+      <NativeLink href="https://www.protocols.io/" target="_blank">
         protocols.io
-      </ExternalLink>
+      </NativeLink>
       , which is an open-access repository of science methods.
     </Paragraph>
 
@@ -55,26 +55,26 @@ const Post = props => (
       <li>
         For a submission to Bio-protocol (these are subject to peer review),
         please refer to their{' '}
-        <ExternalLink
+        <NativeLink
           href="http://www.bio-protocol.org/Protocol_Preparation_Guidelines.aspx"
           target="_blank"
         >
           guidelines
-        </ExternalLink>{' '}
+        </NativeLink>{' '}
         and then submit the protocol using{' '}
-        <ExternalLink
+        <NativeLink
           href="http://www.bio-protocol.org/login.aspx?in=2%20"
           target="_blank"
         >
           this link
-        </ExternalLink>
+        </NativeLink>
         .
       </li>
       <li>
         For a submission to{' '}
-        <ExternalLink href="https://www.protocols.io/" target="_blank">
+        <NativeLink href="https://www.protocols.io/" target="_blank">
           protocols.io
-        </ExternalLink>
+        </NativeLink>
         , after describing the step-by-step protocol, select “Get DOI” to obtain
         a persistent digital object identifier, which should be included within
         the Materials and Methods section of your manuscript, using this format:
@@ -89,12 +89,12 @@ const Post = props => (
     <Paragraph>
       To ensure that new research is made available as rapidly as possible,
       eLife offers an{' '}
-      <ExternalLink
+      <NativeLink
         href="http://elifesciences.org/elife-news/picking-up-speed"
         target="_blank"
       >
         optional service to authors
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       whereby a PDF of their accepted manuscript can be published within a few
       days of acceptance.
     </Paragraph>
@@ -124,12 +124,12 @@ const Post = props => (
       The final version of the accepted article will be published, along with
       the decision letter incorporating the review comments and the authors’
       response to those comments (as in{' '}
-      <ExternalLink
+      <NativeLink
         href="http://elifesciences.org/content/1/e00109/#decision-letter"
         target="_blank"
       >
         eLife 2012;1:e00109
-      </ExternalLink>
+      </NativeLink>
       ). If authors have any questions or concerns about the content of the
       decision letter after peer review, or their response to this letter, it is
       important to notify the journal office as soon as possible.
@@ -188,48 +188,48 @@ const Post = props => (
       (where they agree) with another journal of the corresponding author’s
       choice. As an example of what others have done, we have facilitated the
       transfer of review material to a range of journals, including{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.biologists.com/biology-open/transfer-to-biology-open-from-elife/"
         target="_blank"
       >
         Biology Open
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       (which offers the option to upload the manuscript files on the
       corresponding author’s behalf),{' '}
-      <ExternalLink href="https://bmcbiol.biomedcentral.com/" target="_blank">
+      <NativeLink href="https://bmcbiol.biomedcentral.com/" target="_blank">
         BMC Biology
-      </ExternalLink>
+      </NativeLink>
       ,{' '}
-      <ExternalLink href="http://embor.embopress.org/" target="_blank">
+      <NativeLink href="http://embor.embopress.org/" target="_blank">
         EMBO Reports
-      </ExternalLink>
+      </NativeLink>
       ,{' '}
-      <ExternalLink href="http://www.eneuro.org/ " target="_blank">
+      <NativeLink href="http://www.eneuro.org/ " target="_blank">
         eNeuro
-      </ExternalLink>
+      </NativeLink>
       , the{' '}
-      <ExternalLink
+      <NativeLink
         href="https://www.plos.org/which-journal-is-right-for-me"
         target="_blank"
       >
         PLOS journals
-      </ExternalLink>
+      </NativeLink>
       , the{' '}
-      <ExternalLink href="http://jcb.rupress.org/" target="_blank">
+      <NativeLink href="http://jcb.rupress.org/" target="_blank">
         Journal of Cell Biology
-      </ExternalLink>
+      </NativeLink>
       , and the{' '}
-      <ExternalLink href="http://jgp.rupress.org/" target="_blank">
+      <NativeLink href="http://jgp.rupress.org/" target="_blank">
         Journal of General Physiology
-      </ExternalLink>
+      </NativeLink>
       . We encourage authors of neuroscience submissions to consider re-using
       reviews with other members of the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://nprc.incf.org/index.php/about/information-for-authors/"
         target="_blank"
       >
         Neuroscience Peer Review Consortium
-      </ExternalLink>
+      </NativeLink>
       .
     </Paragraph>
 

--- a/app/components/pages/StaticPages/AuthorGuide/Revised.js
+++ b/app/components/pages/StaticPages/AuthorGuide/Revised.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { H1, H2, H3, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 
 const Revised = props => (
   <React.Fragment>
@@ -28,12 +28,12 @@ const Revised = props => (
     <Paragraph>
       The text file, with any main tables at the end, should be uploaded as a
       DOCX (or DOC or RTF) file, or as a LaTeX file (ideally using our{' '}
-      <ExternalLink
+      <NativeLink
         href="https://cdn.elifesciences.org/author-guide/elife-latex-template.zip"
         target="_blank"
       >
         LaTeX template
-      </ExternalLink>
+      </NativeLink>
       ). The uploaded Article File should include tracked changes indicating the
       revisions made, ideally using the tracked changes function in Word. (If
       you prefer to indicate textual changes in another way, for example with
@@ -70,23 +70,23 @@ const Revised = props => (
       resubmission. This is designed to highlight genetically modified organisms
       and strains, cell lines, reagents, and software that are essential to
       reproduce the results presented. Please download and complete{' '}
-      <ExternalLink
+      <NativeLink
         href="https://cdn.elifesciences.org/author-guide/key_resources_table.xlsx"
         target="_blank"
       >
         this template
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for the Key Resources Table to ensure consistency. The template is a
       resource developed by FlyBase with input from other model organism
       databases, and it includes notes on completion and an example table. The
       completed Key Resources Table should be incorporated within your article
       file at the very beginning of the Materials and Methods section (
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/articles/32586#s4"
         target="_blank"
       >
         example in published article available here
-      </ExternalLink>
+      </NativeLink>
       ).
     </Paragraph>
 

--- a/app/components/pages/StaticPages/AuthorGuide/Types.js
+++ b/app/components/pages/StaticPages/AuthorGuide/Types.js
@@ -3,7 +3,7 @@ import { H1, H2, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
 import CalloutTextBox from '../../../ui/atoms/CalloutTextBox'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 
 const Types = props => (
   <React.Fragment>
@@ -14,22 +14,22 @@ const Types = props => (
     <H2>Editorials, Insights, and Feature articles</H2>
 
     <Paragraph>
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/articles/editorial"
         target="_blank"
       >
         Editorials
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       in eLife are written by eLife editors or staff.
     </Paragraph>
 
     <Paragraph>
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/articles/insight"
         target="_blank"
       >
         Insights
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       are commissioned by eLife staff and are always related to a Research
       Article published in the journal. Insights are written by experts in the
       field of the Research Article: they explain why the results reported are
@@ -37,12 +37,12 @@ const Types = props => (
     </Paragraph>
 
     <Paragraph>
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/articles/feature"
         target="_blank"
       >
         Feature Articles
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       should offer fresh insights into topics of broad interest to readers
       working in the life and biomedical sciences. There are no strict limits on
       length, but authors are advised to stay below 2000 words, two display
@@ -92,9 +92,9 @@ const Types = props => (
       Therefore, major datasets must be publicly deposited (unless there are
       strong ethical or legal reasons to restrict access); relevant code must
       conform to the{' '}
-      <ExternalLink href="https://opensource.org/docs/osd" target="_blank">
+      <NativeLink href="https://opensource.org/docs/osd" target="_blank">
         Open Source Definition
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and be deposited in an appropriate public repository; and methodological
       advances need to be comprehensively described, along with details of the
       reagents and equipment, and their sources. Authors should follow the
@@ -138,19 +138,19 @@ const Types = props => (
       Materials and Methods section when the methods are the same as the
       original paper. Authors should upload a completed version of the
       Transparent Reporting Form (
-      <ExternalLink
+      <NativeLink
         href="https://cdn.elifesciences.org/xpub/guides/transparent_reporting.pdf"
         target="_blank"
       >
         PDF
-      </ExternalLink>
+      </NativeLink>
       ;{' '}
-      <ExternalLink
+      <NativeLink
         href="https://cdn.elifesciences.org/xpub/guides/transparent_reporting.docx"
         target="_blank"
       >
         Word
-      </ExternalLink>
+      </NativeLink>
       ) to accompany their submission.
     </Paragraph>
 
@@ -181,12 +181,12 @@ const Types = props => (
       original article&quot;&apos;, and it should be written in a measured tone;
       manuscripts not written in measured tone will be sent back to the authors
       for revision: please read{' '}
-      <ExternalLink
+      <NativeLink
         href="https://elifesciences.org/inside-elife/08093bce/elife-latest-introducing-scientific-correspondence-at-elife?_ga=2.134784754.2069272108.1540132848-2034406101.1537543708"
         target="_blank"
       >
         this blogpost
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       for more information.
     </Paragraph>
 

--- a/app/components/pages/StaticPages/ReviewerGuide/ReviewProcess.js
+++ b/app/components/pages/StaticPages/ReviewerGuide/ReviewProcess.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { H1, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 
 const ReviewProcess = props => (
   <React.Fragment>
@@ -25,12 +25,12 @@ const ReviewProcess = props => (
       An online consultation session is opened with the reviewer(s) once all the
       reviews have been received. The Reviewing Editor will draft a decision
       letter, with input welcome from the other reviewer(s). A{' '}
-      <ExternalLink
+      <NativeLink
         href="http://elifesciences.org/about#leadership"
         target="_blank"
       >
         Senior Editor
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       is available at each stage to provide guidance and oversight of the
       process as a whole. Our aim is to provide clear and decisive instructions
       to authors, so that they know what they need to do to get the article
@@ -50,9 +50,9 @@ const ReviewProcess = props => (
     <Paragraph>
       We very much appreciate the efforts of our peer reviewers, and we are
       pleased to work with{' '}
-      <ExternalLink href="https://publons.com/in/elife/" target="_blank">
+      <NativeLink href="https://publons.com/in/elife/" target="_blank">
         Publons
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       to give researchers the opportunity to be recognised for providing reviews
       for eLife.
     </Paragraph>

--- a/app/components/pages/StaticPages/ReviewerGuide/ReviewingPolicies.js
+++ b/app/components/pages/StaticPages/ReviewerGuide/ReviewingPolicies.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { H1, H2, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import List from '../../../ui/atoms/List'
 
 const ReviewingPolicies = props => (
@@ -66,19 +66,19 @@ const ReviewingPolicies = props => (
       We ask reviewers to recognise potential competing interests that could
       lead them to be positively or negatively disposed towards an article. We
       follow the recommendations of the{' '}
-      <ExternalLink
+      <NativeLink
         href="http://www.icmje.org/recommendations/browse/roles-and-responsibilities/author-responsibilities--conflicts-of-interest.html"
         target="_blank"
       >
         ICMJE
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       and the guidance provided by{' '}
-      <ExternalLink
+      <NativeLink
         href="http://journals.plos.org/plosmedicine/s/competing-interests"
         target="_blank"
       >
         PLOS
-      </ExternalLink>
+      </NativeLink>
       . Reviewers should inform the editors or journal staff if they are close
       competitors or collaborators of the authors. Reviewers must recuse
       themselves if they feel that they are unable to offer an impartial review.
@@ -119,9 +119,9 @@ const ReviewingPolicies = props => (
       relating to the confidentiality of the review process. If you would like
       to opt out of eLife&apos;s research and/or surveys, please contact the
       journal office (
-      <ExternalLink href="mailto:editorial@elifesciences.org" target="_blank">
+      <NativeLink href="mailto:editorial@elifesciences.org" target="_blank">
         here
-      </ExternalLink>
+      </NativeLink>
       ).
     </Paragraph>
   </React.Fragment>

--- a/app/components/pages/StaticPages/ReviewerGuide/WritingTheReview.js
+++ b/app/components/pages/StaticPages/ReviewerGuide/WritingTheReview.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { H1, H2, Link } from '@pubsweet/ui'
 
 import Paragraph from '../../../ui/atoms/Paragraph'
-import ExternalLink from '../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../ui/atoms/NativeLink'
 import List from '../../../ui/atoms/List'
 
 const WritingTheReview = props => (
@@ -13,12 +13,12 @@ const WritingTheReview = props => (
 
     <Paragraph>
       eLife’s{' '}
-      <ExternalLink
+      <NativeLink
         href="http://elifesciences.org/about#aims-and-scope"
         target="_blank"
       >
         scope
-      </ExternalLink>{' '}
+      </NativeLink>{' '}
       is broad and inclusive, covering the full range of biomedical and life
       science research, from the most basic and theoretical work through to
       translational, applied and clinical research. We seek to publish all

--- a/app/components/pages/SubmissionWizard/steps/Disclosure/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Disclosure/index.js
@@ -6,7 +6,7 @@ import { format, parse } from 'date-fns'
 
 import Paragraph from '../../../../ui/atoms/Paragraph'
 import SmallParagraph from '../../../../ui/atoms/SmallParagraph'
-import ExternalLink from '../../../../ui/atoms/ExternalLink'
+import NativeLink from '../../../../ui/atoms/NativeLink'
 import { FormH3 } from '../../../../ui/atoms/FormHeadings'
 import ValidatedField from '../../../../ui/atoms/ValidatedField'
 import ControlledCheckbox from '../../../../ui/atoms/ControlledCheckbox'
@@ -37,12 +37,12 @@ const DisclosurePage = ({ values }) => {
       <Box mb={4}>
         <Paragraph>
           Our{' '}
-          <ExternalLink
+          <NativeLink
             href="https://elifesciences.org/privacy-notice"
             target="_blank"
           >
             privacy policy
-          </ExternalLink>{' '}
+          </NativeLink>{' '}
           explains that we share your personal information with various third
           parties to enable us to review and publish your manuscript, and that
           we protect your data with detailed contractual arrangements with those
@@ -56,9 +56,9 @@ const DisclosurePage = ({ values }) => {
           in the UK. Because of this risk, we ask for your explicit consent to
           share your personal data with them, which you can withdraw at any time
           (by emailing{' '}
-          <ExternalLink href="mailto:data@elifesciences.org">
+          <NativeLink href="mailto:data@elifesciences.org">
             data@elifesciences.org
-          </ExternalLink>
+          </NativeLink>
           ). Please enter your name and check the box below to give this
           consent. Without this consent we will not be able to evaluate your
           submission.

--- a/app/components/pages/ThankYou/ThankYou.js
+++ b/app/components/pages/ThankYou/ThankYou.js
@@ -4,7 +4,7 @@ import { Box } from 'grid-styled'
 import PropTypes from 'prop-types'
 import { H1 } from '@pubsweet/ui'
 import { th } from '@pubsweet/ui-toolkit'
-import ExternalLink from '../../ui/atoms/ExternalLink'
+import NativeLink from '../../ui/atoms/NativeLink'
 import ButtonLink from '../../ui/atoms/ButtonLink'
 import Paragraph from '../../ui/atoms/Paragraph'
 import SmallParagraph from '../../ui/atoms/SmallParagraph'
@@ -16,7 +16,7 @@ const SubText = styled(SmallParagraph)`
   color: ${th('colorTextSecondary')};
 `
 
-const BookmarkLink = styled(ExternalLink)`
+const BookmarkLink = styled(NativeLink)`
   display: inline-block;
   clear: both;
 `

--- a/app/components/ui/atoms/ExternalLink.md
+++ b/app/components/ui/atoms/ExternalLink.md
@@ -1,5 +1,0 @@
-Styled link, to be used for navigation to external websites, as opposed to the `Link` component in pubsweet for internal links.
-
-```js
-<ExternalLink href="www.wikipedia.com">Go to wikipedia</ExternalLink>
-```

--- a/app/components/ui/atoms/NativeLink.js
+++ b/app/components/ui/atoms/NativeLink.js
@@ -1,9 +1,9 @@
 import styled from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
 
-const ExternalLink = styled.a`
+const NativeLink = styled.a`
   color: ${th('colorPrimary')};
   text-decoration: none;
 `
 
-export default ExternalLink
+export default NativeLink

--- a/app/components/ui/atoms/NativeLink.md
+++ b/app/components/ui/atoms/NativeLink.md
@@ -1,0 +1,5 @@
+Styled link, to be used for navigation to external websites (or hash links within the same page via id), as opposed to the `Link` component in pubsweet for internal links.
+
+```js
+<NativeLink href="www.wikipedia.com">Go to wikipedia</NativeLink>
+```


### PR DESCRIPTION
#### Background
At the moment we use 2 (or 3) different types of links in our application:
- `ExternalLink` - our own component: an anchor tag with eLife styling applied
- `Link` from pubsweet - which uses react-router's `Link` under the hood & applies styling)

(Note: elsewhere we also import `Link` directly from react-router, in situations where it's not styled normally i.e. non-blue links in ProfileMenu, DashboardList, etc.)

Until now, we had never linked to a heading within the same page (via an id).

#### What does this PR do?
- Fixes broken links in `EditorialProcess` & `Fees` components by changing `Link` (react-router) to `ExternalLink` (regular anchor tag)
- Renames the `ExternalLink` component to `NativeLink`, to better describe all use cases
- Updates ExternalLInk/Native Link styleguidist description accordingly

#### Any relevant tickets
Fixes #907 
Fixes #955

#### How has this been tested?
Manually clicking the links