### PR TITLE
Fix semibold issue

### DIFF
--- a/app/components/global/AppBar/ProfileMenu.js
+++ b/app/components/global/AppBar/ProfileMenu.js
@@ -59,7 +59,8 @@ const MenuItem = styled.li`
 `
 
 const MenuHeading = styled.div`
-  font-weight: bold;
+  font-family: ${th('fontHeading')};
+  font-weight: 400;
   border-bottom: ${th('borderWidth')} ${th('borderStyle')} ${th('colorBorder')};
   padding: ${th('space.2')};
   padding-right: ${th('space.3')};

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -50,7 +50,8 @@ const Root = styled(Flex)`
 
 const TitleBox = styled(Box)`
   color: ${props => props.theme[props.color]};
-  font-weight: bold;
+  font-family: ${th('fontHeading')};
+  font-weight: 400;
   text-align: left;
   flex-grow: 1;
   ${media.tabletPortraitUp`

--- a/app/components/ui/molecules/StaffCard.js
+++ b/app/components/ui/molecules/StaffCard.js
@@ -11,7 +11,8 @@ const StaffImg = styled.img`
 `
 
 const StaffName = styled.div`
-  font-weight: bold;
+  font-family: ${th('fontHeading')};
+  font-weight: 400;
 `
 const StaffCard = ({ name, telephone, jobTitle, photoURL }) => (
   <React.Fragment>

--- a/client/elife-theme/src/elements/ui/Action.js
+++ b/client/elife-theme/src/elements/ui/Action.js
@@ -1,0 +1,9 @@
+import { css } from 'styled-components'
+import { th } from '@pubsweet/ui-toolkit'
+
+export default css`
+  // Action is sometimes a Link underneath & sometimes a Button
+  // eLife styling makes a button's font: Noto Sans SemiBold
+  // This reverses that override
+  font-family: ${th('fontInterface')};
+`

--- a/client/elife-theme/src/elements/ui/Action.js
+++ b/client/elife-theme/src/elements/ui/Action.js
@@ -1,9 +1,0 @@
-import { css } from 'styled-components'
-import { th } from '@pubsweet/ui-toolkit'
-
-export default css`
-  // Action is sometimes a Link underneath & sometimes a Button
-  // eLife styling makes a button's font: Noto Sans SemiBold
-  // This reverses that override
-  font-family: ${th('fontInterface')};
-`

--- a/client/elife-theme/src/elements/ui/Button.js
+++ b/client/elife-theme/src/elements/ui/Button.js
@@ -38,7 +38,7 @@ export default css`
   padding: ${th('space.2')};
   min-width: calc(${th('gridUnit')} * 28);
   text-transform: uppercase;
-  font-family: ${th('fontHeading')};
+  font-family: ${props => (props.to ? th('fontHeading') : th('fontInterface'))};
   font-weight: 400;
 
   ${props => props.small && small};

--- a/client/elife-theme/src/elements/ui/Button.js
+++ b/client/elife-theme/src/elements/ui/Button.js
@@ -38,7 +38,7 @@ export default css`
   padding: ${th('space.2')};
   min-width: calc(${th('gridUnit')} * 28);
   text-transform: uppercase;
-  font-family: ${props => (props.to ? th('fontHeading') : th('fontInterface'))};
+  font-family: ${th('fontHeading')};
   font-weight: 400;
 
   ${props => props.small && small};

--- a/client/elife-theme/src/elements/ui/Button.js
+++ b/client/elife-theme/src/elements/ui/Button.js
@@ -38,6 +38,8 @@ export default css`
   padding: ${th('space.2')};
   min-width: calc(${th('gridUnit')} * 28);
   text-transform: uppercase;
+  font-family: ${th('fontHeading')};
+  font-weight: 400;
 
   ${props => props.small && small};
   ${props => props.extraSmall && extraSmall};

--- a/client/elife-theme/src/elements/ui/Heading.js
+++ b/client/elife-theme/src/elements/ui/Heading.js
@@ -5,6 +5,7 @@ export default css`
   /* clear browser-added margin and font-size */
   margin-top: 0px;
   color: ${th('colorText')};
+  font-weight: 400;
 `
 
 export const H1 = css`


### PR DESCRIPTION
#### Background
Noto Sans SemiBold + non-Chrome browsers do not play well :cry: 

#### What does this PR do?
- override default font family of `Button` component in pubsweet, to now use `Noto Sans SemiBold`
- over-override font family `Action` component (that sometimes uses Button under the hood), so this is back to just `Noto Sans`
- add `font-weight: 400` everywhere that we use our `fontHeading` theme variable (aka `Noto Sans SemiBold` font family)

#### Any relevant tickets
fixes #915 
relates #687 

#### How has this been tested?
N/A - style change