### PR TITLE
Improve dashboarditem dates and add tests

### DIFF
--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -1,32 +1,41 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Flex, Box } from 'grid-styled'
-import {
-  differenceInCalendarDays,
-  differenceInCalendarMonths,
-  format,
-} from 'date-fns'
+import { differenceInCalendarDays, format } from 'date-fns'
 import { th } from '@pubsweet/ui-toolkit'
 import PropTypes from 'prop-types'
 import ManuscriptStatus from '../atoms/ManuscriptStatus'
 import media from '../../global/layout/media'
 
-const dashboardDateText = date => {
+export const dashboardDateText = date => {
   const diffDays = differenceInCalendarDays(new Date(), date)
-  const diffMonths = differenceInCalendarMonths(new Date(), date)
-  if (diffDays < 0) {
+  if (diffDays < 0 || Number.isNaN(diffDays)) {
     return 'Invalid date'
   }
+
   if (diffDays === 0) {
     return 'Today'
   }
+
   if (diffDays === 1) {
     return 'Yesterday'
   }
-  if (diffMonths > 0) {
+
+  if (diffDays < 14) {
+    return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ago`
+  }
+
+  if (diffDays < 30) {
+    const diffWeeks = Math.round(diffDays / 7)
+    return `${diffWeeks} ${diffWeeks === 1 ? 'week' : 'weeks'} ago`
+  }
+
+  if (diffDays < 730) {
+    const diffMonths = Math.round(diffDays / 30)
     return `${diffMonths} ${diffMonths === 1 ? 'month' : 'months'} ago`
   }
-  return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ago`
+  const diffYears = Math.round(diffDays / 365)
+  return `${diffYears} ${diffYears === 1 ? 'year' : 'years'} ago`
 }
 
 const mapColor = statusCode =>

--- a/app/components/ui/molecules/DashboardListItem.test.js
+++ b/app/components/ui/molecules/DashboardListItem.test.js
@@ -1,0 +1,36 @@
+import { subDays } from 'date-fns'
+
+import { dashboardDateText } from './DashboardListItem'
+
+describe('DashboardListItem', () => {
+  describe('dashboardDateText', () => {
+    it('show invalid for future date', () => {
+      expectText(-1, 'Invalid date')
+    })
+    it('handles bad argument', () => {
+      const value = dashboardDateText(Object())
+      expect(value).toBe('Invalid date')
+    })
+    it('shows correct text', () => {
+      expectText(0, 'Today')
+      expectText(1, 'Yesterday')
+      expectText(2, '2 days ago')
+      expectText(6, '6 days ago')
+      expectText(13, '13 days ago')
+      expectText(14, '2 weeks ago')
+      expectText(29, '4 weeks ago')
+      expectText(30, '1 month ago')
+      expectText(44, '1 month ago')
+      expectText(45, '2 months ago')
+      expectText(364, '12 months ago')
+      expectText(729, '24 months ago')
+      expectText(730, '2 years ago')
+      expectText(1460, '4 years ago')
+    })
+  })
+})
+
+function expectText(daysAgo, expectedText) {
+  const value = dashboardDateText(subDays(new Date(), daysAgo))
+  expect(value).toBe(expectedText)
+}


### PR DESCRIPTION
#### Background

Improves the display of dates on the dashboard item.

#### Any relevant tickets

Closes 957

#### How has this been tested?
Locally