### PR TITLE
965 - default dropdown background color is now colorBackground

### DIFF
--- a/app/components/ui/atoms/NavigationDropdown.js
+++ b/app/components/ui/atoms/NavigationDropdown.js
@@ -36,6 +36,7 @@ class NavigationDropdown extends React.Component {
         border: 'none',
         boxShadow: 'none',
         minHeight: this.props.theme.space[6],
+        backgroundColor: this.props.theme.colorBackground,
       }),
       singleValue: (base, state) => ({
         ...base,


### PR DESCRIPTION
#### Background

Background colour of dropdown was grey before becoming active. It should be `colorBackground` like the dropdown options list at all times.

<img width="479" alt="screenshot 2018-11-02 at 16 44 20" src="https://user-images.githubusercontent.com/22455561/47928565-9af99300-debe-11e8-8fd7-f8aaeea52a47.png">

What does this PR do?

Sets the dropdown's in-active background to `colorBackground`.

<img width="520" alt="screenshot 2018-11-02 at 16 45 46" src="https://user-images.githubusercontent.com/22455561/47928669-c7151400-debe-11e8-9ebb-fa5872ee88b8.png">

#### Any relevant tickets

closes #965

#### How has this been tested?

visually
