### PR TITLE
Push image and deploy the Helm chart - review scheduled for Friday

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,7 @@ elifePipeline {
         stage 'Deploy for review', {
             checkout scm
             sh "scripts/helm_deploy.sh pr-${prNumber} ${commit}"
+            def reviewUrl = sh script: "scripts/helm_url.sh pr-${prNumber}", returnStdout: true
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ elifePipeline {
     elifePullRequestOnly { prNumber ->
         stage 'Deploy for review', {
             checkout scm
-            sh "scripts/helm_deploy.sh pr-${prNumber}"
+            sh "scripts/helm_deploy.sh pr-${prNumber} ${commit}"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ elifePipeline {
                 commit,
                 'success',
                 'continuous-integration/jenkins/deploy-for-review',
-                'Deploy for review URL',
+                'Deploy for review URL (experimental)',
                 reviewUrl
             )
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ elifePipeline {
         stage 'Deploy for review', {
             checkout scm
             sh "scripts/helm_deploy.sh pr-${prNumber} ${commit}"
-            def reviewUrl = sh script: "scripts/helm_url.sh pr-${prNumber}", returnStdout: true
+            def reviewUrl = sh(script: "scripts/helm_url.sh pr-${prNumber}", returnStdout: true).trim()
             echo "Review url: $reviewUrl"
             elifeGithubCommitStatus(
                 commit,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ elifePipeline {
 
     elifePullRequestOnly { prNumber ->
         stage 'Deploy for review', {
+            checkout scm
             sh "scripts/helm_deploy.sh pr-${prNumber}"
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,14 @@ elifePipeline {
             checkout scm
             sh "scripts/helm_deploy.sh pr-${prNumber} ${commit}"
             def reviewUrl = sh script: "scripts/helm_url.sh pr-${prNumber}", returnStdout: true
+            echo "Review url: $reviewUrl"
+            elifeGithubCommitStatus(
+                commit,
+                'success',
+                'continuous-integration/jenkins/deploy-for-review',
+                'Deploy for review URL',
+                reviewUrl
+            )
         }
     }
 }

--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -21,4 +21,4 @@ else
 fi
 
 cd helm/
-sudo -u elife helm upgrade --install $release_name --set image.tag=${image_tag} elife-xpub
+sudo -u elife -H helm upgrade --install $release_name --set image.tag=${image_tag} elife-xpub

--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -8,8 +8,8 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-release_name="elife-xpub--{$1}"
-image_tag="$2"
+release_name="elife-xpub--${1}"
+image_tag="${2}"
 
 # temporary: should use an S3 chart repository
 if [ ! -d /tmp/elife-xpub-formula ]; then
@@ -21,4 +21,4 @@ else
 fi
 
 cd helm/
-sudo -u elife -H helm upgrade --install $release_name --set image.tag=${image_tag} elife-xpub
+sudo -u elife -H helm upgrade --install "$release_name" --set image.tag="${image_tag}" elife-xpub

--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -4,7 +4,7 @@ set -e
 if [ "$#" -ne 2 ]; then
     echo "Usage: $0 INSTANCE_NAME IMAGE_TAG"
     echo "Example: $0 pr-42 latest"
-    echo "Will create a elife-xpub--$INSTANCE_NAME Helm release deploying the given tag"
+    echo "Will create a elife-xpub--\$INSTANCE_NAME Helm release deploying the given tag"
     exit 1
 fi
 

--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -21,4 +21,4 @@ else
 fi
 
 cd helm/
-helm upgrade --install $release_name --set image.tag=${image_tag} elife-xpub
+sudo -u elife helm upgrade --install $release_name --set image.tag=${image_tag} elife-xpub

--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 INSTANCE_NAME IMAGE_TAG"
+    echo "Example: $0 pr-42 latest"
+    echo "Will create a elife-xpub--$INSTANCE_NAME Helm release deploying the given tag"
+    exit 1
+fi
+
+release_name="elife-xpub--{$1}"
+image_tag="$2"
+
+# temporary: should use an S3 chart repository
+if [ ! -d /tmp/elife-xpub-formula ]; then
+    git clone git@github.com:elifesciences/elife-xpub-formula.git /tmp/elife-xpub-formula
+    cd /tmp/elife-xpub-formula
+else
+    cd /tmp/elife-xpub-formula
+    git pull origin master
+fi
+
+cd helm/
+helm upgrade --install $release_name --set image.tag=${image_tag} elife-xpub

--- a/scripts/helm_url.sh
+++ b/scripts/helm_url.sh
@@ -11,5 +11,5 @@ fi
 release_name="elife-xpub--${1}"
 # TODO: hardcoded ip of a node
 node_ip=35.172.178.78
-node_port=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services "$release_name")
+node_port=$(sudo -u elife -H kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services "$release_name")
 echo "http://$node_ip:$node_port"

--- a/scripts/helm_url.sh
+++ b/scripts/helm_url.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 INSTANCE_NAME"
+    echo "Example: $0 pr-42"
+    echo "Will return a public URL of the elife-xpub--\$INSTANCE_NAME Helm release"
+    exit 1
+fi
+
+release_name="elife-xpub--${1}"
+# TODO: hardcoded ip of a node
+node_ip=35.172.178.78
+node_port=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services "$release_name")
+echo "http://$node_ip:$node_port"


### PR DESCRIPTION
Experimental deploy through an Helm chart on the eLife `kubernetes--demo` cluster. Relies on the `master` version of the [chart](https://github.com/elifesciences/elife-xpub-formula/tree/master/helm/elife-xpub), parameterizing the image tag to use.

Very limited scope:

- pushes the image built by Jenkins at `elifesciences/elife-xpub` in the same Docker Hub organization as the other projects
- allows to but see the login page but has no database yet, hence clicking around will give a `ECONNREFUSED` error
- provide a URL to reach that in the `continuous-integration/jenkins/deploy-for-review` commit status check