### PR TITLE
990 - Add woff fallback for fonts

### DIFF
--- a/client/elife-theme/src/global.js
+++ b/client/elife-theme/src/global.js
@@ -6,7 +6,8 @@ injectGlobal`
     font-display: fallback;
     font-family: "Noto Sans SemiBold";
     src:
-      url('/assets/fonts/NotoSans-SemiBold-webfont-custom-2-subsetting.woff2') format('woff2');
+      url('/assets/fonts/NotoSans-SemiBold-webfont-custom-2-subsetting.woff2') format('woff2'),
+      url('/assets/fonts/NotoSans-SemiBold-webfont-custom-2-subsetting.woff') format('woff');
   }
 
   /* Sans */
@@ -14,7 +15,8 @@ injectGlobal`
     font-display: fallback;
     font-family: "Noto Sans";
     src:
-      url('/assets/fonts/NotoSans-Regular-webfont-custom-2-subsetting.woff2') format('woff2');
+      url('/assets/fonts/NotoSans-Regular-webfont-custom-2-subsetting.woff2') format('woff2'),
+      url('/assets/fonts/NotoSans-Regular-webfont-custom-2-subsetting.woff') format('woff');
   }
 
 
@@ -23,6 +25,7 @@ injectGlobal`
     font-display: fallback;
     font-family: "Noto Serif";
     src:
-      url('/assets/fonts/NotoSerif-Regular-webfont-custom-2-subsetting.woff2') format('woff2');
+      url('/assets/fonts/NotoSerif-Regular-webfont-custom-2-subsetting.woff2') format('woff2'),
+      url('/assets/fonts/NotoSerif-Bold-webfont-basic-latin-subsetting.woff') format('woff');
   }
 `


### PR DESCRIPTION
#### Background

IE doesn't support the `woff2` file format that we are using to load the `NotoSans` and `NotoSerif` fonts within the app. This is causing the app to fallback to a system font in IE. 

What does this PR do?

Adds fallback styling import of a `woff` file for the `Noto` fonts when the users browser is unable to load the `woff2` file type.

#### Any relevant tickets

closes#990

#### How has this been tested?

visually within IE11
