### PR TITLE
Wait for postgres before any test job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ elifePipeline {
             ]
             try {
                 sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d postgres"
-                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_wait_postgres app -c './scripts/wait-for-it.sh postgres:5432'"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_wait_postgres app bash -c './scripts/wait-for-it.sh postgres:5432'"
                 parallel actions
             } finally {
                 sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml down -v"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,11 +43,11 @@ elifePipeline {
                 },
             ]
             try {
-                sh "docker-compose -f docker-compose.ci.yml up -d postgres"
-                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_wait_postgres -c './scripts/wait-for-it.sh postgres:5432'"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d postgres"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_wait_postgres app -c './scripts/wait-for-it.sh postgres:5432'"
                 parallel actions
             } finally {
-                sh "docker-compose -f docker-compose.ci.yml down -v"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml down -v"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ elifePipeline {
                 'test:browser': {
                     try {
                         withCommitStatus({
-                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app bash -c './scripts/wait-for-it.sh postgres:5432 && npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails'"
+                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app bash -c 'npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails'"
                         }, 'test:browser', commit)
                     } finally {
                         archiveArtifacts artifacts: "build/screenshots/*", allowEmptyArchive: true
@@ -44,6 +44,7 @@ elifePipeline {
             ]
             try {
                 sh "docker-compose -f docker-compose.ci.yml up -d postgres"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_wait_postgres -c './scripts/wait-for-it.sh postgres:5432'"
                 parallel actions
             } finally {
                 sh "docker-compose -f docker-compose.ci.yml down -v"


### PR DESCRIPTION
From https://alfred.elifesciences.org/blue/organizations/jenkins/pull-requests-projects%2Felife-xpub/detail/PR-1009/3/pipeline/35 we see:
```
wait-for-it.sh: waiting 15 seconds for postgres:5432
wait-for-it.sh: postgres:5432 is available after 8 seconds
```

While `test:browser` correctly waited in this way the slow startup of `postgres`, `test` didn't and failed like this:
```
connect ECONNREFUSED 172.19.0.2:5432
```

Better to wait for `postgres` startup before initiating any testing job. This slow startup was probably caused by a new Jenkins agent having to download the image from scratch.