### PR TITLE
Disable authorization header on replay

### DIFF
--- a/test/helpers/replay-setup.js
+++ b/test/helpers/replay-setup.js
@@ -9,4 +9,5 @@ const Replay = require('replay')
 
 module.exports = subFolder => {
   Replay.fixtures = path.join(__dirname, '..', 'http-mocks', subFolder)
+  Replay.headers = [/^accept/, /^body/, /^content-type/, /^host/, /^if-/, /^x-/]
 }


### PR DESCRIPTION
#### Background

Stops the Authorization header being recorded in replay files, so we don't push secrets to the repository within our mocks.

#### Any relevant tickets
Related to #1017 

#### How has this been tested?
Added an authorization header to requests, and made sure new replay files didn't contain the header