### PR TITLE
Add selectors for file upload result

### DIFF
--- a/app/components/ui/molecules/FileUpload.js
+++ b/app/components/ui/molecules/FileUpload.js
@@ -85,7 +85,10 @@ const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
     return (
       <React.Fragment>
         <StyledUploadIcon percentage={conversion.progress} />
-        <UploadInstruction data-test-id="dropzoneMessage">
+        <UploadInstruction
+          data-test-conversion="converting"
+          data-test-id="dropzoneMessage"
+        >
           Manuscript is uploading {conversion.progress}%
         </UploadInstruction>
       </React.Fragment>
@@ -99,7 +102,10 @@ const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
     return (
       <React.Fragment>
         <StyledUploadFailureIcon />
-        <UploadInstruction data-test-id="dropzoneMessage">
+        <UploadInstruction
+          data-test-conversion="failed"
+          data-test-id="dropzoneMessage"
+        >
           <DropzoneErrorText>Oops!</DropzoneErrorText> {displayError} Please{' '}
           <Action onClick={dropzoneOpen}>try again.</Action>
         </UploadInstruction>
@@ -114,7 +120,10 @@ const DropzoneContent = ({ conversion, formError, dropzoneOpen }) => {
     return (
       <React.Fragment>
         <StyledUploadSuccessIcon />
-        <UploadInstruction data-test-id="dropzoneMessage">
+        <UploadInstruction
+          data-test-conversion="completed"
+          data-test-id="dropzoneMessage"
+        >
           Success! <Action onClick={dropzoneOpen}>Replace</Action> your
           manuscript.
         </UploadInstruction>


### PR DESCRIPTION
Primarily for Selenium end-to-end testing to understand when the file has finished uploading, but only the `completed` value is necessary there.

https://github.com/elifesciences/elife-xpub/blob/a8e5bc83de9021c72500a3167a6ad5d0d84e497f/app/components/ui/molecules/FileUpload.test.js#L29 could rely on these to check the various states instead of on the text; or use them in addition to the text.

https://github.com/elifesciences/elife-xpub/blob/develop/test/submission.browser.js#L85 has a bare sleep that could also rely on a waiting condition like this instead, to improve stability.