### PR TITLE
1034 remove manuscript on error

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -39,42 +39,35 @@ function getProgress(loading, data) {
 }
 
 const onUploadValidationError = (
-  fieldName,
-  setFieldError,
+  formFunctions,
   deleteFile,
-  setFieldValue,
   manuscriptId,
   errorMessage,
 ) => {
-  setFieldError(fieldName, errorMessage)
+  formFunctions.setFieldError('files', errorMessage)
   deleteFile({
     variables: { id: manuscriptId },
   }).then(({ data }) => {
-    setFieldValue(fieldName, data.removeUploadedManuscript.files)
+    formFunctions.setFieldValue('files', data.removeUploadedManuscript.files)
   })
 }
 
 export const onFileDrop = (
   files,
-  fieldName,
-  setFieldTouched,
-  setFieldError,
-  setFieldValue,
+  formFunctions,
   deleteFile,
   uploadFile,
   manuscriptId,
 ) => {
   const validationError = errorMessage =>
     onUploadValidationError(
-      fieldName,
-      setFieldError,
+      formFunctions,
       deleteFile,
-      setFieldValue,
       manuscriptId,
       errorMessage,
     )
 
-  setFieldTouched(fieldName, true, false)
+  formFunctions.setFieldTouched('files', true, false)
   if (files.length > 1) {
     validationError(errorMessageMapping.MULTIPLE)
     return
@@ -87,8 +80,8 @@ export const onFileDrop = (
   uploadFile({
     variables: { file, id: manuscriptId, fileSize: file.size },
   }).then(({ data }) => {
-    setFieldValue('meta.title', data.uploadManuscript.meta.title)
-    setFieldValue(fieldName, data.uploadManuscript.files)
+    formFunctions.setFieldValue('meta.title', data.uploadManuscript.meta.title)
+    formFunctions.setFieldValue('files', data.uploadManuscript.files)
   })
 }
 
@@ -134,10 +127,11 @@ const FilesPageContainer = ({
                   onDrop={files =>
                     onFileDrop(
                       files,
-                      fieldName,
-                      setFieldTouched,
-                      setFieldError,
-                      setFieldValue,
+                      {
+                        setFieldTouched,
+                        setFieldError,
+                        setFieldValue,
+                      },
                       deleteFile,
                       uploadFile,
                       values.id,

--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -22,6 +22,18 @@ const UPLOAD_MUTATION = gql`
   }
 `
 
+const DELETE_MUTATION = gql`
+  mutation UploadFile($id: ID!) {
+    removeUploadedManuscript(id: $id) {
+      id
+      files {
+        filename
+        type
+      }
+    }
+  }
+`
+
 function getProgress(loading, data) {
   return loading || !data.uploadProgress ? 0 : data.uploadProgress
 }
@@ -40,52 +52,75 @@ const FilesPageContainer = ({
     {(uploadFile, { loading, error: uploadError }) => {
       const fieldName = 'files'
       return (
-        <React.Fragment>
-          <Box mb={3} width={1}>
-            <ValidatedField
-              component={CoverLetterEditor}
-              id="coverLetter"
-              name="coverLetter"
-              onBlur={value => setFieldValue('coverLetter', value)}
-              onChange={value => setFieldValue('coverLetter', value)}
-            />
-          </Box>
-          <Box width={1}>
-            <ManuscriptUpload
-              conversion={{
-                converting: loading || uploadData.uploadProgress < 100,
-                // TODO import this constant from somewhere (data model package?)
-                completed: values[fieldName].some(
-                  file => file.type === 'MANUSCRIPT_SOURCE',
-                ),
-                progress: getProgress(uploadLoading, uploadData),
-                error: uploadError,
-              }}
-              data-test-id="upload"
-              formError={touched[fieldName] && errors[fieldName]}
-              onDrop={files => {
-                setFieldTouched(fieldName, true, false)
+        <Mutation mutation={DELETE_MUTATION}>
+          {deleteFile => (
+            <React.Fragment>
+              <Box mb={3} width={1}>
+                <ValidatedField
+                  component={CoverLetterEditor}
+                  id="coverLetter"
+                  name="coverLetter"
+                  onBlur={value => setFieldValue('coverLetter', value)}
+                  onChange={value => setFieldValue('coverLetter', value)}
+                />
+              </Box>
+              <Box width={1}>
+                <ManuscriptUpload
+                  conversion={{
+                    converting: loading || uploadData.uploadProgress < 100,
+                    // TODO import this constant from somewhere (data model package?)
+                    completed: values[fieldName].some(
+                      file => file.type === 'MANUSCRIPT_SOURCE',
+                    ),
+                    progress: getProgress(uploadLoading, uploadData),
+                    error: uploadError,
+                  }}
+                  data-test-id="upload"
+                  formError={touched[fieldName] && errors[fieldName]}
+                  onDrop={files => {
+                    setFieldTouched(fieldName, true, false)
 
-                if (files.length > 1) {
-                  setFieldError(fieldName, errorMessageMapping.MULTIPLE)
-                  return
-                }
-                if (files.length === 0) {
-                  setFieldError(fieldName, errorMessageMapping.UNSUPPORTED)
-                  return
-                }
+                    if (files.length > 1) {
+                      setFieldError(fieldName, errorMessageMapping.MULTIPLE)
+                      deleteFile({
+                        variables: { id: values.id },
+                      }).then(({ data }) => {
+                        setFieldValue(
+                          fieldName,
+                          data.removeUploadedManuscript.files,
+                        )
+                      })
+                      return
+                    }
+                    if (files.length === 0) {
+                      setFieldError(fieldName, errorMessageMapping.UNSUPPORTED)
+                      deleteFile({
+                        variables: { id: values.id },
+                      }).then(({ data }) => {
+                        setFieldValue(
+                          fieldName,
+                          data.removeUploadedManuscript.files,
+                        )
+                      })
+                      return
+                    }
 
-                const [file] = files
-                uploadFile({
-                  variables: { file, id: values.id, fileSize: file.size },
-                }).then(({ data }) => {
-                  setFieldValue('meta.title', data.uploadManuscript.meta.title)
-                  setFieldValue(fieldName, data.uploadManuscript.files)
-                })
-              }}
-            />
-          </Box>
-        </React.Fragment>
+                    const [file] = files
+                    uploadFile({
+                      variables: { file, id: values.id, fileSize: file.size },
+                    }).then(({ data }) => {
+                      setFieldValue(
+                        'meta.title',
+                        data.uploadManuscript.meta.title,
+                      )
+                      setFieldValue(fieldName, data.uploadManuscript.files)
+                    })
+                  }}
+                />
+              </Box>
+            </React.Fragment>
+          )}
+        </Mutation>
       )
     }}
   </Mutation>

--- a/app/components/pages/SubmissionWizard/steps/Files/index.test.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.test.js
@@ -1,0 +1,107 @@
+import { onFileDrop } from '.'
+
+const fakeFunction = () => {}
+const fakeResponse = fileName => ({
+  data: {
+    uploadManuscript: { meta: { tile: '' }, files: [{ filename: fileName }] },
+  },
+})
+
+describe('FilesPageContainer', () => {
+  it('onFileDrop sets new manuscript file value when there is no validation error and no existing manuscript file', async () => {
+    const values = {
+      files: [],
+    }
+    const setValues = (fieldName, value) => (values[fieldName] = value)
+    const files = [
+      {
+        name: 'document1.docx',
+      },
+    ]
+    await onFileDrop(
+      files,
+      'files',
+      fakeFunction,
+      fakeFunction,
+      setValues,
+      () => new Promise(resolve => resolve({})),
+      data =>
+        new Promise(resolve => resolve(fakeResponse(data.variables.file))),
+    )
+    expect(values.files).toHaveLength(1)
+  })
+
+  it('onFileDrop replaces manuscript file value when there is no validation error a file exists', async () => {
+    const setValues = (fieldName, value) => (values[fieldName] = value)
+    const values = {
+      files: [
+        {
+          filename: 'document1.docx',
+        },
+      ],
+    }
+    const files = [
+      {
+        name: 'document2.docx',
+      },
+    ]
+    await onFileDrop(
+      files,
+      'files',
+      fakeFunction,
+      fakeFunction,
+      setValues,
+      () => new Promise(resolve => resolve({})),
+      data =>
+        new Promise(resolve => resolve(fakeResponse(data.variables.file))),
+    )
+    expect(values.files).toHaveLength(1)
+    expect(values.files[0].name).toEqual(files[0].fileName)
+  })
+  it('empties files field when passed no files', async () => {
+    const setValues = (fieldName, value) => (values[fieldName] = value)
+    const values = {
+      files: [{ filename: 'document1.docx' }],
+    }
+    await onFileDrop(
+      [],
+      'files',
+      fakeFunction,
+      fakeFunction,
+      setValues,
+      () =>
+        new Promise(resolve =>
+          resolve({ data: { removeUploadedManuscript: { files: [] } } }),
+        ),
+      () => new Promise(resolve => resolve({})),
+    )
+    expect(values.files).toHaveLength(0)
+  })
+  it('empties files field when passed multiple files', async () => {
+    const setValues = (fieldName, value) => (values[fieldName] = value)
+    const values = {
+      files: [{ filename: 'document1.docx' }],
+    }
+    const files = [
+      {
+        name: 'document2.docx',
+      },
+      {
+        name: 'document3.docx',
+      },
+    ]
+    await onFileDrop(
+      files,
+      'files',
+      fakeFunction,
+      fakeFunction,
+      setValues,
+      () =>
+        new Promise(resolve =>
+          resolve({ data: { removeUploadedManuscript: { files: [] } } }),
+        ),
+      () => new Promise(resolve => resolve({})),
+    )
+    expect(values.files).toHaveLength(0)
+  })
+})

--- a/app/components/pages/SubmissionWizard/steps/Files/utils.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/utils.js
@@ -4,3 +4,7 @@ export const errorMessageMapping = {
   UNSUPPORTED: 'That file is not supported.',
   UPLOAD_FAILURE: 'There was a problem uploading your file.',
 }
+
+export const manuscriptFileTypes = {
+  MANUSCRIPT_SOURCE: 'MANUSCRIPT_SOURCE',
+}

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   rootDir: '../',
   setupTestFrameworkScriptFile: '<rootDir>/test/helpers/jest-setup.js',
   testMatch: ['<rootDir>/app/**/*.test.js'],
-  transformIgnorePatterns: ['/node_modules/(?!@?pubsweet)'],
+  transformIgnorePatterns: ['/node_modules/(?!@?pubsweet|xpub)'],
   moduleNameMapper: {
     '\\.s?css$': 'identity-obj-proxy',
   },

--- a/server/xpub-server/entities/manuscript/resolvers/index.js
+++ b/server/xpub-server/entities/manuscript/resolvers/index.js
@@ -1,5 +1,6 @@
 const logger = require('@pubsweet/logger')
 const { Manuscript, User } = require('@elifesciences/xpub-model')
+const removeUploadedManuscript = require('./removeUploadedManuscript')
 const submitManuscript = require('./submitManuscript')
 const updateManuscript = require('./updateManuscript')
 const uploadManuscript = require('./uploadManuscript')
@@ -40,6 +41,8 @@ const resolvers = {
     submitManuscript,
 
     uploadManuscript,
+
+    removeUploadedManuscript,
 
     async savePage(_, vars, { user }) {
       const userUuid = await User.getUuidForProfile(user)

--- a/server/xpub-server/entities/manuscript/resolvers/removeUploadedManuscript.js
+++ b/server/xpub-server/entities/manuscript/resolvers/removeUploadedManuscript.js
@@ -1,0 +1,24 @@
+const { Manuscript, User } = require('@elifesciences/xpub-model')
+const logger = require('@pubsweet/logger')
+
+async function removeUploadedManuscript(_, vars, { user }) {
+  const userUuid = await User.getUuidForProfile(user)
+  const manuscript = await Manuscript.find(vars.id, userUuid)
+
+  const manuscriptUploadIndex = manuscript.files.findIndex(
+    element => element.type === 'MANUSCRIPT_SOURCE',
+  )
+
+  if (manuscriptUploadIndex > -1) {
+    manuscript.files.splice(manuscriptUploadIndex, 1)
+    await manuscript.save()
+    logger.debug(`Manuscript file removed`, {
+      manuscriptId: vars.id,
+      userId: userUuid,
+    })
+  }
+
+  return manuscript
+}
+
+module.exports = removeUploadedManuscript

--- a/server/xpub-server/entities/manuscript/resolvers/removeUploadedManuscript.test.js
+++ b/server/xpub-server/entities/manuscript/resolvers/removeUploadedManuscript.test.js
@@ -1,0 +1,44 @@
+const { createTables } = require('@pubsweet/db-manager')
+const { User, Manuscript } = require('@elifesciences/xpub-model')
+const { Mutation } = require('.')
+const { userData } = require('./index.test.data')
+
+describe('Manuscripts', () => {
+  const profileId = userData.identities[0].identifier
+  let userId
+  beforeEach(async () => {
+    await createTables(true)
+    const [user] = await Promise.all([new User(userData).save()])
+    userId = user.id
+  })
+
+  describe('removeUploadedManuscript', () => {
+    it('returns the original Manuscript when there is no file to remove', async () => {
+      const manuscript = new Manuscript({ createdBy: userId, files: [] })
+      const { id } = await manuscript.save()
+      const mutatedManuscript = await Mutation.removeUploadedManuscript(
+        {},
+        { id },
+        { user: profileId },
+      )
+      expect(mutatedManuscript.id).toEqual(manuscript.id)
+    })
+
+    it('removes the manuscript file when there is one', async () => {
+      const fakeFile = {
+        filename: 'manuscript.pdf',
+        type: 'MANUSCRIPT_SOURCE',
+        url: 'manuscript/',
+      }
+      const manuscript = new Manuscript({
+        createdBy: userId,
+        files: [fakeFile],
+      })
+      const { id } = await manuscript.save()
+      expect(manuscript.files).toHaveLength(1)
+      await Mutation.removeUploadedManuscript({}, { id }, { user: profileId })
+      const mutatedManuscript = await Manuscript.find(id, userId)
+      expect(mutatedManuscript.files).toHaveLength(0)
+    })
+  })
+})

--- a/server/xpub-server/entities/manuscript/resolvers/removeUploadedManuscript.test.js
+++ b/server/xpub-server/entities/manuscript/resolvers/removeUploadedManuscript.test.js
@@ -8,7 +8,8 @@ describe('Manuscripts', () => {
   let userId
   beforeEach(async () => {
     await createTables(true)
-    const [user] = await Promise.all([new User(userData).save()])
+    const user = new User(userData)
+    await user.save()
     userId = user.id
   })
 

--- a/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.js
+++ b/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.js
@@ -12,6 +12,19 @@ const parseString = promisify(xml2js.parseString)
 
 const { Manuscript, File, User } = require('@elifesciences/xpub-model')
 
+function addFileEntityToManuscript(manuscriptEntity, fileEntity) {
+  const manuscript = manuscriptEntity
+  const manuscriptUploadIndex = manuscript.files.findIndex(
+    element => element.type === 'MANUSCRIPT_SOURCE',
+  )
+
+  if (manuscriptUploadIndex < 0) {
+    manuscript.files.push(fileEntity)
+  } else {
+    manuscript.files[manuscriptUploadIndex] = fileEntity
+  }
+}
+
 async function uploadManuscript(_, { file, id, fileSize }, { user }) {
   /**
    * TODO
@@ -110,7 +123,7 @@ async function uploadManuscript(_, { file, id, fileSize }, { user }) {
     })
   }
 
-  manuscript.files.push(fileEntity)
+  addFileEntityToManuscript(manuscript, fileEntity)
   manuscript.meta.title = title
   await manuscript.save()
 

--- a/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.test.js
+++ b/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.test.js
@@ -183,5 +183,33 @@ describe('Manuscripts', () => {
         ),
       ).rejects.toThrow(`File size shouldn't exceed ${maxFileSize}MB`)
     })
+
+    it('replaces old manuscript file with new manuscript file', async () => {
+      const blankManuscript = new Manuscript({ createdBy: userId })
+      const { id } = await blankManuscript.save()
+      const createFile = fileName => ({
+        filename: fileName,
+        stream: fs.createReadStream(
+          `${__dirname}/../../../../../test/fixtures/dummy-manuscript-2.pdf`,
+        ),
+        mimetype: 'application/pdf',
+      })
+      let manuscript = await Mutation.uploadManuscript(
+        {},
+        { id, file: createFile('manuscript.pdf'), fileSize: 73947 },
+        { user: profileId },
+      )
+
+      expect(manuscript.files).toHaveLength(1)
+      expect(manuscript.files[0].filename).toBe('manuscript.pdf')
+
+      manuscript = await Mutation.uploadManuscript(
+        {},
+        { id, file: createFile('manuscript2.pdf'), fileSize: 73947 },
+        { user: profileId },
+      )
+      expect(manuscript.files).toHaveLength(1)
+      expect(manuscript.files[0].filename).toBe('manuscript2.pdf')
+    })
   })
 })

--- a/server/xpub-server/entities/manuscript/typeDefs.graphqls
+++ b/server/xpub-server/entities/manuscript/typeDefs.graphqls
@@ -8,6 +8,7 @@ extend type Mutation {
   deleteManuscript(id: ID!): ID!
   updateManuscript(data: ManuscriptInput!): Manuscript!
   uploadManuscript(id: ID!, file: Upload!, fileSize: Int!): Manuscript!
+  removeUploadedManuscript(id: ID!): Manuscript!
   submitManuscript(data: ManuscriptInput!): Manuscript!
   savePage(url:String!, id:String!):Manuscript!
 }


### PR DESCRIPTION
#### Background

When there is a client side validation error on the manuscript upload field, the Submission should delete its current Manuscript file.

What does this PR do?

- Refactors the way Manuscript files are uploaded so that there is only ever one of type `MANUSCRIPT_SOURCE` in the manuscript.files field. 
- Extends tests to check any previous manuscript file gets replaced.
- Adds a removeManuscriptUpload mutation to remove any existing manuscript file
- Adds test for removing an upload
- calls the removeManuscriptUpload mutation when a client side upload validation error occurs 

#### Any relevant tickets

close #1034 

#### How has this been tested?

Unit tests
