### PR TITLE
Using tablet breakpoint on dashboard

### DIFF
--- a/app/components/ui/atoms/ManuscriptStatus.js
+++ b/app/components/ui/atoms/ManuscriptStatus.js
@@ -6,7 +6,7 @@ import media from '../../global/layout/media'
 
 const StatusBox = styled(Box)`
   color: ${props => props.theme[props.color]};
-  ${media.mobileUp`
+  ${media.tabletPortraitUp`
     flex: 0 0 120px;
     margin-bottom: 0;
   `};

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -80,7 +80,7 @@ const DateBox = styled(Flex)`
 `
 
 const AbsoluteDate = styled.time`
-  ${media.mobileUp`
+  ${media.tabletPortraitUp`
     font-size: ${th('fontSizeHeading6')};
   `};
 `


### PR DESCRIPTION
#### Background

Uses tablet portrait breakpoint for dashboard list items, to apply either mobile or desktop designs.

You can see the breakpoints [here](https://github.com/elifesciences/elife-xpub/blob/develop/client/elife-theme/src/index.js#L61) and [here](https://github.com/elifesciences/elife-xpub/blob/develop/app/components/global/layout/media.js#L4-L9)

#### Any relevant tickets

Closes #1000 

#### How has this been tested?

Review environment