### PR TITLE
Install Helm charts as dependencies

### DIFF
--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -22,6 +22,6 @@ fi
 
 cd helm/
 cd elife-xpub
-helm dependency update .
+sudo -u elife -H helm dependency update .
 cd -
 sudo -u elife -H helm upgrade --install "$release_name" --set image.tag="${image_tag}" elife-xpub

--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -21,4 +21,7 @@ else
 fi
 
 cd helm/
+cd elife-xpub
+helm dependency update .
+cd -
 sudo -u elife -H helm upgrade --install "$release_name" --set image.tag="${image_tag}" elife-xpub

--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -22,6 +22,7 @@ fi
 
 cd helm/
 cd elife-xpub
+sudo -u elife -H helm init --client-only
 sudo -u elife -H helm dependency update .
 cd -
 sudo -u elife -H helm upgrade --install "$release_name" --set image.tag="${image_tag}" elife-xpub


### PR DESCRIPTION
Recently https://github.com/elifesciences/elife-xpub-formula/pull/57 introduced a `stable/postgresql` chart as a dependency, to make the review environments work properly providing a database. The script needs to be expanded to resolve this dependency and download it before installation.