### PR TITLE
Publish elifesciences/elife-xpub:latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,10 @@ elifePipeline {
 
         stage 'Push image', {
             sh "docker push elifesciences/elife-xpub:${commit}"
+            elifeMainlineOnly {
+                sh "docker tag elifesciences/elife-xpub:${commit} elifesciences/elife-xpub:latest"
+                sh "docker push elifesciences/elife-xpub:latest"
+            }
         }
     }
 


### PR DESCRIPTION
`latest` as the most recent version of `develop` that passed tests. This is equivalent to what Gitlab CI does for the older image `xpub/xpub-elife`.

We do this only on the mainline and not on pull requests.