### PR TITLE
Use common dockerComposeBuild step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,19 +18,19 @@ elifePipeline {
             def actions = [
                 'lint': {
                     withCommitStatus({
-                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_lint app npm run lint"
+                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm --name elife-xpub_app_lint app npm run lint"
                     }, 'lint', commit)
                 },
                 'test': {
                     withCommitStatus({
-                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test app npm test"
+                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm --name elife-xpub_app_test app npm test"
                     }, 'test', commit)
                 },
                 // TODO: not sure this can run in parallel with `test`?
                 'test:browser': {
                     try {
                         withCommitStatus({
-                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app bash -c 'npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails'"
+                            sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_browser app bash -c 'npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails'"
                         }, 'test:browser', commit)
                     } finally {
                         archiveArtifacts artifacts: "build/screenshots/*", allowEmptyArchive: true
@@ -38,16 +38,16 @@ elifePipeline {
                 },
                 'test:dependencies': {
                     withCommitStatus({
-                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_dependencies app npm run test:dependencies"
+                        sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm --name elife-xpub_app_test_dependencies app npm run test:dependencies"
                     }, 'test:dependencies', commit)
                 },
             ]
             try {
-                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml up -d postgres"
-                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml run --rm --name elife-xpub_wait_postgres app bash -c './scripts/wait-for-it.sh postgres:5432'"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d postgres"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm --name elife-xpub_wait_postgres app bash -c './scripts/wait-for-it.sh postgres:5432'"
                 parallel actions
             } finally {
-                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml down -v"
+                sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml down -v"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ elifePipeline {
 
         stage 'Build image', {
             // TODO: pull existing docker image if caching is not already effective
-            sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.ci.yml build"
+            dockerComposeBuild(commit)
         }
 
         stage 'Project tests', {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,15 +3,12 @@ version: '3'
 services:
   app:
     build:
-      context: .
       dockerfile: ./Dockerfile
       args:
         CI_COMMIT_SHA: ${IMAGE_TAG}
     image: elifesciences/elife-xpub:${IMAGE_TAG}
     # no need to start the up in any scenario, yet
     command: sh
-    ports:
-      - ${PORT}:3000
     depends_on:
       - postgres
     environment:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+services:
+  app:
+    build:
+      dockerfile: ./Dockerfile-development
+    command: sh -c "yarn install --frozen-lockfile && ./scripts/wait-for-it.sh postgres:5432 -s -t 40 -- npx pubsweet server"
+    volumes:
+      - ./:/home/xpub
+    depends_on:
+      - postgres
+    environment:
+      NODE_ENV: development
+      PGHOST: postgres
+      PGUSER: $USER
+
+  postgres:
+    environment:
+      POSTGRES_USER: $USER
+    volumes:
+      - postgres-volume:/var/lib/postgresql/data
+      - ./scripts/test.sql:/docker-entrypoint-initdb.d/test.sql
+
+  fakes3:
+    image: lphoward/fake-s3
+    ports:
+      - 4569:4569
+
+volumes:
+  postgres-volume:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,33 +5,12 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile-development
-    command: sh -c "yarn install --frozen-lockfile && ./scripts/wait-for-it.sh postgres:5432 -s -t 40 -- npx pubsweet server"
     ports:
       - ${PORT:-3000}:3000
-    volumes:
-      - ./:/home/xpub
     depends_on:
       - postgres
-    environment:
-      NODE_ENV: development
-      PGHOST: postgres
-      PGUSER: $USER
 
   postgres:
     image: postgres:10.4
     ports:
       - 5432:5432
-    environment:
-      POSTGRES_USER: $USER
-    volumes:
-      - postgres-volume:/var/lib/postgresql/data
-      - ./scripts/test.sql:/docker-entrypoint-initdb.d/test.sql
-
-  fakes3:
-    image: lphoward/fake-s3
-    ports:
-      - 4569:4569
-
-volumes:
-  postgres-volume:
-


### PR DESCRIPTION
This implements a common eLife docker-compose pattern:

- local usage targets automatically `docker-compose.yml` and `docker-compose.override.yml` files, which are merged together when you run `docker-compose anycommand`.
- CI uses `docker-compose -f docker-compose.yml -f docker-compose.ci.yml anycommand`, and these two files are merged together instead.

`docker-compose.yml` remains only for the common settings.

With this separation, we can use the [`dockerComposeBuild`](https://github.com/elifesciences/elife-jenkins-workflow-libs/blob/master/vars/dockerComposeBuild.groovy) custom Jenkins step, which enforces verbosity and is now logging exceptions so that we can classify errors and provide retries on e.g. Docker Hub timing out.