### PR TITLE
Logging on error when calling eLife API

### DIFF
--- a/server/xpub-model/entities/user/helpers/elife-api.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.js
@@ -13,7 +13,12 @@ const request = (endpoint, query = {}) => {
   if (secret) {
     req.header.Authorization = secret
   }
-  return req.query(query)
+  return req
+    .query(query)
+    .catch(err => {
+      logger.error('Failed to fetch from eLife API:', err.message)
+      throw err
+    })
 }
 
 const convertPerson = apiPerson => {

--- a/server/xpub-model/entities/user/helpers/elife-api.test.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.test.js
@@ -1,5 +1,3 @@
-const person = require('./elife-api.test.person')
-
 jest.mock('config', () => ({
   server: {
     api: {
@@ -35,8 +33,10 @@ jest.mock('superagent', () => ({
   },
 }))
 
-const api = require('./elife-api')
+const logger = require('@pubsweet/logger')
 const request = require('superagent')
+const api = require('./elife-api')
+const person = require('./elife-api.test.person')
 
 describe('eLife API tests', () => {
   it('sends the Authorization token', async () => {
@@ -55,7 +55,9 @@ describe('eLife API tests', () => {
   })
 
   it('logs on error', async () => {
+    jest.spyOn(logger, 'error').mockImplementationOnce(() => {})
     request.query.mockRejectedValue(new Error('Forbidden'))
     await expect(api.people()).rejects.toThrow('Forbidden')
+    expect(logger.error).toHaveBeenCalled()
   })
 })

--- a/server/xpub-model/entities/user/helpers/elife-api.test.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.test.js
@@ -17,7 +17,7 @@ jest.mock('config', () => ({
 jest.mock('superagent', () => ({
   header: {},
   url: '',
-  query: jest.fn(() => ({
+  query: jest.fn(() => Promise.resolve({
     body: { items: [person] },
   })),
   get(url) {
@@ -52,5 +52,10 @@ describe('eLife API tests', () => {
     expect(result[0].firstname).toBe('Given Names')
     expect(result[0].surname).toBe('Surname')
     expect(result[0].email).toBe('person@email.com')
+  })
+
+  it('logs on error', async () => {
+    request.query.mockRejectedValue(new Error('Forbidden'))
+    await expect(api.people()).rejects.toThrow('Forbidden')
   })
 })


### PR DESCRIPTION
#### Background
Logs any errors that occur when calling the eLife API.

#### Any relevant tickets
#1090 #1065

#### How has this been tested?
- [x] Unit / Integration tests