### PR TITLE
Use Jenkins canonical hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # eLife xPub
 
-[![Build Status](http://ci--alfred.elifesciences.org/buildStatus/icon?job=test-elife-xpub)](https://ci--alfred.elifesciences.org/blue/organizations/jenkins/test-elife-xpub/activity)
+[![Build Status](http://alfred.elifesciences.org/buildStatus/icon?job=test-elife-xpub)](https://alfred.elifesciences.org/blue/organizations/jenkins/test-elife-xpub/activity)
 [![mattermost](https://img.shields.io/badge/mattermost_chat-coko%2Fxpub-blue.svg)](https://mattermost.coko.foundation/coko/channels/xpub)
 
 ## Description


### PR DESCRIPTION
Very small change, just to illustrate Jenkins review environments that get generated on pull requests.