### PR TITLE
display the name of the uploading/uploaded file

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
@@ -127,11 +127,11 @@ const DropzoneContent = ({
     return (
       <React.Fragment>
         <StyledUploadSuccessIcon />
+        <FileName>{fileName}</FileName>
         <UploadInstruction
           data-test-conversion="completed"
           data-test-id="dropzoneMessage"
         >
-          <FileName>{fileName}</FileName>
           Success! <Action onClick={dropzoneOpen}>Replace</Action> your
           manuscript.
         </UploadInstruction>

--- a/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
@@ -94,11 +94,11 @@ const DropzoneContent = ({
     return (
       <React.Fragment>
         <StyledUploadIcon percentage={conversion.progress} />
+        <FileName>{fileName}</FileName>
         <UploadInstruction
           data-test-conversion="converting"
           data-test-id="dropzoneMessage"
         >
-          <FileName>{fileName}</FileName>
           Manuscript is uploading {conversion.progress}%
         </UploadInstruction>
       </React.Fragment>

--- a/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
@@ -80,8 +80,16 @@ const DropzoneErrorText = styled(ErrorText.withComponent('span'))`
 const CentredFlex = styled(Flex)`
   text-align: center;
 `
+const FileName = styled.p`
+  text-size= 14px;
+`
 
-const DropzoneContent = ({ conversion, errorMessage, dropzoneOpen }) => {
+const DropzoneContent = ({
+  conversion,
+  errorMessage,
+  dropzoneOpen,
+  fileName,
+}) => {
   if (conversion.converting) {
     return (
       <React.Fragment>
@@ -90,6 +98,7 @@ const DropzoneContent = ({ conversion, errorMessage, dropzoneOpen }) => {
           data-test-conversion="converting"
           data-test-id="dropzoneMessage"
         >
+          <FileName>{fileName}</FileName>
           Manuscript is uploading {conversion.progress}%
         </UploadInstruction>
       </React.Fragment>
@@ -122,6 +131,7 @@ const DropzoneContent = ({ conversion, errorMessage, dropzoneOpen }) => {
           data-test-conversion="completed"
           data-test-id="dropzoneMessage"
         >
+          <FileName>{fileName}</FileName>
           Success! <Action onClick={dropzoneOpen}>Replace</Action> your
           manuscript.
         </UploadInstruction>
@@ -189,6 +199,7 @@ class ManuscriptUpload extends React.Component {
         maxSize={config.fileUpload.maxSizeMB * 1e6}
         onDrop={files => {
           this.setErrorMessage(null)
+          this.fileName = files[0].name
           onDrop(files)
         }}
         saveInnerRef={node => {
@@ -202,6 +213,7 @@ class ManuscriptUpload extends React.Component {
               conversion={conversion}
               dropzoneOpen={() => dropzoneRef.open()}
               errorMessage={this.state.errorMessage}
+              fileName={this.fileName}
             />
           </Box>
         </CentredFlex>


### PR DESCRIPTION
#### Background
display the name of the uploading/uploaded file

closes: #988 

#### How has this been tested?
it's a cosmetic change, on the dropzone file name should be display while uploading/uploaded a file

- [x] Has been reviewed against Designs
- [x] Necessary updates to styleguide
