### PR TITLE
Allow S3_ENDPOINT environment variable

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -8,6 +8,8 @@ PGUSER=test
 PGPASSWORD=pw
 PGDATABASE=test
 NODE_ENV=test
+NODE_CONFIG_ENV=ci
+PUBSWEET_SECRET=fakesecret
 BROWSER=chrome:headless --no-sandbox
 
 # setup data for postgres image

--- a/.env.ci
+++ b/.env.ci
@@ -13,3 +13,6 @@ BROWSER=chrome:headless --no-sandbox
 # setup data for postgres image
 POSTGRES_USER=test
 POSTGRES_PASSWORD=pw
+
+# configure app to access fakes3
+S3_ENDPOINT=http://fakes3:4569

--- a/.env.ci
+++ b/.env.ci
@@ -13,6 +13,3 @@ BROWSER=chrome:headless --no-sandbox
 # setup data for postgres image
 POSTGRES_USER=test
 POSTGRES_PASSWORD=pw
-
-# configure app to access fakes3
-S3_ENDPOINT=http://fakes3:4569

--- a/config/ci.js
+++ b/config/ci.js
@@ -3,7 +3,10 @@ const AWS = require('aws-sdk')
 module.exports = {
   aws: {
     s3: {
-      endpoint: new AWS.Endpoint('http://fakes3:4569'),
+      endpoint: new AWS.Endpoint(
+        // randomise port to avoid conflicts in parallel test runs
+        `http://localhost:${Math.floor(Math.random() * 50000) + 15000}`,
+      ),
     },
   },
   meca: {

--- a/config/ci.js
+++ b/config/ci.js
@@ -1,4 +1,11 @@
+const AWS = require('aws-sdk')
+
 module.exports = {
+  aws: {
+    s3: {
+      endpoint: new AWS.Endpoint('http://fakes3:4569'),
+    },
+  },
   meca: {
     sftp: {
       disableUpload: true,

--- a/config/custom-environment-variables.js
+++ b/config/custom-environment-variables.js
@@ -34,7 +34,6 @@ module.exports = {
   },
   aws: {
     s3: {
-      endpoint: 'S3_ENDPOINT',
       params: {
         Bucket: 'S3_BUCKET',
       },

--- a/config/custom-environment-variables.js
+++ b/config/custom-environment-variables.js
@@ -34,6 +34,7 @@ module.exports = {
   },
   aws: {
     s3: {
+      endpoint: 'S3_ENDPOINT',
       params: {
         Bucket: 'S3_BUCKET',
       },

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -19,6 +19,7 @@ services:
       PGUSER:
       PGPASSWORD:
       PGDATABASE:
+      PUBSWEET_SECRET:
     volumes:
       - ./build/screenshots:/tmp/screenshots
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -8,7 +8,7 @@ services:
         CI_COMMIT_SHA: ${IMAGE_TAG}
     image: elifesciences/elife-xpub:${IMAGE_TAG}
     # no need to start the up in any scenario, yet
-    command: sh
+    command: sh -c "npx pubsweet server"
     depends_on:
       - postgres
     environment:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,11 +21,6 @@ services:
       - postgres-volume:/var/lib/postgresql/data
       - ./scripts/test.sql:/docker-entrypoint-initdb.d/test.sql
 
-  fakes3:
-    image: lphoward/fake-s3
-    ports:
-      - 4569:4569
-
 volumes:
   postgres-volume:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,8 @@ services:
     image: postgres:10.4
     ports:
       - 5432:5432
+
+  fakes3:
+    image: lphoward/fake-s3
+    ports:
+      - 4569:4569

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start:styleguide": "docker-compose run --no-deps -p 6060:6060 app yarn run styleguide",
     "stop:services": "docker-compose down -v",
     "styleguide": "styleguidist server",
-    "test": "NODE_ENV=test jest --runInBand",
+    "test": "NODE_CONFIG_ENV=test jest --runInBand",
     "test:browser": "NODE_CONFIG_ENV=test NODE_ENV=production testcafe \"${BROWSER:-chrome}\" 'test/**/*.browser.js'",
     "test:dependencies": "check-yarn-dupes react react-dom styled-components pubsweet-server",
     "update": "yarn upgrade-interactive --latest"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start:styleguide": "docker-compose run --no-deps -p 6060:6060 app yarn run styleguide",
     "stop:services": "docker-compose down -v",
     "styleguide": "styleguidist server",
-    "test": "jest --runInBand",
+    "test": "NODE_ENV=test jest --runInBand",
     "test:browser": "NODE_CONFIG_ENV=test NODE_ENV=production testcafe \"${BROWSER:-chrome}\" 'test/**/*.browser.js'",
     "test:dependencies": "check-yarn-dupes react react-dom styled-components pubsweet-server",
     "update": "yarn upgrade-interactive --latest"


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/1064

Useful to get `app` to talk to the `fakes3` container rather than a real S3 bucket. We would run `fakes3` in CI, too, despite not using it by default for now.

Shouldn't affect tests as they have a `test` environment that is separate from `ci` anyway. `ci` would be used to run pull request review environments.

Probably `ci` is used also for `elife-xpub--ci` usage in the `develop` branch, but right now the environment variable should be empty so it should be irrelevant.