### PR TITLE
add person info modal to people picker

### DIFF
--- a/app/components/pages/Dashboard/EjpLink.js
+++ b/app/components/pages/Dashboard/EjpLink.js
@@ -1,16 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
-import { th } from '@pubsweet/ui-toolkit'
 
 import SmallParagraph from '../../ui/atoms/SmallParagraph'
 import NativeLink from '../../ui/atoms/NativeLink'
 
-const CenterdSmallParagraph = styled(SmallParagraph)`
-  color: ${th('colorTextSecondary')};
+const CenterdSmallParagraph = styled(SmallParagraph).attrs({ secondary: true })`
   text-align: center;
 `
 
-const EjpLink = props => (
+const EjpLink = () => (
   <CenterdSmallParagraph>
     Can&#39;t find a submission? You might find it in our full{' '}
     <NativeLink href="https://submit.elifesciences.org">

--- a/app/components/pages/SubmissionWizard/operations.js
+++ b/app/components/pages/SubmissionWizard/operations.js
@@ -5,7 +5,8 @@ const editorFragment = gql`
     id
     name
     aff
-    subjectAreas
+    focuses
+    expertises
   }
 `
 const reviewerFragment = gql`

--- a/app/components/pages/SubmissionWizard/steps/Disclosure/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Disclosure/index.js
@@ -1,7 +1,5 @@
 import React from 'react'
-import styled from 'styled-components'
 import { Box } from 'grid-styled'
-import { th } from '@pubsweet/ui-toolkit'
 import { format, parse } from 'date-fns'
 
 import Paragraph from '../../../../ui/atoms/Paragraph'
@@ -10,10 +8,6 @@ import NativeLink from '../../../../ui/atoms/NativeLink'
 import { FormH3 } from '../../../../ui/atoms/FormHeadings'
 import ValidatedField from '../../../../ui/atoms/ValidatedField'
 import ControlledCheckbox from '../../../../ui/atoms/ControlledCheckbox'
-
-const StyledSmallParagraph = styled(SmallParagraph)`
-  color: ${th('colorTextSecondary')};
-`
 
 const localDate = parse(new Date())
 const formattedLocalDate = format(localDate, 'MMM D, YYYY')
@@ -30,9 +24,9 @@ const DisclosurePage = ({ values }) => {
         <Paragraph>
           {values.author.firstName} {values.author.lastName}
         </Paragraph>
-        <StyledSmallParagraph>
+        <SmallParagraph secondary>
           {formattedArticleType} {formattedLocalDate}
-        </StyledSmallParagraph>
+        </SmallParagraph>
       </Box>
       <Box mb={4}>
         <Paragraph>

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.md
@@ -12,7 +12,11 @@ const data = {
       id: 1,
       name: 'Alfred Badger',
       aff: 'Institute of Badgers',
-      subjectAreas: ['Human Biology and Medicine', 'Neuroscience'],
+      focuses: ['biophysics and structural biology', 'immunology'],
+      expertises: [
+        'Evolutionary Biology',
+        'Microbiology and Infectious Disease',
+      ],
     },
   ],
   opposedSeniorEditors: [
@@ -20,7 +24,11 @@ const data = {
       id: 3,
       name: 'Charlie Badger',
       aff: 'Badger University',
-      subjectAreas: ['Cell Biology'],
+      focuses: ['cell biology'],
+      expertises: [
+        'Biochemistry and Chemical Biology',
+        'Chromosomes and Gene Expression',
+      ],
     },
   ],
   suggestedReviewingEditors: [],

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
@@ -14,6 +14,8 @@ const formValues = {
       id: 1,
       name: 'Alfred Badger',
       aff: 'Institute of Badgers',
+      focuses: ['cancer biology'],
+      expertises: ['Neuroscience'],
     },
   ],
   opposedSeniorEditors: [],

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerControl.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerControl.js
@@ -23,9 +23,10 @@ const PeoplePickerControl = ({
           iconType="remove"
           institution={person.aff}
           isKeywordClickable={false}
+          isSelected
           key={person.id}
           name={person.name}
-          onIconClick={() => onRequestRemove(person)}
+          togglePersonSelection={() => onRequestRemove(person)}
         />
       ))
 
@@ -34,8 +35,8 @@ const PeoplePickerControl = ({
           <PersonPod.SelectButton
             isRequired={items.length < minSelection}
             key="chooser"
-            onIconClick={showModal}
             roleName="editor"
+            togglePersonSelection={showModal}
           />,
         )
 

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerControl.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerControl.js
@@ -9,7 +9,6 @@ const PeoplePickerControl = ({
   maxSelection = Infinity,
   minSelection = 0,
   onRequestRemove,
-  onRequestModal,
   initialSelection,
   onSubmit,
   options,
@@ -19,11 +18,12 @@ const PeoplePickerControl = ({
     {({ showModal, hideModal, isModalVisible }) => {
       const items = initialSelection.map(person => (
         <PersonPod
+          expertises={person.expertises}
+          focuses={person.focuses}
           iconType="remove"
           institution={person.aff}
           isKeywordClickable={false}
           key={person.id}
-          keywords={[].concat(person.focuses).concat(person.expertises)}
           name={person.name}
           onIconClick={() => onRequestRemove(person)}
         />

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerControl.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerControl.js
@@ -23,7 +23,7 @@ const PeoplePickerControl = ({
           institution={person.aff}
           isKeywordClickable={false}
           key={person.id}
-          keywords={person.subjectAreas}
+          keywords={[].concat(person.focuses).concat(person.expertises)}
           name={person.name}
           onIconClick={() => onRequestRemove(person)}
         />

--- a/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/PeoplePickerModal.md
@@ -19,25 +19,29 @@ const people = [
     id: 1,
     name: 'Annie Badger',
     aff: 'A University',
-    subjectAreas: ['cell biology'],
+    focuses: ['biophysics and structural biology', 'immunology'],
+    expertises: ['Evolutionary Biology', 'Microbiology and Infectious Disease'],
   },
   {
     id: 2,
     name: 'Bobby Badger',
     aff: 'B College',
-    subjectAreas: ['biochemistry and chemical', 'biology'],
+    focuses: ['biophysics and structural biology', 'immunology'],
+    expertises: ['Evolutionary Biology', 'Microbiology and Infectious Disease'],
   },
   {
     id: 3,
     name: 'Chastity Badger',
     aff: 'C Institute',
-    subjectAreas: ['ecology'],
+    focuses: ['biophysics and structural biology', 'immunology'],
+    expertises: ['Evolutionary Biology', 'Microbiology and Infectious Disease'],
   },
   {
     id: 4,
     name: 'Dave Badger',
     aff: 'D Research Lab',
-    subjectAreas: ['neuroscience'],
+    focuses: ['biophysics and structural biology', 'immunology'],
+    expertises: ['Evolutionary Biology', 'Microbiology and Infectious Disease'],
   },
 ]
 ;<div>

--- a/app/components/pages/SubmissionWizard/steps/Editors/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/index.js
@@ -9,7 +9,8 @@ const EDITOR_LIST_QUERY = gql`
       id
       name
       aff
-      subjectAreas
+      focuses
+      expertises
     }
   }
 `

--- a/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
@@ -7,6 +7,7 @@ import { ErrorText, Action } from '@pubsweet/ui'
 import { th } from '@pubsweet/ui-toolkit'
 import config from 'config'
 import { errorMessageMapping } from './utils'
+import Paragraph from '../../../../ui/atoms/Paragraph'
 
 import Icon from '../../../../ui/atoms/Icon'
 
@@ -64,12 +65,11 @@ const StyledDropzone = styled(({ hasError, saveInnerRef, ...rest }) => (
   padding: ${th('space.4')};
 `
 
-const UploadInstruction = styled.p`
+const UploadInstruction = styled(Paragraph)`
   margin-bottom: 0;
 `
 
-const UploadNote = styled.p`
-  color: ${th('colorTextSecondary')};
+const UploadNote = styled(Paragraph).attrs({ secondary: true })`
   margin-top: 0;
 `
 

--- a/app/components/pages/ThankYou/ThankYou.js
+++ b/app/components/pages/ThankYou/ThankYou.js
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { Box } from 'grid-styled'
 import PropTypes from 'prop-types'
 import { H1 } from '@pubsweet/ui'
-import { th } from '@pubsweet/ui-toolkit'
 import NativeLink from '../../ui/atoms/NativeLink'
 import ButtonLink from '../../ui/atoms/ButtonLink'
 import Paragraph from '../../ui/atoms/Paragraph'
@@ -12,9 +11,7 @@ import SmallParagraph from '../../ui/atoms/SmallParagraph'
 const CenteredContent = styled(Box)`
   text-align: center;
 `
-const SubText = styled(SmallParagraph)`
-  color: ${th('colorTextSecondary')};
-`
+const SubText = styled(SmallParagraph).attrs({ secondary: true })``
 
 const BookmarkLink = styled(NativeLink)`
   display: inline-block;

--- a/app/components/ui/atoms/Paragraph.js
+++ b/app/components/ui/atoms/Paragraph.js
@@ -1,5 +1,9 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
+
+const secondary = css`
+  color: ${th('colorTextSecondary')};
+`
 
 const Paragraph = styled.p`
   font-family: ${th('fontReading')};
@@ -12,6 +16,7 @@ const Paragraph = styled.p`
   &:last-child {
     margin-bottom: 0;
   }
+  ${props => props.secondary && secondary};
 `
 
 export default Paragraph

--- a/app/components/ui/atoms/PersonInfo.js
+++ b/app/components/ui/atoms/PersonInfo.js
@@ -10,7 +10,7 @@ const PersonInfo = ({ person }) => {
     <React.Fragment>
       <H2>{name}</H2>
       <Paragraph>{aff}</Paragraph>
-      <SmallParagraph>
+      <SmallParagraph secondary>
         Research focuses: {subjectAreas.join(', ')}
       </SmallParagraph>
     </React.Fragment>

--- a/app/components/ui/atoms/PersonInfo.js
+++ b/app/components/ui/atoms/PersonInfo.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { H2 } from '@pubsweet/ui'
+import SmallParagraph from './SmallParagraph'
+import Paragraph from './Paragraph'
+
+const PersonInfo = ({ person }) => {
+  const { name, aff, subjectAreas } = person
+  return (
+    <React.Fragment>
+      <H2>{name}</H2>
+      <Paragraph>{aff}</Paragraph>
+      <SmallParagraph>
+        Research focuses: {subjectAreas.join(', ')}
+      </SmallParagraph>
+    </React.Fragment>
+  )
+}
+
+PersonInfo.propTypes = {
+  person: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    aff: PropTypes.string.isRequired,
+    subjectAreas: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  }).isRequired,
+}
+
+export default PersonInfo

--- a/app/components/ui/atoms/PersonInfo.js
+++ b/app/components/ui/atoms/PersonInfo.js
@@ -8,9 +8,9 @@ const PersonInfo = ({ name, institution, focuses, expertises }) => (
   <React.Fragment>
     <H2>{name}</H2>
     <Paragraph>{institution}</Paragraph>
-    <SmallParagraph>Research focuses: {focuses.join(', ')}</SmallParagraph>
+    <SmallParagraph>Expertises: {expertises.join(', ')}</SmallParagraph>
     <SmallParagraph secondary>
-      Expertises: {expertises.join(', ')}
+      Research focuses: {focuses.join(', ')}
     </SmallParagraph>
   </React.Fragment>
 )

--- a/app/components/ui/atoms/PersonInfo.js
+++ b/app/components/ui/atoms/PersonInfo.js
@@ -5,13 +5,14 @@ import SmallParagraph from './SmallParagraph'
 import Paragraph from './Paragraph'
 
 const PersonInfo = ({ person }) => {
-  const { name, aff, subjectAreas } = person
+  const { name, aff, focuses, expertises } = person
   return (
     <React.Fragment>
       <H2>{name}</H2>
       <Paragraph>{aff}</Paragraph>
+      <SmallParagraph>Research focuses: {focuses.join(', ')}</SmallParagraph>
       <SmallParagraph secondary>
-        Research focuses: {subjectAreas.join(', ')}
+        Expertises: {expertises.join(', ')}
       </SmallParagraph>
     </React.Fragment>
   )
@@ -21,7 +22,8 @@ PersonInfo.propTypes = {
   person: PropTypes.shape({
     name: PropTypes.string.isRequired,
     aff: PropTypes.string.isRequired,
-    subjectAreas: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    focuses: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    expertises: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   }).isRequired,
 }
 

--- a/app/components/ui/atoms/PersonInfo.js
+++ b/app/components/ui/atoms/PersonInfo.js
@@ -1,17 +1,27 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { th } from '@pubsweet/ui-toolkit'
 import { H2 } from '@pubsweet/ui'
 import SmallParagraph from './SmallParagraph'
 import Paragraph from './Paragraph'
 
+const StyledH2 = styled(H2)`
+  margin-bottom: 0;
+`
+
+const StyledSmallParagraph = styled(SmallParagraph)`
+  margin-bottom: ${th('space.4')};
+`
+
 const PersonInfo = ({ name, institution, focuses, expertises }) => (
   <React.Fragment>
-    <H2>{name}</H2>
+    <StyledH2>{name}</StyledH2>
     <Paragraph>{institution}</Paragraph>
-    <SmallParagraph>Expertises: {expertises.join(', ')}</SmallParagraph>
-    <SmallParagraph secondary>
+    <SmallParagraph>Expertise: {expertises.join(', ')}</SmallParagraph>
+    <StyledSmallParagraph secondary>
       Research focuses: {focuses.join(', ')}
-    </SmallParagraph>
+    </StyledSmallParagraph>
   </React.Fragment>
 )
 

--- a/app/components/ui/atoms/PersonInfo.js
+++ b/app/components/ui/atoms/PersonInfo.js
@@ -4,27 +4,22 @@ import { H2 } from '@pubsweet/ui'
 import SmallParagraph from './SmallParagraph'
 import Paragraph from './Paragraph'
 
-const PersonInfo = ({ person }) => {
-  const { name, aff, focuses, expertises } = person
-  return (
-    <React.Fragment>
-      <H2>{name}</H2>
-      <Paragraph>{aff}</Paragraph>
-      <SmallParagraph>Research focuses: {focuses.join(', ')}</SmallParagraph>
-      <SmallParagraph secondary>
-        Expertises: {expertises.join(', ')}
-      </SmallParagraph>
-    </React.Fragment>
-  )
-}
+const PersonInfo = ({ name, institution, focuses, expertises }) => (
+  <React.Fragment>
+    <H2>{name}</H2>
+    <Paragraph>{institution}</Paragraph>
+    <SmallParagraph>Research focuses: {focuses.join(', ')}</SmallParagraph>
+    <SmallParagraph secondary>
+      Expertises: {expertises.join(', ')}
+    </SmallParagraph>
+  </React.Fragment>
+)
 
 PersonInfo.propTypes = {
-  person: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    aff: PropTypes.string.isRequired,
-    focuses: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-    expertises: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-  }).isRequired,
+  name: PropTypes.string.isRequired,
+  institution: PropTypes.string.isRequired,
+  focuses: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  expertises: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
 }
 
 export default PersonInfo

--- a/app/components/ui/atoms/PersonInfo.md
+++ b/app/components/ui/atoms/PersonInfo.md
@@ -1,15 +1,13 @@
 ```js
 <PersonInfo
-  person={{
-    id: '1234',
-    name: 'Michael J Frank',
-    aff: 'Max Planck Institute, Germany',
-    focuses: [
-      'genetics of global gene expression',
-      'mouse models of human disease',
-      'haematology',
-    ],
-    expertises: ['Neuroscience', 'Cell Biology'],
-  }}
+  id="1234"
+  name="Michael J Frank"
+  institution="Max Planck Institute, Germany"
+  focuses={[
+    'genetics of global gene expression',
+    'mouse models of human disease',
+    'haematology',
+  ]}
+  expertises={['Neuroscience', 'Cell Biology']}
 />
 ```

--- a/app/components/ui/atoms/PersonInfo.md
+++ b/app/components/ui/atoms/PersonInfo.md
@@ -4,11 +4,12 @@
     id: '1234',
     name: 'Michael J Frank',
     aff: 'Max Planck Institute, Germany',
-    subjectAreas: [
+    focuses: [
       'genetics of global gene expression',
       'mouse models of human disease',
       'haematology',
     ],
+    expertises: ['Neuroscience', 'Cell Biology'],
   }}
 />
 ```

--- a/app/components/ui/atoms/PersonInfo.md
+++ b/app/components/ui/atoms/PersonInfo.md
@@ -1,0 +1,14 @@
+```js
+<PersonInfo
+  person={{
+    id: '1234',
+    name: 'Michael J Frank',
+    aff: 'Max Planck Institute, Germany',
+    subjectAreas: [
+      'genetics of global gene expression',
+      'mouse models of human disease',
+      'haematology',
+    ],
+  }}
+/>
+```

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -115,12 +115,12 @@ const CollapsibleBox = styled(Box)`
 const PersonPodContainer = ({
   isIconClickable,
   onIconClick,
-  textContainer,
   icon,
+  children,
   ...props
 }) => (
   <StyledPod justifyContent="space-between">
-    {textContainer}
+    {children}
     <Flex flexDirection="column" justifyContent="center">
       <StyledButton
         data-test-id="person-pod-button"
@@ -146,10 +146,14 @@ const PodIcon = ({ iconType }) => {
   }
 }
 
-const PersonText = ({
+const PersonPod = ({
+  isIconClickable = true,
+  onIconClick,
+  iconType,
   name,
   institution = '',
-  keywords,
+  focuses,
+  expertises,
   isKeywordClickable,
   onKeywordClick = null,
   isStatusShown = false,
@@ -157,6 +161,7 @@ const PersonText = ({
   ...props
 }) => {
   let keywordList
+  const keywords = [].concat(focuses).concat(expertises)
   if (isKeywordClickable) {
     keywordList = keywords.map(keyword => (
       <SmallAction
@@ -181,58 +186,56 @@ const PersonText = ({
   )
 
   return (
-    <CollapsibleBox m={2} {...props}>
-      <StyledParagraph>{name}</StyledParagraph>
-      {institution && <StyledParagraph>{institution}</StyledParagraph>}
-      {!institution && <Box mb={3} />}
-      <Flex alignItems="center">
-        <ButtonAsIconWrapper>
-          <StyledInfoIcon />
-        </ButtonAsIconWrapper>
-        <StyledSmallParagraph>{separatedKeywords}</StyledSmallParagraph>
-      </Flex>
-      {isStatusShown && <StyledSmallParagraph>{status}</StyledSmallParagraph>}
-    </CollapsibleBox>
+    <React.Fragment>
+      <PersonPodContainer
+        icon={<PodIcon iconType={iconType} />}
+        isIconClickable={isIconClickable}
+        onIconClick={onIconClick}
+      >
+        <CollapsibleBox m={2} {...props}>
+          <StyledParagraph>{name}</StyledParagraph>
+          {institution && <StyledParagraph>{institution}</StyledParagraph>}
+          {!institution && <Box mb={3} />}
+          <Flex alignItems="center">
+            <ButtonAsIconWrapper>
+              <StyledInfoIcon />
+            </ButtonAsIconWrapper>
+            <StyledSmallParagraph>{separatedKeywords}</StyledSmallParagraph>
+          </Flex>
+          {isStatusShown && (
+            <StyledSmallParagraph>{status}</StyledSmallParagraph>
+          )}
+        </CollapsibleBox>
+      </PersonPodContainer>
+    </React.Fragment>
   )
 }
 
-const PersonPod = ({
-  isIconClickable = true,
+const SelectButton = ({
+  roleName,
+  isRequired,
+  isIconClickable,
   onIconClick,
-  iconType,
   ...props
 }) => (
-  <PersonPodContainer
-    icon={<PodIcon iconType={iconType} />}
-    isIconClickable={isIconClickable}
-    onIconClick={onIconClick}
-    textContainer={<PersonText {...props} />}
-  />
-)
-
-const ChooserText = ({ roleName, isRequired, ...props }) => (
-  <Flex flexDirection="column" justifyContent="center">
-    <Box ml={2}>
-      <StyledParagraph>
-        Choose {roleName} ({isRequired ? 'required' : 'optional'})
-      </StyledParagraph>
-    </Box>
-  </Flex>
-)
-
-const SelectButton = ({ isIconClickable, onIconClick, ...props }) => (
   <PersonPodContainer
     icon={<PodIcon iconType="add" />}
     isIconClickable
     onIconClick={onIconClick}
-    textContainer={<ChooserText {...props} />}
-  />
+  >
+    <Flex flexDirection="column" justifyContent="center">
+      <Box ml={2}>
+        <StyledParagraph>
+          Choose {roleName} ({isRequired ? 'required' : 'optional'})
+        </StyledParagraph>
+      </Box>
+    </Flex>
+  </PersonPodContainer>
 )
 
 PersonPodContainer.propTypes = {
   isIconClickable: PropTypes.bool.isRequired,
   onIconClick: PropTypes.func.isRequired,
-  textContainer: PropTypes.element.isRequired,
   icon: PropTypes.element.isRequired,
 }
 
@@ -240,40 +243,33 @@ PodIcon.propTypes = {
   iconType: PropTypes.oneOf(['add', 'remove', 'selected']).isRequired,
 }
 
-PersonText.propTypes = {
+PersonPod.propTypes = {
+  isIconClickable: PropTypes.bool,
+  onIconClick: PropTypes.func.isRequired,
+  iconType: PropTypes.oneOf(['add', 'remove', 'selected']).isRequired,
   name: PropTypes.string.isRequired,
   institution: PropTypes.string,
-  keywords: PropTypes.arrayOf(PropTypes.string.isRequired),
+  focuses: PropTypes.arrayOf(PropTypes.string.isRequired),
+  expertises: PropTypes.arrayOf(PropTypes.string.isRequired),
   isKeywordClickable: PropTypes.bool.isRequired,
   onKeywordClick: PropTypes.func,
   isStatusShown: PropTypes.bool,
   status: PropTypes.string,
 }
 
-PersonText.defaultProps = {
+PersonPod.defaultProps = {
+  isIconClickable: true,
   institution: '',
-  keywords: [],
+  focuses: [],
+  expertises: [],
   onKeywordClick: null,
   isStatusShown: false,
   status: '',
 }
 
-PersonPod.propTypes = {
-  isIconClickable: PropTypes.bool,
-  onIconClick: PropTypes.func.isRequired,
-  iconType: PropTypes.oneOf(['add', 'remove', 'selected']).isRequired,
-}
-
-PersonPod.defaultProps = {
-  isIconClickable: true,
-}
-
-ChooserText.propTypes = {
+SelectButton.propTypes = {
   roleName: PropTypes.string.isRequired,
   isRequired: PropTypes.bool.isRequired,
-}
-
-SelectButton.propTypes = {
   onIconClick: PropTypes.func.isRequired,
 }
 

--- a/app/components/ui/atoms/PersonPod.js
+++ b/app/components/ui/atoms/PersonPod.js
@@ -7,6 +7,8 @@ import { Flex, Box } from 'grid-styled'
 
 import Icon from './Icon'
 import ButtonAsIconWrapper from './ButtonAsIconWrapper'
+import SmallParagraph from './SmallParagraph'
+import Paragraph from './Paragraph'
 
 const AddIcon = props => (
   <Icon
@@ -75,20 +77,14 @@ const StyledButton = styled.button`
   }
 `
 
-const RegularP = styled.p`
-  font-size: ${th('fontSizeBase')};
-  line-height: ${th('lineHeightBase')};
+const StyledParagraph = styled(Paragraph)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0;
 `
 
-const SmallP = styled.p`
-  font-size: ${th('fontSizeBaseSmall')};
-  line-height: ${th('lineHeightBaseSmall')};
-  color: ${th('colorTextSecondary')}
-  // vertical spacing of 6px comes from: 24px grid - lineHeightBaseSmall
+const StyledSmallParagraph = styled(SmallParagraph).attrs({ secondary: true })`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -186,16 +182,16 @@ const PersonText = ({
 
   return (
     <CollapsibleBox m={2} {...props}>
-      <RegularP>{name}</RegularP>
-      {institution && <RegularP>{institution}</RegularP>}
+      <StyledParagraph>{name}</StyledParagraph>
+      {institution && <StyledParagraph>{institution}</StyledParagraph>}
       {!institution && <Box mb={3} />}
       <Flex alignItems="center">
         <ButtonAsIconWrapper>
           <StyledInfoIcon />
         </ButtonAsIconWrapper>
-        <SmallP>{separatedKeywords}</SmallP>
+        <StyledSmallParagraph>{separatedKeywords}</StyledSmallParagraph>
       </Flex>
-      {isStatusShown && <SmallP>{status}</SmallP>}
+      {isStatusShown && <StyledSmallParagraph>{status}</StyledSmallParagraph>}
     </CollapsibleBox>
   )
 }
@@ -217,9 +213,9 @@ const PersonPod = ({
 const ChooserText = ({ roleName, isRequired, ...props }) => (
   <Flex flexDirection="column" justifyContent="center">
     <Box ml={2}>
-      <RegularP>
+      <StyledParagraph>
         Choose {roleName} ({isRequired ? 'required' : 'optional'})
-      </RegularP>
+      </StyledParagraph>
     </Box>
   </Flex>
 )

--- a/app/components/ui/atoms/PersonPod.md
+++ b/app/components/ui/atoms/PersonPod.md
@@ -10,9 +10,10 @@ Clickable keywords:
   expertises={['Cellular Biology']}
   isKeywordClickable={true}
   onKeywordClick={keyword => console.log(keyword, 'clicked')}
+  isPicked={false}
   isStatusShown={false}
   iconType="add"
-  onIconClick={() => console.log('icon clicked')}
+  togglePersonSelection={() => console.log('icon clicked')}
 />
 ```
 
@@ -26,9 +27,10 @@ Showing the person's status:
   expertises={['Biochemistry and Chemical Biology', 'Plant Biology']}
   isKeywordClickable={false}
   status="Currently unavailable"
+  isPicked={false}
   isStatusShown={true}
   iconType="add"
-  onIconClick={() => console.log('icon clicked')}
+  togglePersonSelection={() => console.log('icon clicked')}
 />
 ```
 
@@ -43,9 +45,10 @@ Removal icon:
   isKeywordClickable={false}
   onKeywordClick={() => console.log('keyword clicked')}
   status="Currently unavailable"
+  isSelectedInForm={false}
   isStatusShown={true}
   iconType="remove"
-  onIconClick={() => console.log('icon clicked')}
+  togglePersonSelection={() => console.log('icon clicked')}
 />
 ```
 
@@ -58,9 +61,10 @@ Selected icon:
   focuses={[]}
   expertises={['Cell Biology']}
   isKeywordClickable={false}
+  isSelectedInForm={false}
   isStatusShown={true}
   iconType="selected"
-  onIconClick={() => console.log('icon clicked')}
+  togglePersonSelection={() => console.log('icon clicked')}
 />
 ```
 
@@ -74,7 +78,9 @@ Disabled:
   expertises={['Cell Biology']}
   isKeywordClickable={false}
   iconType="add"
-  isIconClickable={false}
+  isSelectedButtonClickable={false}
+  isSelectedInForm={false}
+  togglePersonSelection={() => console.log('icon clicked')}
 />
 ```
 
@@ -82,16 +88,16 @@ Disabled:
 
 ```js
 ;<PersonPod.SelectButton
-  role="Senior Editor(s)"
+  roleName="Senior Editor(s)"
   isRequired={true}
-  onIconClick={() => console.log('icon clicked')}
+  togglePersonSelection={() => console.log('icon clicked')}
 />
 ```
 
 ```js
 ;<PersonPod.SelectButton
-  role="Reviewing Editor(s)"
+  roleName="Reviewing Editor(s)"
   isRequired={false}
-  onIconClick={() => console.log('icon clicked')}
+  togglePersonSelection={() => console.log('icon clicked')}
 />
 ```

--- a/app/components/ui/atoms/PersonPod.md
+++ b/app/components/ui/atoms/PersonPod.md
@@ -6,7 +6,8 @@ Clickable keywords:
 ;<PersonPod
   name="Brian B Aldrich"
   institution="Utrecht University"
-  keywords={['Cell Biology', 'Biochemistry and Chemical Biology']}
+  focuses={['cell biology', 'biochemistry and chemical biology']}
+  expertises={['Cellular Biology']}
   isKeywordClickable={true}
   onKeywordClick={keyword => console.log(keyword, 'clicked')}
   isStatusShown={false}
@@ -21,11 +22,8 @@ Showing the person's status:
 ;<PersonPod
   name="Brian B Aldrich"
   institution="Utrecht University"
-  keywords={[
-    'Structural Biology and Molecular Biophysics',
-    'Biochemistry and Chemical Biology',
-    'Plant Biology',
-  ]}
+  focuses={['structural biology and molecular biophysics']}
+  expertises={['Biochemistry and Chemical Biology', 'Plant Biology']}
   isKeywordClickable={false}
   status="Currently unavailable"
   isStatusShown={true}
@@ -40,7 +38,8 @@ Removal icon:
 ;<PersonPod
   name="Brian B Aldrich"
   institution="National Centre for Biological Sciences, Tata Institute of Fundamental Research"
-  keywords={['Human Biology and Medicine', 'Neuroscience']}
+  focuses={['human biology and medicine']}
+  expertises={['Neuroscience']}
   isKeywordClickable={false}
   onKeywordClick={() => console.log('keyword clicked')}
   status="Currently unavailable"
@@ -56,7 +55,8 @@ Selected icon:
 ;<PersonPod
   name="Brian B Aldrich"
   institution="Utrecht University"
-  keywords={['Cell Biology']}
+  focuses={[]}
+  expertises={['Cell Biology']}
   isKeywordClickable={false}
   isStatusShown={true}
   iconType="selected"
@@ -70,7 +70,8 @@ Disabled:
 ;<PersonPod
   name="Brian B Aldrich"
   institution="Utrecht University"
-  keywords={['Cell Biology']}
+  focuses={['biological experiments']}
+  expertises={['Cell Biology']}
   isKeywordClickable={false}
   iconType="add"
   isIconClickable={false}

--- a/app/components/ui/atoms/PersonPod.test.js
+++ b/app/components/ui/atoms/PersonPod.test.js
@@ -21,7 +21,8 @@ const propsWithClickableFunctionality = {
   institution: 'Utrecht University',
   isKeywordClickable: true,
   isStatusShown: false,
-  keywords: ['cell biology'],
+  focuses: ['cell biology'],
+  expertises: ['Cancer cells', 'Neroscience'],
   name: 'Richard Aldrich',
   onIconClick: handleIconClick,
   onKeywordClick: handleKeywordClick,
@@ -48,7 +49,9 @@ describe('PersonPod component', () => {
 
   it('onKeywordClick handler - fired when selection button is clicked', () => {
     const wrapper = makePersonPodWrapper(propsWithClickableFunctionality)
-    const keyword = wrapper.find('button[data-test-id="clickable-keyword"]')
+    const keyword = wrapper
+      .find('button[data-test-id="clickable-keyword"]')
+      .at(0)
     keyword.simulate('click')
     expect(handleKeywordClick.mock.calls).toHaveLength(1)
   })
@@ -58,9 +61,11 @@ describe('PersonPod component', () => {
     expect(
       wrapper.find('button[data-test-id="clickable-keyword"]').exists(),
     ).toBe(false)
-    const keywords = wrapper.find('span[data-test-id="non-clickable-keyword"]')
-    expect(keywords.exists()).toBe(true)
-    keywords.simulate('click')
+    const keyword = wrapper
+      .find('span[data-test-id="non-clickable-keyword"]')
+      .at(0)
+    expect(keyword.exists()).toBe(true)
+    keyword.simulate('click')
     expect(handleKeywordClick.mock.calls).toHaveLength(0)
   })
 })

--- a/app/components/ui/atoms/PersonPod.test.js
+++ b/app/components/ui/atoms/PersonPod.test.js
@@ -17,14 +17,15 @@ function makePersonPodWrapper(props) {
 }
 
 const propsWithClickableFunctionality = {
+  togglePersonSelection: handleIconClick,
   iconType: 'add',
+  name: 'Richard Aldrich',
   institution: 'Utrecht University',
-  isKeywordClickable: true,
-  isStatusShown: false,
   focuses: ['cell biology'],
   expertises: ['Cancer cells', 'Neroscience'],
-  name: 'Richard Aldrich',
-  onIconClick: handleIconClick,
+  isKeywordClickable: true,
+  isSelected: true,
+  isStatusShown: false,
   onKeywordClick: handleKeywordClick,
 }
 

--- a/app/components/ui/atoms/SmallParagraph.js
+++ b/app/components/ui/atoms/SmallParagraph.js
@@ -1,5 +1,9 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
+
+const secondary = css`
+  color: ${th('colorTextSecondary')};
+`
 
 const SmallParagraph = styled.p`
   font-family: ${th('fontReading')};
@@ -12,6 +16,8 @@ const SmallParagraph = styled.p`
   &:last-child {
     margin-bottom: 0;
   }
+
+  ${props => props.secondary && secondary};
 `
 
 export default SmallParagraph

--- a/app/components/ui/molecules/ModalDialog.js
+++ b/app/components/ui/molecules/ModalDialog.js
@@ -34,10 +34,16 @@ const ModalDialog = ({
   children,
   onAccept,
   onCancel,
+  open,
   size,
+  transparentBackground = true,
   ...props
 }) => (
-  <ModalOverlay transparentBackground {...props}>
+  <ModalOverlay
+    open={open}
+    transparentBackground={transparentBackground}
+    {...props}
+  >
     <MiddleAligner alignItems="center" justifyContent="center">
       <WhiteBox p={3} size={size}>
         {children}

--- a/app/components/ui/molecules/ModalDialog.md
+++ b/app/components/ui/molecules/ModalDialog.md
@@ -1,14 +1,19 @@
 White modal dialog in the centre of the viewport, surrounded by greyed-out background
 
+Plain modal:
+
 ```js
 const FormH2 = require('../atoms/FormHeadings.js').FormH2
+initialState = {
+  open: false,
+}
 ;<div>
   <button onClick={() => setState({ open: true })}>Open</button>
   <ModalDialog
     acceptText="Yeeeeah"
     cancelText="woah now"
     onAccept={() => {
-      console.log('accepted')
+      setState({ open: false })
     }}
     onCancel={() => setState({ open: false })}
     open={state.open}
@@ -32,6 +37,43 @@ const FormH2 = require('../atoms/FormHeadings.js').FormH2
         <option>l</option>
       </select>
     </p>
+  </ModalDialog>
+</div>
+```
+
+PersonInfo modal:
+
+```js
+const PersonInfo = require('../atoms/PersonInfo.js').default
+initialState = {
+  open: false,
+  personAdded: false,
+}
+;<div>
+  <button onClick={() => setState({ open: true })}>Open</button>
+  <p> Person added: {state.personAdded ? 'true' : 'false'}</p>
+  <ModalDialog
+    acceptText="Add person"
+    cancelText="Cancel"
+    onAccept={() => {
+      setState({ personAdded: true, open: false })
+    }}
+    onCancel={() => setState({ open: false })}
+    open={state.open}
+    size={state.size}
+  >
+    <PersonInfo
+      person={{
+        id: '1234',
+        name: 'Michael J Frank',
+        aff: 'Max Planck Institute, Germany',
+        subjectAreas: [
+          'genetics of global gene expression',
+          'mouse models of human disease',
+          'haematology',
+        ],
+      }}
+    />
   </ModalDialog>
 </div>
 ```

--- a/app/components/ui/molecules/ModalDialog.md
+++ b/app/components/ui/molecules/ModalDialog.md
@@ -1,6 +1,32 @@
-White modal dialog in the centre of the viewport, surrounded by greyed-out background
+White modal dialog in the centre of the viewport, surrounded by greyed-out background. You are able to put whatever content you want inside.
 
-Plain modal:
+Child is just a div with a fixed height:
+
+```js
+const FormH2 = require('../atoms/FormHeadings.js').FormH2
+initialState = {
+  open: false,
+  accepted: false,
+}
+;<div>
+  <button onClick={() => setState({ open: true })}>Open</button>
+  <p>Accepted in modal: {state.accepted ? 'true' : 'false'}</p>
+  <ModalDialog
+    acceptText="Yes"
+    cancelText="No"
+    onAccept={() => {
+      setState({ open: false, accepted: true })
+    }}
+    onCancel={() => setState({ open: false })}
+    open={state.open}
+    size={state.size}
+  >
+    <div style={{ height: '500px' }} />
+  </ModalDialog>
+</div>
+```
+
+Children are various headings & paragraph elements:
 
 ```js
 const FormH2 = require('../atoms/FormHeadings.js').FormH2
@@ -10,7 +36,7 @@ initialState = {
 ;<div>
   <button onClick={() => setState({ open: true })}>Open</button>
   <ModalDialog
-    acceptText="Yeeeeah"
+    acceptText="Click meeee"
     cancelText="woah now"
     onAccept={() => {
       setState({ open: false })
@@ -37,43 +63,6 @@ initialState = {
         <option>l</option>
       </select>
     </p>
-  </ModalDialog>
-</div>
-```
-
-PersonInfo modal:
-
-```js
-const PersonInfo = require('../atoms/PersonInfo.js').default
-initialState = {
-  open: false,
-  personAdded: false,
-}
-;<div>
-  <button onClick={() => setState({ open: true })}>Open</button>
-  <p> Person added: {state.personAdded ? 'true' : 'false'}</p>
-  <ModalDialog
-    acceptText="Add person"
-    cancelText="Cancel"
-    onAccept={() => {
-      setState({ personAdded: true, open: false })
-    }}
-    onCancel={() => setState({ open: false })}
-    open={state.open}
-    size={state.size}
-  >
-    <PersonInfo
-      person={{
-        id: '1234',
-        name: 'Michael J Frank',
-        aff: 'Max Planck Institute, Germany',
-        focuses: ['biophysics and structural biology', 'immunology'],
-        expertises: [
-          'Evolutionary Biology',
-          'Microbiology and Infectious Disease',
-        ],
-      }}
-    />
   </ModalDialog>
 </div>
 ```

--- a/app/components/ui/molecules/ModalDialog.md
+++ b/app/components/ui/molecules/ModalDialog.md
@@ -67,10 +67,10 @@ initialState = {
         id: '1234',
         name: 'Michael J Frank',
         aff: 'Max Planck Institute, Germany',
-        subjectAreas: [
-          'genetics of global gene expression',
-          'mouse models of human disease',
-          'haematology',
+        focuses: ['biophysics and structural biology', 'immunology'],
+        expertises: [
+          'Evolutionary Biology',
+          'Microbiology and Infectious Disease',
         ],
       }}
     />

--- a/app/components/ui/molecules/PeoplePicker.js
+++ b/app/components/ui/molecules/PeoplePicker.js
@@ -77,7 +77,7 @@ const PeoplePickerBody = ({
             }
             isKeywordClickable={false}
             key={person.id}
-            keywords={person.subjectAreas}
+            keywords={[].concat(person.focuses).concat(person.expertises)}
             name={person.name}
             onIconClick={() => toggleSelection(person)}
             // onKeywordClick will need to be added, once we know what the desired behaviour is
@@ -173,9 +173,9 @@ class PeoplePicker extends React.Component {
 
     extendedPeople = extendedPeople.map(person => ({
       ...person,
-      searchValue: `${person.name} ${person.subjectAreas.join(' ')} ${
-        person.aff ? person.aff : ''
-      }`,
+      searchValue: `${person.name} ${person.focuses.join(
+        ' ',
+      )} ${person.expertises.join(' ')} ${person.aff ? person.aff : ''}`,
     }))
     const searchOptions = extendedPeople.map(person => ({
       value: person.name,

--- a/app/components/ui/molecules/PeoplePicker.js
+++ b/app/components/ui/molecules/PeoplePicker.js
@@ -72,13 +72,14 @@ const PeoplePickerBody = ({
             focuses={person.focuses}
             iconType={isSelected(person) ? 'selected' : 'add'}
             institution={person.aff}
-            isIconClickable={
+            isKeywordClickable={false}
+            isSelectButtonClickable={
               isSelected(person) || selection.length < maxSelection
             }
-            isKeywordClickable={false}
+            isSelected={isSelected(person)}
             key={person.id}
             name={person.name}
-            onIconClick={() => toggleSelection(person)}
+            togglePersonSelection={() => toggleSelection(person)}
             // onKeywordClick will need to be added, once we know what the desired behaviour is
           />
         ))

--- a/app/components/ui/molecules/PeoplePicker.js
+++ b/app/components/ui/molecules/PeoplePicker.js
@@ -51,8 +51,6 @@ const PeoplePickerBody = ({
   isSelected,
   maxSelection,
   minSelection,
-  onCancel,
-  onSubmit,
   people,
   selection,
   toggleSelection,
@@ -70,6 +68,8 @@ const PeoplePickerBody = ({
       {people
         .map(person => (
           <PersonPod
+            expertises={person.expertises}
+            focuses={person.focuses}
             iconType={isSelected(person) ? 'selected' : 'add'}
             institution={person.aff}
             isIconClickable={
@@ -77,7 +77,6 @@ const PeoplePickerBody = ({
             }
             isKeywordClickable={false}
             key={person.id}
-            keywords={[].concat(person.focuses).concat(person.expertises)}
             name={person.name}
             onIconClick={() => toggleSelection(person)}
             // onKeywordClick will need to be added, once we know what the desired behaviour is

--- a/app/components/ui/molecules/PeoplePicker.md
+++ b/app/components/ui/molecules/PeoplePicker.md
@@ -102,7 +102,7 @@ const people = [
 
 const selection = people.slice(0, 2)
 ;<PeoplePicker.Body
-  isSelected={person => selection.includes(person)}
+  select={person => selection.includes(person)}
   maxSelection={5}
   minSelection={3}
   people={people}

--- a/app/components/ui/molecules/PeoplePicker.md
+++ b/app/components/ui/molecules/PeoplePicker.md
@@ -7,26 +7,36 @@ const people = [
   {
     id: 1,
     name: 'Annie Badger',
-    institution: 'A University',
-    subjectAreas: ['Cell biology'],
+    aff: 'A University',
+    focuses: ['biophysics and structural biology', 'immunology'],
+    expertises: ['Evolutionary Biology', 'Microbiology and Infectious Disease'],
   },
   {
     id: 2,
     name: 'Bobby Badger',
-    institution: 'B College',
-    subjectAreas: ['Biochemistry and chemical biology'],
+    aff: 'B College',
+    focuses: ['cell biology'],
+    expertises: [
+      'Biochemistry and Chemical Biology',
+      'Chromosomes and Gene Expression',
+    ],
   },
   {
     id: 3,
     name: 'Chastity Badger',
-    institution: 'C Institute',
-    subjectAreas: ['Ecology'],
+    aff: 'C Institute',
+    focuses: ['computational and systems biology'],
+    expertises: [
+      'Developmental Biology',
+      'Stem Cells and Regenerative Medicine',
+    ],
   },
   {
     id: 4,
     name: 'Dave Badger',
-    institution: 'D Research Lab',
-    subjectAreas: ['Neuroscience', 'Pumpkins', 'Chaffinches'],
+    aff: 'D Research Lab',
+    focuses: ['auditory cognition'],
+    expertises: ['Neuroscience', 'Pumpkins', 'Chaffinches'],
   },
 ]
 ;<PeoplePicker
@@ -57,26 +67,36 @@ const people = [
   {
     id: 1,
     name: 'Annie Badger',
-    institution: 'A University',
-    keywords: 'cell biology',
+    aff: 'A University',
+    focuses: ['biophysics and structural biology', 'immunology'],
+    expertises: ['Evolutionary Biology', 'Microbiology and Infectious Disease'],
   },
   {
     id: 2,
     name: 'Bobby Badger',
-    institution: 'B College',
-    keywords: 'biochemistry and chemical biology',
+    aff: 'B College',
+    focuses: ['cell biology'],
+    expertises: [
+      'Biochemistry and Chemical Biology',
+      'Chromosomes and Gene Expression',
+    ],
   },
   {
     id: 3,
     name: 'Chastity Badger',
-    institution: 'C Institute',
-    keywords: 'ecology',
+    aff: 'C Institute',
+    focuses: ['computational and systems biology'],
+    expertises: [
+      'Developmental Biology',
+      'Stem Cells and Regenerative Medicine',
+    ],
   },
   {
     id: 4,
     name: 'Dave Badger',
-    institution: 'D Research Lab',
-    keywords: 'neuroscience',
+    aff: 'D Research Lab',
+    focuses: ['auditory cognition'],
+    expertises: ['Neuroscience', 'Pumpkins', 'Chaffinches'],
   },
 ]
 

--- a/app/components/ui/molecules/PeoplePicker.test.js
+++ b/app/components/ui/molecules/PeoplePicker.test.js
@@ -10,16 +10,36 @@ const people = [
     id: 1,
     name: 'Annie Nadine',
     aff: 'eLife',
-    subjectAreas: ['Biophysics and Structural Biology', 'Immunology'],
+    focuses: ['biophysics and structural biology', 'immunology'],
+    expertises: ['Evolutionary Biology', 'Microbiology and Infectious Disease'],
   },
-  { id: 2, name: 'Bobby Aaron', aff: 'eLife', subjectAreas: ['Cell Biology'] },
+  {
+    id: 2,
+    name: 'Bobby Aaron',
+    aff: 'eLife',
+    focuses: ['cell biology'],
+    expertises: [
+      'Biochemistry and Chemical Biology',
+      'Chromosomes and Gene Expression',
+    ],
+  },
   {
     id: 3,
     name: 'Chastity Bob',
     aff: 'eLife',
-    subjectAreas: ['Computational and Systems Biology'],
+    focuses: ['computational and systems biology'],
+    expertises: [
+      'Developmental Biology',
+      'Stem Cells and Regenerative Medicine',
+    ],
   },
-  { id: 4, name: 'Dave Paul', aff: 'eLife', subjectAreas: ['Neuroscience'] },
+  {
+    id: 4,
+    name: 'Dave Paul',
+    aff: 'eLife',
+    focuses: ['auditory cognition'],
+    expertises: ['Neuroscience'],
+  },
 ]
 
 const makeWrapper = props =>
@@ -181,7 +201,7 @@ describe('PeoplePicker', () => {
 
     it('does match characters in the middle of the word', () => {
       searchFor('y')
-      expect(searchWrapper.find('PersonPod')).toHaveLength(3)
+      expect(searchWrapper.find('PersonPod')).toHaveLength(4)
     })
 
     it('filters the people pods when you click on the search icon', () => {

--- a/server/xpub-model/entities/user/helpers/elife-api.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.js
@@ -22,21 +22,21 @@ const request = (endpoint, query = {}) => {
 }
 
 const convertPerson = apiPerson => {
+  const { id, name, research, emailAddresses, affiliations } = apiPerson
+  const { focuses = [], expertises = [] } = research
+
   let person = {
-    id: apiPerson.id,
-    name: apiPerson.name.preferred,
-    aff: apiPerson.affiliations && apiPerson.affiliations[0].name[0],
-    subjectAreas: ((apiPerson.research && apiPerson.research.expertises) || [])
-      .map(e => e.name)
-      .concat((apiPerson.research && apiPerson.research.focuses) || []),
-    surname: apiPerson.name.surname,
-    firstname: apiPerson.name.givenNames,
+    id,
+    name: name.preferred,
+    aff: affiliations ? affiliations[0].name[0] : undefined,
+    focuses,
+    expertises: expertises.map(expertise => expertise.name) || [],
+    surname: name.surname,
+    firstname: name.givenNames,
   }
   // if we used a secret then pull out the email too
-  if (config.get('server.api.secret') && apiPerson.emailAddresses) {
-    const email = apiPerson.emailAddresses.length
-      ? apiPerson.emailAddresses[0].value
-      : ''
+  if (config.get('server.api.secret') && emailAddresses) {
+    const email = emailAddresses.length ? emailAddresses[0].value : ''
 
     person = {
       ...person,

--- a/server/xpub-server/entities/manuscript/resolvers/index.js
+++ b/server/xpub-server/entities/manuscript/resolvers/index.js
@@ -126,7 +126,8 @@ const resolvers = {
 
   Assignee: {
     __resolveType: assignee => {
-      if (assignee.subjectAreas !== undefined) return 'EditorAlias'
+      if (assignee.focuses !== undefined) return 'EditorAlias'
+      if (assignee.expertises !== undefined) return 'EditorAlias'
       if (assignee.name !== undefined) return 'ReviewerAlias'
       if (assignee.firstName !== undefined) return 'AuthorAlias'
       return null

--- a/server/xpub-server/entities/manuscript/typeDefs.graphqls
+++ b/server/xpub-server/entities/manuscript/typeDefs.graphqls
@@ -71,7 +71,8 @@ type EditorAlias {
   id: ID
   name: String
   aff: String
-  subjectAreas: [String]
+  focuses: [String]
+  expertises: [String]
 }
 type ReviewerAlias {
   name: String

--- a/server/xpub-server/entities/user/resolvers.test.js
+++ b/server/xpub-server/entities/user/resolvers.test.js
@@ -53,7 +53,10 @@ describe('User', () => {
           'cellular neurophysiology',
           'biochemical neuroscience',
         ],
-        expertises: [],
+        expertises: [
+          'Structural Biology and Molecular Biophysics',
+          'Neuroscience',
+        ],
       })
     })
   })

--- a/server/xpub-server/entities/user/resolvers.test.js
+++ b/server/xpub-server/entities/user/resolvers.test.js
@@ -45,9 +45,7 @@ describe('User', () => {
         id: '8d7e57b3',
         aff: undefined,
         name: 'Richard Aldrich',
-        subjectAreas: [
-          'Structural Biology and Molecular Biophysics',
-          'Neuroscience',
+        focuses: [
           'ion channels',
           'calcium binding proteins',
           'membrane transport',
@@ -55,6 +53,7 @@ describe('User', () => {
           'cellular neurophysiology',
           'biochemical neuroscience',
         ],
+        expertises: [],
       })
     })
   })


### PR DESCRIPTION
#### What does this PR do?
- add new `PersonInfo` component - text that goes inside new modal dialog
- refactor existing `Paragraph` & `SmallParagraph` components to allow `secondary` prop for text colour (make consistent across the rest of the existing codebase)
- separate subjectAreas into focuses & expertises when making the API call to eLife's `/people` endpoint, so that we can separate these in the modal view
- refactor PersonPod to make it easier to add to
- render modal inside PersonPod, make PersonPod stateful to keep track of whether the modal is open
- hook up to PeoplePickerModal & PeoplePickerControl

To do:
- tests
- change `ModalDialog` in order to satisfy this product req:
> Clicking outside of the lightbox should close the modal

Could raise in a new ticket for the to dos?

#### Any relevant tickets

Closes #635 

#### How has this been tested?

Adjusted existing tests, but all testing for this new component TBD

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [x] Has been reviewed against Designs
- [x] Necessary updates to styleguide
