### PR TITLE
1107 confirmation dialog manuscript delete

### DIFF
--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -171,7 +171,8 @@ const DashboardListItem = ({ manuscript }) => {
               <Mutation mutation={DELETE_MANUSCRIPT}>
                 {deleteManuscript => (
                   <ModalDialog
-                    acceptText="Confirm"
+                    acceptText="Delete"
+                    attention
                     onAccept={() => {
                       hideModal()
                       deleteManuscript({

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -14,7 +14,6 @@ import ManuscriptStatus from '../atoms/ManuscriptStatus'
 import media from '../../global/layout/media'
 import ModalDialog from './ModalDialog'
 import ModalHistoryState from './ModalHistoryState'
-import ButtonAsIconWrapper from '../atoms/ButtonAsIconWrapper'
 
 export const dashboardDateText = date => {
   const diffDays = differenceInCalendarDays(new Date(), date)
@@ -104,7 +103,7 @@ const StyledRemoveIcon = styled(TrashIcon)`
   fill: ${th('colorTextSecondary')};
 `
 
-const ButtonContainer = styled(ButtonAsIconWrapper)`
+const ButtonContainer = styled(Box)`
   width: 5%;
 `
 

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { Flex, Box } from 'grid-styled'
 import { differenceInCalendarDays, format } from 'date-fns'
 import { th } from '@pubsweet/ui-toolkit'
+import { H2 } from '@pubsweet/ui'
 import PropTypes from 'prop-types'
 import { Mutation } from 'react-apollo'
 import Icon from '../../ui/atoms/Icon'
@@ -11,6 +12,9 @@ import { DELETE_MANUSCRIPT } from '../../pages/SubmissionWizard/operations'
 import { ALL_MANUSCRIPTS } from '../../pages/Dashboard/operations'
 import ManuscriptStatus from '../atoms/ManuscriptStatus'
 import media from '../../global/layout/media'
+import ModalDialog from './ModalDialog'
+import ModalHistoryState from './ModalHistoryState'
+import ButtonAsIconWrapper from '../atoms/ButtonAsIconWrapper'
 
 export const dashboardDateText = date => {
   const diffDays = differenceInCalendarDays(new Date(), date)
@@ -100,7 +104,7 @@ const StyledRemoveIcon = styled(TrashIcon)`
   fill: ${th('colorTextSecondary')};
 `
 
-const ButtonContainer = styled(Box)`
+const ButtonContainer = styled(ButtonAsIconWrapper)`
   width: 5%;
 `
 
@@ -122,20 +126,15 @@ const ItemContent = styled(Flex)`
 `
 
 const DashboardListItem = ({ manuscript }) => {
-  const onClickHandler = deleteManuscript => {
-    deleteManuscript({
-      variables: { id: manuscript.id },
-      refetchQueries: [{ query: ALL_MANUSCRIPTS }],
-    })
-  }
+  const title = manuscript.meta.title || '(Untitled)'
 
   const renderItemContent = () => {
-    const { meta, clientStatus, created } = manuscript
+    const { clientStatus, created } = manuscript
     const date = new Date(created)
     return (
       <ItemContent>
         <TitleBox color={mapColor(clientStatus)} data-test-id="title" mb={3}>
-          {meta.title || '(Untitled)'}
+          {title}
         </TitleBox>
         <ManuscriptStatus statusCode={clientStatus} />
         <DateBox>
@@ -154,24 +153,42 @@ const DashboardListItem = ({ manuscript }) => {
           <ButtonContainer />
         </Fragment>
       ) : (
-        <Fragment>
-          <DashboardLink
-            data-test-id="continue-submission"
-            to={`${manuscript.lastStepVisited}`}
-          >
-            {renderItemContent()}
-          </DashboardLink>
-          <ButtonContainer>
-            <Mutation mutation={DELETE_MANUSCRIPT}>
-              {deleteManuscript => (
+        <ModalHistoryState name={manuscript.id}>
+          {({ showModal, hideModal, isModalVisible }) => (
+            <Fragment>
+              <DashboardLink
+                data-test-id="continue-submission"
+                to={`${manuscript.lastStepVisited}`}
+              >
+                {renderItemContent()}
+              </DashboardLink>
+              <ButtonContainer>
                 <StyledRemoveIcon
                   data-test-id="trash"
-                  onClick={() => onClickHandler(deleteManuscript)}
+                  onClick={() => showModal()}
                 />
-              )}
-            </Mutation>
-          </ButtonContainer>
-        </Fragment>
+              </ButtonContainer>
+              <Mutation mutation={DELETE_MANUSCRIPT}>
+                {deleteManuscript => (
+                  <ModalDialog
+                    acceptText="Confirm"
+                    onAccept={() =>
+                      deleteManuscript({
+                        variables: { id: manuscript.id },
+                        refetchQueries: [{ query: ALL_MANUSCRIPTS }],
+                      })
+                    }
+                    onCancel={hideModal}
+                    open={isModalVisible()}
+                  >
+                    {'<H2>Confirm delete submission?</H2>'}
+                    Your submission "{title}" will be deleted permanently
+                  </ModalDialog>
+                )}
+              </Mutation>
+            </Fragment>
+          )}
+        </ModalHistoryState>
       )}
     </Root>
   )

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -172,17 +172,20 @@ const DashboardListItem = ({ manuscript }) => {
                 {deleteManuscript => (
                   <ModalDialog
                     acceptText="Confirm"
-                    onAccept={() =>
+                    onAccept={() => {
+                      hideModal()
                       deleteManuscript({
                         variables: { id: manuscript.id },
                         refetchQueries: [{ query: ALL_MANUSCRIPTS }],
                       })
-                    }
+                    }}
                     onCancel={hideModal}
                     open={isModalVisible()}
                   >
-                    {'<H2>Confirm delete submission?</H2>'}
-                    Your submission "{title}" will be deleted permanently
+                    <H2>Confirm delete submission?</H2>
+                    Your submission &quot;
+                    {title}
+                    &quot; will be deleted permanently
                   </ModalDialog>
                 )}
               </Mutation>

--- a/app/components/ui/molecules/ModalDialog.js
+++ b/app/components/ui/molecules/ModalDialog.js
@@ -50,7 +50,7 @@ const ModalDialog = ({
         {children}
         <Flex justifyContent="center" mt={3}>
           <Box mr={3}>
-            <Button onClick={onCancel} type="button">
+            <Button data-test-id="cancel" onClick={onCancel} type="button">
               {cancelText}
             </Button>
           </Box>

--- a/app/components/ui/molecules/ModalDialog.js
+++ b/app/components/ui/molecules/ModalDialog.js
@@ -37,6 +37,7 @@ const ModalDialog = ({
   open,
   size,
   transparentBackground = true,
+  attention,
   ...props
 }) => (
   <ModalOverlay
@@ -54,14 +55,26 @@ const ModalDialog = ({
             </Button>
           </Box>
           <Box>
-            <Button
-              data-test-id="accept"
-              onClick={onAccept}
-              primary
-              type="button"
-            >
-              {acceptText}
-            </Button>
+            {attention && (
+              <Button
+                attention
+                data-test-id="accept"
+                onClick={onAccept}
+                type="button"
+              >
+                {acceptText}
+              </Button>
+            )}
+            {!attention && (
+              <Button
+                data-test-id="accept"
+                onClick={onAccept}
+                primary
+                type="button"
+              >
+                {acceptText}
+              </Button>
+            )}
           </Box>
         </Flex>
       </WhiteBox>

--- a/client/elife-theme/src/elements/ui/Button.js
+++ b/client/elife-theme/src/elements/ui/Button.js
@@ -31,6 +31,31 @@ const primary = css`
     }
   }
 `
+const attention = css`
+  background-color: ${th('colorError')};
+  border-color: ${th('colorError')};
+  color: ${th('colorTextReverse')};
+
+  &:focus,
+  &:hover {
+    background-color: ${darken('colorError', 0.3)};
+    border-color: ${darken('colorError', 0.3)};
+  }
+
+  &:active {
+    background-color: ${darken('colorError', 0.5)};
+    border-color: ${darken('colorError', 0.5)};
+  }
+
+  &[disabled] {
+    &:focus,
+    &:hover,
+    &:active {
+      background-color: ${th('colorError')};
+      border-color: ${th('colorError')};
+    }
+  }
+`
 
 export default css`
   font-size: ${th('fontSizeBaseSmall')}
@@ -44,4 +69,5 @@ export default css`
   ${props => props.small && small};
   ${props => props.extraSmall && extraSmall};
   ${props => props.primary && primary};
+  ${props => props.attention && attention};
 `

--- a/test/delete.submision.browser.js
+++ b/test/delete.submision.browser.js
@@ -1,4 +1,5 @@
 import config from 'config'
+import { Selector } from 'testcafe'
 import { author, dashboard, login, wizardStep } from './pageObjects'
 import setFixtureHooks from './helpers/set-fixture-hooks'
 
@@ -41,7 +42,9 @@ test('Create a Submission', async t => {
   await t
     .navigateTo(`${config.get('pubsweet-server.baseUrl')}`)
     .click(dashboard.trashButton)
-    .wait(1000)
+    .wait(100)
+    .click(Selector('[data-test-id=accept'))
+    .wait(100)
     .expect(dashboard.trashButton.count)
     .eql(0)
 })

--- a/test/delete.submision.browser.js
+++ b/test/delete.submision.browser.js
@@ -38,13 +38,18 @@ test('Create a Submission', async t => {
     .typeText(author.emailField, 'example@example.org')
     .click(wizardStep.next)
 
-  // navigate back to the dashboard page and delete the submission
+  // navigate back to the dashboard page and cancel the delete the submission
   await t
     .navigateTo(`${config.get('pubsweet-server.baseUrl')}`)
     .click(dashboard.trashButton)
-    .wait(100)
+    .click(Selector('[data-test-id=cancel'))
+    .expect(dashboard.trashButton.count)
+    .eql(1)
+
+  // navigate back to the dashboard page and cancel the delete the submission
+  await t
+    .click(dashboard.trashButton)
     .click(Selector('[data-test-id=accept'))
-    .wait(100)
     .expect(dashboard.trashButton.count)
     .eql(0)
 })


### PR DESCRIPTION
#### Background
once a manuscript is being deleted, we need the user confirmed first if this can be deleted

What does this PR do?
creates a dialogue to ask the user
closes: #1107 

#### How has this been tested?
create a submission go back to the dashboard, so the manuscript is fully submitted, and then press the trash button a dialogue should appear

- [x] Browser tests

#### UI Changes

- [x] Has been reviewed against Designs
- [x] Necessary updates to styleguide
