### PR TITLE
Trigger elife-xpub-deployment update directly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,4 +75,10 @@ elifePipeline {
             )
         }
     }
+
+    elifeMainlineOnly {
+        stage 'Downstream', {
+            build job: '/dependencies/dependencies-elife-xpub-deployment-update-xpub', wait: false, parameters: [string(name: 'commit', value: commit)]
+        }
+    }
 }


### PR DESCRIPTION
At the moment https://alfred.elifesciences.org/job/dependencies/job/dependencies-elife-xpub-deployment-update-xpub/ updates the Docker image tag of `elife-xpub` to use on `elife-xpub--*` environments (EC2 instances deploying it with `docker-compose`).

That pipeline is triggered by a Docker Hub hook that follows Gitlab's push of the image built by Gitlab CI (`xpub/xpub-elife`).

This change triggers that pipeline right after the successful completion of this pipeline instead. It also passes a `commit` parameter so that we don't have to read labels anymore from the Docker image, relying on this value instead.

This additional trigger is unnecessary at the moment, but it opens the way for `elife-xpub-deployment` to:

- start using the `elifesciences/elife-xpub` Docker image built by Jenkins in this pipeline
- stop listening to the Docker Hub hook