### PR TITLE
Fix failing e2e test

### DIFF
--- a/server/xpub-model/entities/user/helpers/elife-api.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.js
@@ -14,7 +14,7 @@ const request = (endpoint, query = {}) => {
     req.header.Authorization = secret
   }
   return req.query(query).catch(err => {
-    logger.error('Failed to fetch from eLife API:', err.message)
+    logger.error('Failed to fetch from eLife API:', err.message, err.stack)
     throw err
   })
 }

--- a/server/xpub-model/entities/user/helpers/elife-api.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.js
@@ -20,13 +20,7 @@ const request = (endpoint, query = {}) => {
 }
 
 const convertPerson = apiPerson => {
-  const {
-    id,
-    name = {},
-    research = {},
-    emailAddresses,
-    affiliations,
-  } = apiPerson
+  const { id, name, research = {}, emailAddresses, affiliations } = apiPerson
   const { focuses = [], expertises = [] } = research
 
   let person = {

--- a/server/xpub-model/entities/user/helpers/elife-api.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.js
@@ -13,16 +13,20 @@ const request = (endpoint, query = {}) => {
   if (secret) {
     req.header.Authorization = secret
   }
-  return req
-    .query(query)
-    .catch(err => {
-      logger.error('Failed to fetch from eLife API:', err.message)
-      throw err
-    })
+  return req.query(query).catch(err => {
+    logger.error('Failed to fetch from eLife API:', err.message)
+    throw err
+  })
 }
 
 const convertPerson = apiPerson => {
-  const { id, name, research, emailAddresses, affiliations } = apiPerson
+  const {
+    id,
+    name = {},
+    research = {},
+    emailAddresses,
+    affiliations,
+  } = apiPerson
   const { focuses = [], expertises = [] } = research
 
   let person = {

--- a/server/xpub-model/entities/user/helpers/elife-api.test.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.test.js
@@ -15,28 +15,20 @@ jest.mock('config', () => ({
 jest.mock('superagent', () => ({
   header: {},
   url: '',
-  query: jest.fn(() =>
-    Promise.resolve({
-      body: { items: [person] },
-    }),
-  ),
   get: jest.fn(),
   getHeader() {
     return this.header
   },
-  getQuery() {
-    return this.query
-  },
 }))
 
 const makeGetResponse = examplePerson => () => ({
-    header: request.header,
-    query: jest.fn(() =>
-      Promise.resolve({
-        body: { items: [examplePerson] },
-      }),
-    ),
-  })
+  header: request.header,
+  query: jest.fn(() =>
+    Promise.resolve({
+      body: { items: [examplePerson] },
+    }),
+  ),
+})
 
 const logger = require('@pubsweet/logger')
 const request = require('superagent')
@@ -70,9 +62,9 @@ describe('eLife API tests', () => {
 
   it('logs on error', async () => {
     request.get.mockImplementation(() => ({
-        header: request.header,
-        query: jest.fn(() => Promise.reject(new Error('Forbidden'))),
-      }))
+      header: request.header,
+      query: jest.fn(() => Promise.reject(new Error('Forbidden'))),
+    }))
     jest.spyOn(logger, 'error').mockImplementationOnce(() => {})
     await expect(api.people()).rejects.toThrow('Forbidden')
     expect(logger.error).toHaveBeenCalled()

--- a/server/xpub-model/entities/user/helpers/elife-api.test.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.test.js
@@ -51,6 +51,13 @@ describe('eLife API tests', () => {
     expect(result[0].firstname).toBe(person.allDetails.name.givenNames)
     expect(result[0].surname).toBe(person.allDetails.name.surname)
     expect(result[0].email).toBe(person.allDetails.emailAddresses[0].value)
+    expect(result[0].aff).toBe(person.allDetails.affiliations[0].name[0])
+    expect(result[0].expertises).toHaveLength(
+      person.allDetails.research.expertises.length,
+    )
+    expect(result[0].focuses).toHaveLength(
+      person.allDetails.research.focuses.length,
+    )
   })
 
   it('creates correct person with minimum required data', async () => {

--- a/server/xpub-model/entities/user/helpers/elife-api.test.person.js
+++ b/server/xpub-model/entities/user/helpers/elife-api.test.person.js
@@ -1,39 +1,52 @@
 module.exports = {
-  id: 'ca22ca22',
-  type: {
-    id: 'reviewing-editor',
-    label: 'Reviewing Editor',
-  },
-  name: {
-    surname: 'Surname',
-    givenNames: 'Given Names',
-    preferred: 'Given Names Surname',
-    index: 'Surname, Given Names',
-  },
-  emailAddresses: [
-    {
-      value: 'person@email.com',
-      access: 'restricted',
+  allDetails: {
+    id: 'ca22ca22',
+    type: {
+      id: 'reviewing-editor',
+      label: 'Reviewing Editor',
     },
-  ],
-  research: {
-    focuses: ['protein synthesis', 'translational control'],
-    expertises: [
+    name: {
+      surname: 'Surname',
+      givenNames: 'Given Names',
+      preferred: 'Given Names Surname',
+      index: 'Surname, Given Names',
+    },
+    emailAddresses: [
       {
-        id: 'chromosomes-gene-expression',
-        name: 'Chromosomes and Gene Expression',
+        value: 'person@email.com',
+        access: 'restricted',
+      },
+    ],
+    research: {
+      focuses: ['protein synthesis', 'translational control'],
+      expertises: [
+        {
+          id: 'chromosomes-gene-expression',
+          name: 'Chromosomes and Gene Expression',
+        },
+      ],
+    },
+    affiliations: [
+      {
+        name: ['National Institute of Child Health and Human Development'],
+        address: {
+          formatted: ['United States'],
+          components: {
+            country: 'United States',
+          },
+        },
       },
     ],
   },
-  affiliations: [
-    {
-      name: ['National Institute of Child Health and Human Development'],
-      address: {
-        formatted: ['United States'],
-        components: {
-          country: 'United States',
-        },
-      },
+  minimumDetails: {
+    id: 'ca22ca22',
+    type: {
+      id: 'reviewing-editor',
+      label: 'Reviewing Editor',
     },
-  ],
+    name: {
+      preferred: 'Given Names Surname',
+      index: 'Surname, Given Names',
+    },
+  },
 }


### PR DESCRIPTION
#### Background

End 2 End test is failing as the test data being returned from the person api does not contain `research` data. This is not a required field according to the api schema so the xpub `elife-api` should be able to handle uesrs with the minimum required data.

What does this PR do?

Casts any undefined `research` value within person data to an empty object to prevent the `elife-api` from throwing an error.

Extends `elife-api.test.js` to run a test against the minimum required details that may be returned from the person api.
