### PR TITLE
Force ci to use fakes3 on its fixed port

### DIFF
--- a/config/ci.js
+++ b/config/ci.js
@@ -3,10 +3,7 @@ const AWS = require('aws-sdk')
 module.exports = {
   aws: {
     s3: {
-      endpoint: new AWS.Endpoint(
-        // randomise port to avoid conflicts in parallel test runs
-        `http://localhost:${Math.floor(Math.random() * 50000) + 15000}`,
-      ),
+      endpoint: new AWS.Endpoint('http://localhost:4569'),
     },
   },
   meca: {


### PR DESCRIPTION
For https://github.com/elifesciences/elife-xpub/issues/1064#issuecomment-442754324

Exploring with the build why was [this commit](https://github.com/elifesciences/elife-xpub/pull/1117/commits/b07650cb6fc0a315218b44c9c47be64a7210f4cf) necessary. I am trying to:

- use `test` and `docker-compose.ci.yml` for all automated testing
- use `ci` and Kubernetes, Helm for review environments

`elife-xpub--ci` is dead so won't use any environment.