### PR TITLE
Change upload progress and sciencebeam timeout

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -56,8 +56,7 @@ module.exports = {
       'cell-biology': 'Cell Biology',
       'chromosomes-gene-expression': 'Chromosomes and Gene Expression',
       'computational-systems-biology': 'Computational and Systems Biology',
-      'developmental-biology':
-        'Developmental Biology',
+      'developmental-biology': 'Developmental Biology',
       ecology: 'Ecology',
       'epidemiology-global-health': 'Epidemiology and Global Health',
       'evolutionary-biology': 'Evolutionary Biology',
@@ -68,7 +67,8 @@ module.exports = {
       neuroscience: 'Neuroscience',
       'physics-living-systems': 'Physics of Living Systems',
       'plant-biology': 'Plant Biology',
-      'stem-cells-and-regenerative-medicine': 'Stem Cells and Regenerative Medicine',
+      'stem-cells-and-regenerative-medicine':
+        'Stem Cells and Regenerative Medicine',
       'structural-biology-molecular-biophysics':
         'Structural Biology and Molecular Biophysics',
     },
@@ -118,7 +118,7 @@ module.exports = {
   },
   scienceBeam: {
     url: 'https://sciencebeam-texture.elifesciences.org/api/convert',
-    timeoutMs: 3000,
+    timeoutMs: 6000,
   },
   fileUpload: {
     isPublic: true,

--- a/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.js
+++ b/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.js
@@ -95,6 +95,7 @@ async function uploadManuscript(_, { file, id, fileSize }, { user }) {
   } catch (err) {
     logger.error(`Manuscript was not uploaded to S3: ${err}`)
     await fileEntity.delete()
+    clearInterval(handle)
     throw err
   }
 

--- a/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.js
+++ b/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.js
@@ -56,7 +56,7 @@ async function uploadManuscript(_, { file, id, fileSize }, { user }) {
 
   const pubsub = await pubsubManager.getPubsub()
 
-  // Predict upload time
+  // Predict upload time - The analysis was done on #839
   const predictedTime = 5 + 4.67e-6 * fileSize
   const startedTime = Date.now()
 


### PR DESCRIPTION
#### Background

- Increased Sciencebeam timeout
- Used a time-based prediction method for upload progress - see #839 for the maths

#### Any relevant tickets

Closes #839 

#### How has this been tested?

Tested locally - already have the end2end and browser tests
