### PR TITLE
upgrade xpub-edit with version 2.5.4 that fix the issue with the spac…

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "redux-logger": "^3.0.1",
     "styled-components": "^3.4.2",
     "uuid": "^3.3.2",
-    "xpub-edit": "^2.5.2",
+    "xpub-edit": "^2.5.4",
     "yup": "^0.26.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15593,10 +15593,10 @@ xmlbuilder@~9.0.1:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
-xpub-edit@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/xpub-edit/-/xpub-edit-2.5.2.tgz#0a026891edc5bd20dac68e749ed2d6d3032c5739"
-  integrity sha512-jhj5dJfu/hAON45UjsFOVpfocDeVNIGSJX+Jr98k3gfLAR5VzZ4r2/geuklBvdJ0A8V7/gkUKI2oQY3/HYTZcg==
+xpub-edit@^2.5.4:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/xpub-edit/-/xpub-edit-2.5.4.tgz#0a026891edc5bd20dac68e749ed2d6d3032c5739"
+  integrity sha512-gQLsUz8/pgfgnicgAqp52s4rIm09wunfEg7F9QXoxmcsRrkee1xDAoqvWivuMAQRwYqJUxTif8LT4Op61RxX3A==
   dependencies:
     "@pubsweet/ui-toolkit" "^1.2.0"
     prosemirror-commands "^1.0.1"


### PR DESCRIPTION
xpub-edit version 2.5.4 that fixes the issue with the space being eaten

#### Background
there is an issue on ProseMirror and firefox that removes the spaces on the editor

#### Any relevant tickets
https://gitlab.coko.foundation/pubsweet/pubsweet/merge_requests/458

closes: #1004 
