### PR TITLE
Upgrade yarn to 1.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# built from https://gitlab.coko.foundation/yld/xpub-deployment-config-postgres
 FROM xpub/xpub:base
 
 WORKDIR ${HOME}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "engines": {
     "node": ">=8.9.4",
-    "yarn": ">=1.2"
+    "yarn": "^1.10.1"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,7 +361,7 @@
     joi "^13.6.0"
     lodash "^4.17.4"
 
-"@pubsweet/ui-toolkit@1.2.0", "@pubsweet/ui-toolkit@^1.2.0":
+"@pubsweet/ui-toolkit@1.2.0", "@pubsweet/ui-toolkit@^1.2.0", "@pubsweet/ui-toolkit@^2.0.1":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@pubsweet/ui-toolkit/-/ui-toolkit-1.2.0.tgz#5531149fa2229acc06e76e964b8a412bf503c4ce"
   integrity sha512-HwnFt4eES5RopLLY7ajb//UvaCLXS29XCWOOB5cs90DkwysVZaH/GM5HB/QtClQ5tuXiR3BqfjLy2mHMA0Z+PQ==


### PR DESCRIPTION
#### Background

We currently accept any version of yarn greater than 1.2.

1.10 introduced a new field in the `yarn.lock` file, which [gets stripped out when using earlier versions](https://github.com/yarnpkg/yarn/issues/6440)

We generally use the latest version of yarn locally, so this change will throw an error if an earlier version of yarn is used.
