### PR TITLE
Added base Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # built from ./Dockerfile-base
-FROM xpub/xpub:20181213
+FROM xpub/xpub:20181213-1147
 
 WORKDIR ${HOME}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# built from ./Dockerfile-base
 FROM xpub/xpub:base
 
 WORKDIR ${HOME}

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8.9.4
 
 ENV HOME "/home/xpub"
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,0 +1,19 @@
+FROM node:8
+
+ENV HOME "/home/xpub"
+
+RUN mkdir -p ${HOME}
+
+WORKDIR ${HOME}
+
+# Build yarn offline cache
+
+RUN yarn config set yarn-offline-mirror /npm-packages-offline-cache && \
+  yarn config set prefer-offline true && \
+  yarn config set yarn-offline-mirror-pruning true
+
+RUN git clone https://github.com/elifesciences/elife-xpub.git && \
+    cd elife-xpub && \
+    yarn autoclean --init && yarn && \
+    cd && rm -rf elife-xpub
+

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM node:8.9.4
+FROM node:8.14.0
 
 ENV HOME "/home/xpub"
 


### PR DESCRIPTION
#### Background

The image for `elife-xpub` gets [built from `xpub/xpub`](https://github.com/elifesciences/elife-xpub/blob/develop/Dockerfile#L1) which in turn is currently built from [yld/xpub-deployment-config-postgres](https://gitlab.coko.foundation/yld/xpub-deployment-config-postgres/blob/master/images/xpub-base/Dockerfile)

This change relocated the base Dockerfile to the elife-xpub repository.

#### Any relevant tickets

Unblocks #1199 

#### How has this been tested?

Manually built and pushed the image, and tested CI for develop and PRs