### PR TITLE
Fork ci into a `formula` environment

### DIFF
--- a/config/formula.js
+++ b/config/formula.js
@@ -1,0 +1,7 @@
+module.exports = {
+  meca: {
+    sftp: {
+      disableUpload: true,
+    },
+  },
+}


### PR DESCRIPTION
Spawned from https://github.com/elifesciences/elife-xpub-formula/pull/64

We know `ci` by now is only used inside Kubernetes review environments and will be renamed to [`review`](https://github.com/elifesciences/elife-xpub/issues/1153).

This makes an alternative copy `formula` that uses all similar empty/local defaults, but doesn't talk to `fakes3` as this is not there in the formula.

The formula is used for production-like environments:

- `end2end`
- `staging`
- `prod`

Those are working with their own environment configuration, but we need a similar environment to run the tests of the formula itself (e.g. creating a server from scratch whenever a change is made.)