### PR TITLE
Configure staging to use mailer rather than fake-mailer

### DIFF
--- a/config/staging.js
+++ b/config/staging.js
@@ -13,6 +13,10 @@ module.exports = {
     url: 'https://continuumtest--cdn-journal.elifesciences.org/submit',
     enableMock: false,
   },
+  mailer: {
+    from: 'editorial-staging@elifesciences.org',
+    path: `${__dirname}/non-serializable/mailer`,
+  },
   aws: {
     s3: {
       params: {


### PR DESCRIPTION
Also from https://github.com/elifesciences/elife-xpub/issues/890

[By default](https://github.com/elifesciences/elife-xpub/blob/develop/config/default.js#L86) environments use `fake-mailer.js` rather than `mailer.js`, which is only used in `prod`. To send real emails from `staging` we need to do the same.

Also the [test configuration](https://github.com/elifesciences/elife-xpub/blob/develop/config/test.js#L52-L61) looks wrong as the [documentation](https://gitlab.coko.foundation/pubsweet/pubsweet/tree/master/packages/components/SendEmail-server/) states this object should be configured just with the `path` field.