### PR TITLE
Fixing styleguide

### DIFF
--- a/styleguide/components/StyleGuideRenderer.js
+++ b/styleguide/components/StyleGuideRenderer.js
@@ -1,6 +1,3 @@
 import DefaultRenderer from 'react-styleguidist/lib/rsg-components/StyleGuide/StyleGuideRenderer'
-import { injectGlobalStyles } from 'pubsweet-client/src/helpers/StyleRoot'
-
-injectGlobalStyles()
 
 export default DefaultRenderer

--- a/styleguide/components/Wrapper.js
+++ b/styleguide/components/Wrapper.js
@@ -3,12 +3,15 @@ import { ThemeProvider } from 'styled-components'
 import { MemoryRouter } from 'react-router-dom'
 
 import StyleRoot from 'pubsweet-client/src/helpers/StyleRoot'
-import theme from '@elifesciences/elife-theme'
+import theme, { GlobalStyle } from '@elifesciences/elife-theme'
 
 export default ({ children }) => (
   <ThemeProvider theme={theme}>
     <MemoryRouter>
-      <StyleRoot>{children}</StyleRoot>
+      <StyleRoot>
+        <GlobalStyle/>
+        {children}
+      </StyleRoot>
     </MemoryRouter>
   </ThemeProvider>
 )


### PR DESCRIPTION
The styleguide broke due to the recent Pubsweet upgrade introduce in #1237 

This fix uses the new method to add global styles to the styleguide, and removes the old method.