### PR TITLE
Fix Submission and Supporting File deletion

### DIFF
--- a/server/xpub-controller/supportingFiles.js
+++ b/server/xpub-controller/supportingFiles.js
@@ -10,8 +10,9 @@ class SupportingFiles {
   }
 
   async removeAll() {
+    console.log('0', this.id, this.user)
     let manuscript = await ManuscriptModel.find(this.id, this.user)
-
+    console.log('1', manuscript)
     const filesWithoutSupporting = manuscript.files.filter(
       file => file.type !== 'SUPPORTING_FILE',
     )

--- a/server/xpub-server/entities/manuscript/resolvers/index.js
+++ b/server/xpub-server/entities/manuscript/resolvers/index.js
@@ -1,6 +1,7 @@
 const logger = require('@pubsweet/logger')
 const { Manuscript, User, File } = require('@elifesciences/xpub-model')
 const elifeApi = require('@elifesciences/xpub-model/entities/user/helpers/elife-api')
+const { S3Storage } = require('@elifesciences/xpub-controller')
 
 const removeUploadedManuscript = require('./removeUploadedManuscript')
 const submitManuscript = require('./submitManuscript')
@@ -39,7 +40,7 @@ const resolvers = {
       if (files) {
         try {
           await files.forEach(file => {
-            file.deleteContent()
+            S3Storage.deleteContent(file)
             file.delete()
           })
         } catch (error) {

--- a/server/xpub-server/entities/manuscript/resolvers/removeSupportingFiles.js
+++ b/server/xpub-server/entities/manuscript/resolvers/removeSupportingFiles.js
@@ -1,7 +1,9 @@
 const { SupportingFiles, S3Storage } = require('@elifesciences/xpub-controller')
+const { User } = require('@elifesciences/xpub-model')
 
-async function removeSupportingFiles(_, id, user) {
-  const files = new SupportingFiles(S3Storage, id, user)
+async function removeSupportingFiles(_, { id }, { user }) {
+  const userUuid = await User.getUuidForProfile(user)
+  const files = new SupportingFiles(S3Storage, id, userUuid)
   await files.removeAll()
 }
 


### PR DESCRIPTION
#### Background

Fixes a bug causing a graphql error when deleting submissions from the dashboard and supporting files from the wizard.

#### Any relevant tickets

Looks to fix bugs introduced with the merge of #1203

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.
**Remember** run `npm run test:browser` locally on this branch as its been removed from the pipeline.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

Patch fix to get develop branch working again. The new `xpub-controller` files need to have tests written against them in the future.

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
