### PR TITLE
1265 support heading

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
@@ -37,7 +37,7 @@ const StyledDropzone = styled(({ setRef, ...rest }) => (
   border-style: none;
   width: auto;
   height: auto;
-  margin-bottom: ${th('space.2')};
+  margin-bottom: ${th('space.3')};
   ${props =>
     props.children.length &&
     css`

--- a/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
@@ -24,6 +24,13 @@ margin-top: ${th('space.1')};
 font-size: ${th('fontSizeBaseSmall')};
 `
 
+const SectionHeading = styled.span`
+  color: ${th('colorTextSecondary')};
+  display: inline-block;
+  margin-bottom: ${th('space.3')};
+  font-size: ${th('fontSizeBaseSmall')};
+`
+
 const StyledDropzone = styled(({ setRef, ...rest }) => (
   <Dropzone ref={setRef} {...rest} />
 ))`
@@ -79,6 +86,7 @@ const UploadControl = styled(Box).attrs({
 })`
   display: none;
   text-align: right;
+  font-size: ${th('fontSizeBaseSmall')};
   &:first-child {
     text-align: left;
   }
@@ -175,7 +183,9 @@ class SupportingUpload extends React.Component {
     )
     return (
       <React.Fragment>
-        {successfullyUploadedFiles.length > 0 && <p>Supporting Files:</p>}
+        {successfullyUploadedFiles.length > 0 && (
+          <SectionHeading>Supporting files:</SectionHeading>
+        )}
         <StyledDropzone
           data-test-id="supportingFilesUpload"
           maxSize={config.fileUpload.maxSizeMB * 1e6}


### PR DESCRIPTION
#### Background

Reduces the font size of the supporting files heading, upload link / text and remove link to 14px from 16px and makes spacing consistent.

#### Any relevant tickets

closes #1265

#### How has this been tested?

Have ran browser test locally. This is an aesthetics change so no extra tests required.

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [x] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
