### PR TITLE
Enable browser tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,14 +71,12 @@ elifePipeline {
         }
 
         stage 'Browser Tests', {
-            withCommitStatus({
-                sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.yml -f docker-compose.ci.yml run -p 10081:10081 --rm --name elife-xpub_app_test_browser app bash -c 'socat -d tcp-listen:10081,reuseaddr,fork tcp:localhost:10080 & npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails'"
-            }, 'test:browser', commit)
-
             try {
                 sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml up -d postgres"
                 sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm --name elife-xpub_wait_postgres app bash -c './scripts/wait-for-it.sh postgres:5432'"
-                parallel actions
+                withCommitStatus({
+                    sh "IMAGE_TAG=${commit} NODE_ENV=production NODE_CONFIG_ENV=test PGDATABASE=test_browser docker-compose -f docker-compose.yml -f docker-compose.ci.yml run -p 10081:10081 --rm --name elife-xpub_app_test_browser app bash -c 'socat -d tcp-listen:10081,reuseaddr,fork tcp:localhost:10080 & npm run test:browser -- --screenshots /tmp/screenshots --screenshots-on-fails'"
+                }, 'test:browser', commit)
             } finally {
                 sh "IMAGE_TAG=${commit} docker-compose -f docker-compose.yml -f docker-compose.ci.yml down -v"
             }


### PR DESCRIPTION
#### Background

Runs browser tests within it's own stage in Jenkins. This stops it from being run in parallel alongside linting and unit tests, which allows the app server to start up more quickly for the browser tests, which in turn stops them from hanging.

These changes have been [cherry-picked](https://git-scm.com/docs/git-cherry-pick) from #1251 

#### Any relevant tickets

Related to #1228 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.
**Remember** run `npm run test:browser` locally on this branch as its been removed from the pipeline.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
