### PR TITLE
1262 Update/fix article types

### DIFF
--- a/server/meca/file-generators/article.helpers.js
+++ b/server/meca/file-generators/article.helpers.js
@@ -56,9 +56,9 @@ const contribStructure = {
 const articleTypeMap = {
   'research-article': 5,
   'short-report': 13,
-  'tools-resources': 19,
+  'tools-resources': 18,
   'scientific-correspondence': 20,
-  feature: 23,
+  feature: 24,
 }
 
 const journalMeta = {


### PR DESCRIPTION
#### Background

Allows eJP to import the correct article type.

#### Any relevant tickets

Closes 1262

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Tested locally for a features article type and got:
```      <article-id pub-id-type="manuscript">987a81b3-be8c-4f54-9b0f-de22ad399743</article-id>
      <article-categories>
        <subj-group subj-group-type="article_type">
          <subject>24</subject>```