### PR TITLE
1010 reviewer suggestion

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.js
@@ -275,29 +275,31 @@ class EditorsPage extends React.Component {
 
           {values.suggestedReviewers.map((_, index) => (
             // eslint-disable-next-line react/no-array-index-key
-            <Box key={index} mb={2}>
-              <TwoColumnLayout bottomSpacing={false}>
-                <ValidatedField
-                  label={
-                    index < limits.suggestedReviewers.min
-                      ? `Reviewer ${index + 1} name`
-                      : `Reviewer ${index + 1} name (optional)`
-                  }
-                  name={`suggestedReviewers.${index}.name`}
-                  onChange={this.handleSuggestedReviewersChanged}
-                />
-                <ValidatedField
-                  label={
-                    index < limits.suggestedReviewers.min
-                      ? `Reviewer ${index + 1} email`
-                      : `Reviewer ${index + 1} email (optional)`
-                  }
-                  name={`suggestedReviewers.${index}.email`}
-                  onChange={this.handleSuggestedReviewersChanged}
-                  type="email"
-                />
-              </TwoColumnLayout>
-            </Box>
+            <div data-test-id="suggestedReviewerInputGroup" key={index}>
+              <Box mb={2}>
+                <TwoColumnLayout bottomSpacing={false}>
+                  <ValidatedField
+                    label={
+                      index < limits.suggestedReviewers.min
+                        ? `Reviewer ${index + 1} name`
+                        : `Reviewer ${index + 1} name (optional)`
+                    }
+                    name={`suggestedReviewers.${index}.name`}
+                    onChange={this.handleSuggestedReviewersChanged}
+                  />
+                  <ValidatedField
+                    label={
+                      index < limits.suggestedReviewers.min
+                        ? `Reviewer ${index + 1} email`
+                        : `Reviewer ${index + 1} email (optional)`
+                    }
+                    name={`suggestedReviewers.${index}.email`}
+                    onChange={this.handleSuggestedReviewersChanged}
+                    type="email"
+                  />
+                </TwoColumnLayout>
+              </Box>
+            </div>
           ))}
 
           <OptionalExclude

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.js
@@ -102,7 +102,7 @@ class EditorsPage extends React.Component {
       if (reviewers) {
         // first count the blanks at the end
         let numBlanks = 0
-        for (let index = reviewers.length - 1; index > 0; index -= 1) {
+        for (let index = reviewers.length - 1; index >= 0; index -= 1) {
           const item = reviewers[index]
           if (itemIsBlank(item)) {
             numBlanks += 1

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.js
@@ -150,7 +150,7 @@ class EditorsPage extends React.Component {
               maxSelection={limits.suggestedSeniorEditors.max}
               minSelection={limits.suggestedSeniorEditors.min}
               modalName="suggestedSeniorEditors"
-              modalTitle="Suggest senior editors"
+              modalTitle="Suggest Senior Editors"
               onRequestRemove={person =>
                 this.removeSelection('suggestedSeniorEditors', person)
               }
@@ -180,7 +180,7 @@ class EditorsPage extends React.Component {
               maxSelection={limits.opposedSeniorEditors.max}
               minSelection={limits.opposedSeniorEditors.min}
               modalName="opposedSeniorEditors"
-              modalTitle="Exclude senior editors"
+              modalTitle="Exclude Senior Editors"
               onRequestRemove={person =>
                 this.removeSelection('opposedSeniorEditors', person)
               }
@@ -213,7 +213,7 @@ class EditorsPage extends React.Component {
               maxSelection={limits.suggestedReviewingEditors.max}
               minSelection={limits.suggestedReviewingEditors.min}
               modalName="suggestedReviewingEditors"
-              modalTitle="Suggest reviewing editors"
+              modalTitle="Suggest Reviewing Editors"
               onRequestRemove={person =>
                 this.removeSelection('suggestedReviewingEditors', person)
               }
@@ -245,7 +245,7 @@ class EditorsPage extends React.Component {
               maxSelection={limits.opposedReviewingEditors.max}
               minSelection={limits.opposedReviewingEditors.min}
               modalName="opposedReviewingEditors"
-              modalTitle="Exclude reviewing editors"
+              modalTitle="Exclude Reviewing Editors"
               onRequestRemove={person =>
                 this.removeSelection('opposedReviewingEditors', person)
               }
@@ -275,31 +275,29 @@ class EditorsPage extends React.Component {
 
           {values.suggestedReviewers.map((_, index) => (
             // eslint-disable-next-line react/no-array-index-key
-            <div data-test-id="suggestedReviewerInputGroup" key={index}>
-              <Box mb={2}>
-                <TwoColumnLayout bottomSpacing={false}>
-                  <ValidatedField
-                    label={
-                      index < limits.suggestedReviewers.min
-                        ? `Reviewer ${index + 1} name`
-                        : `Reviewer ${index + 1} name (optional)`
-                    }
-                    name={`suggestedReviewers.${index}.name`}
-                    onChange={this.handleSuggestedReviewersChanged}
-                  />
-                  <ValidatedField
-                    label={
-                      index < limits.suggestedReviewers.min
-                        ? `Reviewer ${index + 1} email`
-                        : `Reviewer ${index + 1} email (optional)`
-                    }
-                    name={`suggestedReviewers.${index}.email`}
-                    onChange={this.handleSuggestedReviewersChanged}
-                    type="email"
-                  />
-                </TwoColumnLayout>
-              </Box>
-            </div>
+            <Box data-test-id="suggestedReviewerInputGroup" key={index} mb={2}>
+              <TwoColumnLayout bottomSpacing={false}>
+                <ValidatedField
+                  label={
+                    index < limits.suggestedReviewers.min
+                      ? `Reviewer ${index + 1} name`
+                      : `Reviewer ${index + 1} name (optional)`
+                  }
+                  name={`suggestedReviewers.${index}.name`}
+                  onChange={this.handleSuggestedReviewersChanged}
+                />
+                <ValidatedField
+                  label={
+                    index < limits.suggestedReviewers.min
+                      ? `Reviewer ${index + 1} email`
+                      : `Reviewer ${index + 1} email (optional)`
+                  }
+                  name={`suggestedReviewers.${index}.email`}
+                  onChange={this.handleSuggestedReviewersChanged}
+                  type="email"
+                />
+              </TwoColumnLayout>
+            </Box>
           ))}
 
           <OptionalExclude

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.md
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.md
@@ -33,11 +33,7 @@ const data = {
   ],
   suggestedReviewingEditors: [],
   opposedReviewingEditors: [],
-  suggestedReviewers: [
-    { name: '', email: '' },
-    { name: '', email: '' },
-    { name: '', email: '' },
-  ],
+  suggestedReviewers: [{ name: '', email: '' }],
   opposedReviewers: [],
   opposedReviewersReason: '',
   noConflictOfInterest: false,

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
@@ -68,11 +68,10 @@ describe('EditorsPage component', () => {
 
   it('Adds a new suggested reviewer row when details are entered into the last current row', () => {
     const wrapper = makeWrapper()
-    expect(
-      wrapper.find('[data-test-id="suggestedReviewerInputGroup"]'),
-    ).toHaveLength(1)
-    wrapper
-      .find('[data-test-id="suggestedReviewerInputGroup"]')
+    const suggestedReviewerInputs = () =>
+      wrapper.find('[data-test-id="suggestedReviewerInputGroup"]')
+    expect(suggestedReviewerInputs()).toHaveLength(1)
+    suggestedReviewerInputs()
       .at(0)
       .find('input')
       .at(0)
@@ -80,8 +79,38 @@ describe('EditorsPage component', () => {
         target: { name: 'suggestedReviewers.0.name', value: 'name' },
       })
     wrapper.update()
-    expect(
-      wrapper.find('[data-test-id="suggestedReviewerInputGroup"]'),
-    ).toHaveLength(2)
+    expect(suggestedReviewerInputs()).toHaveLength(2)
+  })
+  it('Removes trailing suggested reviewer rows when cleared down', () => {
+    const wrapper = makeWrapper()
+    const suggestedReviewerInputs = () =>
+      wrapper.find('[data-test-id="suggestedReviewerInputGroup"]')
+
+    const enterSuggestedReviewerDetails = (index, value) => {
+      suggestedReviewerInputs()
+        .at(index)
+        .find('input')
+        .at(0)
+        .simulate('change', {
+          target: { name: `suggestedReviewers.${index}.name`, value },
+        })
+      wrapper.update()
+    }
+
+    expect(suggestedReviewerInputs()).toHaveLength(1)
+
+    for (let lineNumber = 0; lineNumber < 3; lineNumber += 1) {
+      enterSuggestedReviewerDetails(lineNumber, `name ${lineNumber}`)
+    }
+
+    expect(suggestedReviewerInputs()).toHaveLength(4)
+    // remove not trailing reviewer details
+    enterSuggestedReviewerDetails(1, '')
+    enterSuggestedReviewerDetails(0, '')
+    expect(suggestedReviewerInputs()).toHaveLength(4)
+
+    // remove trailing reviewer detail
+    enterSuggestedReviewerDetails(2, '')
+    expect(suggestedReviewerInputs()).toHaveLength(1)
   })
 })

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
@@ -69,7 +69,9 @@ describe('EditorsPage component', () => {
   it('Adds a new suggested reviewer row when details are entered into the last current row', () => {
     const wrapper = makeWrapper()
     const suggestedReviewerInputs = () =>
-      wrapper.find('[data-test-id="suggestedReviewerInputGroup"]')
+      wrapper.find(
+        '[data-test-id="suggestedReviewerInputGroup"] > TwoColumnLayout',
+      )
     expect(suggestedReviewerInputs()).toHaveLength(1)
     suggestedReviewerInputs()
       .at(0)
@@ -81,10 +83,13 @@ describe('EditorsPage component', () => {
     wrapper.update()
     expect(suggestedReviewerInputs()).toHaveLength(2)
   })
+
   it('Removes trailing suggested reviewer rows when cleared down', () => {
     const wrapper = makeWrapper()
     const suggestedReviewerInputs = () =>
-      wrapper.find('[data-test-id="suggestedReviewerInputGroup"]')
+      wrapper.find(
+        '[data-test-id="suggestedReviewerInputGroup"] > TwoColumnLayout',
+      )
 
     const enterSuggestedReviewerDetails = (index, value) => {
       suggestedReviewerInputs()

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
@@ -23,11 +23,7 @@ const formValues = {
   suggestedReviewingEditors: [],
   opposedReviewingEditors: [],
   opposedReviewingEditorsReason: '',
-  suggestedReviewers: [
-    { name: '', email: '' },
-    { name: '', email: '' },
-    { name: '', email: '' },
-  ],
+  suggestedReviewers: [{ name: '', email: '' }],
   opposedReviewers: [],
   opposedReviewersReason: '',
 }

--- a/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/EditorsPage.test.js
@@ -65,4 +65,23 @@ describe('EditorsPage component', () => {
     wrapper.update()
     expect(wrapper.find('CalloutBox')).toHaveLength(1)
   })
+
+  it('Adds a new suggested reviewer row when details are entered into the last current row', () => {
+    const wrapper = makeWrapper()
+    expect(
+      wrapper.find('[data-test-id="suggestedReviewerInputGroup"]'),
+    ).toHaveLength(1)
+    wrapper
+      .find('[data-test-id="suggestedReviewerInputGroup"]')
+      .at(0)
+      .find('input')
+      .at(0)
+      .simulate('change', {
+        target: { name: 'suggestedReviewers.0.name', value: 'name' },
+      })
+    wrapper.update()
+    expect(
+      wrapper.find('[data-test-id="suggestedReviewerInputGroup"]'),
+    ).toHaveLength(2)
+  })
 })

--- a/app/components/pages/SubmissionWizard/steps/Editors/SuggestedReviewersValidator.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/SuggestedReviewersValidator.js
@@ -1,7 +1,7 @@
 import * as yup from 'yup'
 import { cloneDeep, countBy, findIndex } from 'lodash'
 
-const MIN_REVIEWERS = 3
+const MIN_REVIEWERS = 0
 const MAX_REVIEWERS = 6
 
 export const suggestedReviewersLimits = {

--- a/server/xpub-model/entities/manuscript/index.js
+++ b/server/xpub-model/entities/manuscript/index.js
@@ -275,11 +275,7 @@ class Manuscript extends BaseModel {
     // not every time an object is instantiated
     this.addTeam({
       role: 'suggestedReviewer',
-      teamMembers: [
-        { meta: { name: '', email: '' } },
-        { meta: { name: '', email: '' } },
-        { meta: { name: '', email: '' } },
-      ],
+      teamMembers: [{ meta: { name: '', email: '' } }],
     })
   }
 


### PR DESCRIPTION
#### Background

- Removes the requirement to have three suggested reviewers making all optional (but maintaining the limit of six)

- Reduces the initial number of suggested reviewer inputs displayed from three to one

- Extends the EditorPage unit test to test the functionality of adding new inputs when the user fills in blank suggestedReviewer rows and remove trailing empty detail rows.

- Corrects some typos in the props passed to the People picker modal components.

#### Any relevant tickets

closes #1010
closes #1024

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
