### PR TITLE
1164 mimetype store

### DIFF
--- a/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.js
+++ b/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.js
@@ -44,13 +44,14 @@ async function uploadManuscript(_, { file, id, fileSize }, { user }) {
   const userUuid = await User.getUuidForProfile(user)
   const manuscript = await Manuscript.find(id, userUuid)
 
-  const { stream, filename, mimetype } = await file
+  const { stream, filename, mimetype: mimeType } = await file
   logger.info(`Manuscript Upload Size: ${filename}, ${fileSize}`)
   const fileEntity = await new File({
     manuscriptId: manuscript.id,
     url: `manuscripts/${id}`,
     filename,
     type: 'MANUSCRIPT_SOURCE',
+    mimeType,
   }).save()
 
   const pubsub = await pubsubManager.getPubsub()
@@ -105,7 +106,7 @@ async function uploadManuscript(_, { file, id, fileSize }, { user }) {
       config,
       fileContents,
       filename,
-      mimetype,
+      mimeType,
     )
   } catch (error) {
     let errorMessage = ''

--- a/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.test.js
+++ b/server/xpub-server/entities/manuscript/resolvers/uploadManuscript.test.js
@@ -83,6 +83,9 @@ describe('Manuscripts', () => {
       const file = await loadedManuscript.getSource()
       const pdfBinary = await S3Storage.getContent(file)
       expect(pdfBinary.toString().substr(0, 6)).toEqual('%PDF-1')
+      expect(loadedManuscript.files[0].type).toEqual('MANUSCRIPT_SOURCE')
+      expect(loadedManuscript.files[0].filename).toEqual(fileUpload.filename)
+      expect(loadedManuscript.files[0].mimeType).toEqual(fileUpload.mimetype)
     })
 
     it('fails if S3 upload fails', async () => {

--- a/server/xpub-server/entities/manuscript/resolvers/uploadSupportingFile.js
+++ b/server/xpub-server/entities/manuscript/resolvers/uploadSupportingFile.js
@@ -6,12 +6,13 @@ async function uploadSupportingFile(_, { file, id }, { user }) {
   const userUuid = await User.getUuidForProfile(user)
   const manuscript = await Manuscript.find(id, userUuid)
 
-  const { stream, filename } = await file
+  const { stream, filename, mimetype: mimeType } = await file
   const fileEntity = await new File({
     manuscriptId: manuscript.id,
     url: `supporting/${id}`,
     filename,
     type: 'SUPPORTING_FILE',
+    mimeType,
   }).save()
 
   const fileContents = await new Promise((resolve, reject) => {

--- a/server/xpub-server/entities/manuscript/resolvers/uploadSupportingFile.test.js
+++ b/server/xpub-server/entities/manuscript/resolvers/uploadSupportingFile.test.js
@@ -50,5 +50,6 @@ describe('uploadSupportingFile', () => {
     expect(manuscript.files).toHaveLength(1)
     expect(manuscript.files[0].type).toEqual('SUPPORTING_FILE')
     expect(manuscript.files[0].filename).toEqual(supportingFile.filename)
+    expect(manuscript.files[0].mimeType).toEqual(supportingFile.mimetype)
   })
 })


### PR DESCRIPTION
#### Background

Stores the mimetype on the file object in the database and uses it in the MECA package build.

#### Any relevant tickets

Closes #1164 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Tested locally ....

- [x] Unit / Integration tests - modified
- [ ] Browser tests - out of scope
- [ ] End2end tests - out of scope
