### PR TITLE
1140 Fix/ exclude only 1 senior editor

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Editors/schema.js
+++ b/app/components/pages/SubmissionWizard/steps/Editors/schema.js
@@ -7,7 +7,7 @@ import { suggestedReviewersLimits } from './SuggestedReviewersValidator'
 
 const limits = {
   suggestedSeniorEditors: { min: 2, max: 6 },
-  opposedSeniorEditors: { min: 0, max: 2 },
+  opposedSeniorEditors: { min: 0, max: 1 },
   suggestedReviewingEditors: { min: 2, max: 6 },
   opposedReviewingEditors: { min: 0, max: 2 },
   suggestedReviewers: {


### PR DESCRIPTION
#### Background
https://github.com/elifesciences/elife-xpub/issues/1140

What does this PR do?
Changes the max number of `senior editors` to be excluded.

#### Any relevant tickets
Closes #1140 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [x] Browser tests

#### UI Changes

- [ ] Has been reviewed against Designs