### PR TITLE
1196 - Supporting files max upload validation message

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
@@ -259,12 +259,13 @@ class SupportingUpload extends React.Component {
                   </UploadControl>
                 )}
               </Flex>
-              {successfullyUploadedFiles.length > 9 && (
-                <ValidationText>
-                  Maximum {maxSupportingFiles} supporting files
-                </ValidationText>
-              )}
             </React.Fragment>
+          )}
+        {hasManuscript &&
+          successfullyUploadedFiles.length > 9 && (
+            <ValidationText>
+              Maximum {maxSupportingFiles} supporting files
+            </ValidationText>
           )}
       </React.Fragment>
     )


### PR DESCRIPTION

#### Background

When uploading enough files to bring the total supporting files to 10, the validation message advising that 10 is the maximum should be displayed while the uploads are in progress and not after the success of the action.

#### Any relevant tickets

closes #1196

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
