### PR TITLE
1104 responsive dashboard

### DIFF
--- a/app/components/pages/Dashboard/index.js
+++ b/app/components/pages/Dashboard/index.js
@@ -21,7 +21,7 @@ const MobileOnlyContainer = styled(Box)`
 
 const DashboardPage = ({ history }) => (
   <React.Fragment>
-    <Box mx={[0, 0, '16.666%', '16.666%']}>
+    <Box mx={[0, 0, 0, '16.666%']}>
       <DesktopSubmitContainer mb={1} mt={3}>
         <NewSubmissionButton
           dataTestId="desktop-new-submission"

--- a/app/components/pages/Dashboard/index.js
+++ b/app/components/pages/Dashboard/index.js
@@ -11,17 +11,17 @@ import NewSubmissionButton from './NewSubmissionButton'
 const DesktopSubmitContainer = styled(Box)`
   text-align: right;
   display: none;
-  ${media.mobileUp`display: block;`};
+  ${media.tabletPortraitUp`display: block;`};
 `
 
 const MobileOnlyContainer = styled(Box)`
   display: block;
-  ${media.mobileUp`display: none;`};
+  ${media.tabletPortraitUp`display: none;`};
 `
 
 const DashboardPage = ({ history }) => (
   <React.Fragment>
-    <Box mx={[0, 0, 0, '16.666%']}>
+    <Box mx={[0, 0, 0, '16.666%']} pb={[6, 6, 0, 0]}>
       <DesktopSubmitContainer mb={1} mt={3}>
         <NewSubmissionButton
           dataTestId="desktop-new-submission"
@@ -42,7 +42,7 @@ const DashboardPage = ({ history }) => (
       />
     </Box>
     <MobileOnlyContainer>
-      <StickyFooter>
+      <StickyFooter pb={[18, 18, 5, 5]}>
         <NewSubmissionButton
           dataTestId="mobile-new-submission"
           history={history}

--- a/app/components/ui/atoms/StickyFooter.js
+++ b/app/components/ui/atoms/StickyFooter.js
@@ -13,9 +13,14 @@ const Root = styled.div`
   background-color: ${th('colorBackground')};
 `
 
-const StickyFooter = ({ children, ...props }) => (
+const StickyFooter = ({
+  children,
+  pb = [18, 5, 5, 5],
+  pt = [18, 3, 3, 3],
+  ...props
+}) => (
   <Root {...props}>
-    <Centerer pb={[18, 5, 5, 5]} pt={[18, 3, 3, 3]}>
+    <Centerer pb={pb} pt={pt}>
       {children}
     </Centerer>
   </Root>

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -68,8 +68,8 @@ const TitleBox = styled(Box)`
   font-family: ${th('fontHeading')};
   font-weight: 400;
   text-align: left;
-  flex-grow: 1;
   ${media.tabletPortraitUp`
+    flex-grow: 1;
     margin-bottom: 0;
     margin-right: ${th('space.3')};
   `};
@@ -100,7 +100,11 @@ const TrashIcon = props => (
 
 const StyledRemoveIcon = styled(TrashIcon)`
   margin-left: 24px;
+  display: none;
   fill: ${th('colorTextSecondary')};
+  ${media.tabletPortraitUp`
+    display:inline-block;
+  `};
 `
 
 const ButtonContainer = styled(Box)`
@@ -119,9 +123,12 @@ const DashboardLinkFake = styled.div`
   width: 95%;
 `
 
-const ItemContent = styled(Flex)`
+const ItemContent = styled(Box)`
+  ${media.tabletPortraitUp`
+  display: flex;
   flex-direction: row;
   justify-content: space-between;
+`};
 `
 
 const DashboardListItem = ({ manuscript }) => {

--- a/app/components/ui/molecules/DashboardListItem.js
+++ b/app/components/ui/molecules/DashboardListItem.js
@@ -77,11 +77,11 @@ const TitleBox = styled(Box)`
 const DateBox = styled(Flex)`
   color: ${th('colorTextSecondary')}
   justify-content: space-between;
-
   ${media.tabletPortraitUp`
     flex-direction: column;
     text-align: right;
     flex: 0 0 120px;
+    justify-content: flex-start;
   `};
 `
 const AbsoluteDate = styled.time`


### PR DESCRIPTION
#### Background

The addition of a delete icon to the dashboard list items has caused the responsive styling to break at mobile / tablet screen sizes. This fix corrects this list item styling and makes the 'New Submission' button display in the sticky footer bar at tablet view as well as mobile.

#### Any relevant tickets

closes #1104 

#### How has this been tested?
Styling changes so shouldn't need additional tests.

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
