### PR TITLE
Fix article_type to match new eJP Test update

### DIFF
--- a/server/meca/file-generators/article.helpers.js
+++ b/server/meca/file-generators/article.helpers.js
@@ -58,7 +58,7 @@ const articleTypeMap = {
   'short-report': 13,
   'tools-resources': 18,
   'scientific-correspondence': 20,
-  feature: 24,
+  feature: 23,
 }
 
 const journalMeta = {


### PR DESCRIPTION
Clara has updated to eJP Test site to match the live site. We now need to modify out exporter accordingly.

```
Clara [3 days ago]
List of current EJP article type numbers (ascending order):
   Obsolete[-1||D]
   Research Article[1||FV]
   Editorial[2||S]
   Feature: Interview[3||D]
   Point of View[4||D]
   Initial Submission: Research Article[5||SN]
   Feature: Book Review[6||D]
   Feature: Obituary[7||D]
   Feature Contribution[8||S]
   Insight[9||S]
   Feature Article[10||S]
   Correction[11||S]
   Retraction[12||S]
   Initial Submission: Short Report[13||SN]
   Short Report[14||FV]
   Research Advance[15||A]
   Registered Report[16||D]
   Replication Study[17||A]
   Initial Submission: Tools and Resources[18||SN]
   Tools and Resources[19||FV]
   Initial Submission: Scientific Correspondence[20||SN]
   Scientific Correspondence[21||FV]
   Expression of Concern[22||S]
   Initial Submission: Feature Article[23||SN]
   Initial Submission: Research Communication[24||SN]
   Research Communication[25||FV]
   Blank[1001||D]
```