### PR TITLE
1060 - Dashboard manuscript order

### DIFF
--- a/server/xpub-model/entities/manuscript/index.js
+++ b/server/xpub-model/entities/manuscript/index.js
@@ -137,9 +137,11 @@ class Manuscript extends BaseModel {
   }
 
   static async all(user) {
-    const manuscripts = await this.query().where({
-      'manuscript.created_by': user,
-    })
+    const manuscripts = await this.query()
+      .where({
+        'manuscript.created_by': user,
+      })
+      .orderBy('created', 'desc')
 
     await Promise.all(
       manuscripts.map(manuscript => manuscript.$loadRelated('[teams, files]')),


### PR DESCRIPTION
#### Background

Previously the manuscripts returned and displayed on the dashboard were shown in descending order of created date, showing the most recently created  submission a the top of the list. This ordering was accidentally removed during the implementation of the ORM. This PR re-adds the ordering and adds a unit test to ensure manuscripts are returned in the correct order.

#### Any relevant tickets

Closes #1060

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
