### PR TITLE
1260 - People Picker list ordered by Surname

### DIFF
--- a/app/components/ui/PeoplePicker/PeoplePickerLogic.js
+++ b/app/components/ui/PeoplePicker/PeoplePickerLogic.js
@@ -66,9 +66,7 @@ class PeoplePickerLogic extends React.Component {
 
   render() {
     const { people, ...otherProps } = this.props
-    let extendedPeople = [...people].sort((a, b) =>
-      a.name.localeCompare(b.name),
-    )
+    let extendedPeople = [...people]
 
     extendedPeople = extendedPeople.map(person => ({
       ...person,
@@ -76,9 +74,11 @@ class PeoplePickerLogic extends React.Component {
         ' ',
       )} ${person.expertises.join(' ')} ${person.aff ? person.aff : ''}`,
     }))
+
     const searchOptions = extendedPeople.map(person => ({
       value: person.name,
     }))
+
     return this.props.children({
       ...otherProps,
       people: this.filterPeople(

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756332237524035
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756332237524035
@@ -1,0 +1,20 @@
+GET /profiles/ewwboc7m
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:42:02 GMT
+content-type: application/vnd.elife.profile+json;version=1
+content-length: 159
+connection: close
+vary: Accept, Authorization
+cache-control: max-age=300, public, stale-if-error=86400,stale-while-revalidate=300
+etag: "744e02fd7e21d5d5d36b9669da605cee"
+accept-ranges: none
+x-consumer-groups-filtered: user
+access-control-allow-origin: *
+x-kong-upstream-latency: 20
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id": "ewwboc7m", "name": {"preferred": "Tamlyn Rhodes", "index": "Rhodes, Tamlyn"}, "orcid": "0000-0002-6277-0372", "emailAddresses": [], "affiliations": []}

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756377416662907
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756377416662907
@@ -1,0 +1,24 @@
+GET /people/fd108300
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:49:34 GMT
+content-type: application/vnd.elife.person+json;version=1
+transfer-encoding: chunked
+connection: close
+cache-control: max-age=300, public, stale-if-error=86400, stale-while-revalidate=300
+vary: Accept, Authorization
+etag: "fd0c2312dad5393293c368d34a8ec52b"
+x-ua-compatible: IE=edge
+content-language: en
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-consumer-groups-filtered: user
+x-consumer-groups-remote-addr: 34.226.197.243
+access-control-allow-origin: *
+x-kong-upstream-latency: 129
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id":"fd108300","type":{"id":"senior-editor","label":"Senior Editor"},"name":{"surname":"Cooper","givenNames":"Jonathan A","preferred":"Jonathan A Cooper","index":"Cooper, Jonathan A"},"image":{"uri":"https:\/\/iiif.elifesciences.org\/journal-cms\/person%2F2014-04%2Fjon_cooper.jpg","alt":"Jonathan A Cooper","source":{"mediaType":"image\/jpeg","uri":"https:\/\/iiif.elifesciences.org\/journal-cms\/person%2F2014-04%2Fjon_cooper.jpg\/full\/full\/0\/default.jpg","filename":"jon_cooper.jpg"},"size":{"width":214,"height":321},"focalPoint":{"x":50,"y":50}},"profile":[{"text":"Jon Cooper is a member of the Fred Hutchinson Cancer Research Center in Seattle, where he is also a Senior Vice-President and Director of the Division of Basic Sciences. He holds an Affiliate Professor appointment in the Biochemistry department at the University of Washington. After undergraduate studies at the University of Cambridge and post-graduate research at the University of Warwick, he performed postdoctoral research with Bernard Moss at the NIH and with Tony Hunter at the Salk Institute. With Tony, he found that oncogenic retroviruses (Rous sarcoma virus and others) and growth factors (EGF and PDGF) stimulate the tyrosine phosphorylation of overlapping subsets of cell proteins, which were candidates to regulate cell proliferation and metabolism. He joined Fred Hutch in 1985 to continue the work he started at the Salk, investigating the mechanisms by which protein kinases regulate cell proliferation and transformation. His laboratory played important roles in establishing how Src is regulated, how activated growth factor receptors recruit signaling proteins, and Ras-Raf-MAPK signaling. In 1995, postdoc Brian Howell knocked out the gene for a Src substrate and observed a distinctive brain development phenotype. Efforts by several laboratories rapidly established a signaling pathway that regulates neuron migrations during brain development. Further studies on this pathway revealed the importance of ubiquitination and degradation for terminating signaling, and led in recent years to detailed investigation of the roles of Cullin-RING ligases in regulating signal transduction events in vivo and in cultured cells.","type":"paragraph"}],"research":{"focuses":["signaling pathways","cell migration","phosphorylation","cell transformation"],"expertises":[{"id":"cell-biology","name":"Cell Biology"},{"id":"neuroscience","name":"Neuroscience"}]},"affiliations":[{"name":["Fred Hutchinson Cancer Research Center"],"address":{"formatted":["United States"],"components":{"country":"United States"}}}],"competingInterests":"Jon Cooper receives research grants from the NIH and he serves on the editorial board of Molecular and Cellular Biology."}

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756377419256990
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756377419256990
@@ -1,0 +1,24 @@
+GET /people/3e30eb6b
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:49:34 GMT
+content-type: application/vnd.elife.person+json;version=1
+transfer-encoding: chunked
+connection: close
+cache-control: max-age=300, public, stale-if-error=86400, stale-while-revalidate=300
+vary: Accept, Authorization
+etag: "a2c918fb1dd9103f1b9eda61c2d6e13f"
+x-ua-compatible: IE=edge
+content-language: en
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-consumer-groups-filtered: user
+x-consumer-groups-remote-addr: 34.226.197.243
+access-control-allow-origin: *
+x-kong-upstream-latency: 127
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id":"3e30eb6b","type":{"id":"senior-editor","label":"Senior Editor"},"name":{"surname":"Behrens","givenNames":"Timothy","preferred":"Timothy Behrens","index":"Behrens, Timothy"},"image":{"uri":"https:\/\/iiif.elifesciences.org\/journal-cms\/person%2F2014-04%2Ftbmug20copy202.jpg","alt":"Timothy Behrens","source":{"mediaType":"image\/jpeg","uri":"https:\/\/iiif.elifesciences.org\/journal-cms\/person%2F2014-04%2Ftbmug20copy202.jpg\/full\/full\/0\/default.jpg","filename":"tbmug20copy202.jpg"},"size":{"width":823,"height":1024},"focalPoint":{"x":50,"y":50}},"profile":[{"text":"Tim Behrens is Professor of Computational Neuroscience at Oxford University and University College London, and a Wellcome Trust Senior Research Fellow. His work investigating the neural mechanisms that control behaviour has made an impact across scales from cells to brain regions across mammalian species. He has also developed widely used approaches for measuring brain connections non-invasively that have been taken up by the Human Connectome Project, where he is a senior investigator and chair of the anatomical connectivity team.","type":"paragraph"}],"research":{"focuses":["brain imaging","fMRI","learning","cognition","behavioural neuroscience","learning and decision making","brain connectivity","computational neuroscience","neural coding"],"organisms":["macaque monkeys"],"expertises":[{"id":"neuroscience","name":"Neuroscience"}]},"affiliations":[{"name":["University of Oxford"],"address":{"formatted":["United Kingdom"],"components":{"country":"United Kingdom"}}}],"competingInterests":"Tim Behrens receives funding from the Wellcome Trust, the James S McDonnell Foundation, the National Institute of Health, and the UK Engineering and Physical Sciences Research Council. He is on the editorial board of PLOS Biology."}

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756377514920987
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756377514920987
@@ -1,0 +1,24 @@
+GET /people/62b2a06c
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:49:35 GMT
+content-type: application/vnd.elife.person+json;version=1
+transfer-encoding: chunked
+connection: close
+cache-control: max-age=300, public, stale-if-error=86400, stale-while-revalidate=300
+vary: Accept, Authorization
+etag: "4e9bdb07184882f340922a3930928df6"
+x-ua-compatible: IE=edge
+content-language: en
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-consumer-groups-filtered: user
+x-consumer-groups-remote-addr: 34.226.197.243
+access-control-allow-origin: *
+x-kong-upstream-latency: 94
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id":"62b2a06c","type":{"id":"senior-editor","label":"Senior Editor"},"name":{"surname":"Dulac","givenNames":"Catherine","preferred":"Catherine Dulac","index":"Dulac, Catherine"},"image":{"uri":"https:\/\/iiif.elifesciences.org\/journal-cms\/person%2F2012-03%2Fkegley120208elife0135a.jpg","alt":"Catherine Dulac","source":{"mediaType":"image\/jpeg","uri":"https:\/\/iiif.elifesciences.org\/journal-cms\/person%2F2012-03%2Fkegley120208elife0135a.jpg\/full\/full\/0\/default.jpg","filename":"kegley120208elife0135a.jpg"},"size":{"width":4256,"height":2832},"focalPoint":{"x":50,"y":50}},"profile":[{"text":"Catherine Dulac is a Howard Hughes Medical Institute Investigator, Higgins Professor of Molecular and Cellular Biology, and Chair of the Department of Molecular and Cellular Biology in the Faculty of Arts \u0026amp; Sciences at Harvard University. Her work explores the molecular biology of pheromone detection and signaling in mammals, and the neural mechanisms underlying age-, species-, and sex-specific behaviors. She graduated from the Ecole Normale Sup\u00e9rieure, Paris; received her PhD from the University of Paris VI at the Institute of Molecular and Cellular Embryology (Nogent-sur-Marne); and was a postdoctoral fellow at Columbia University. She is a Fellow of the American Academy of Arts and Sciences; of the American Association for the Advancement of Science; and a member of the French Academy of Sciences, Institute of France. She is a recipient of the Liliane Bettencourt Prize, the Richard Lounsbery Award, the Perl\/UNC Neuroscience Prize and the IPSEN Foundation Neuronal Plasticity prize.","type":"paragraph"}],"research":{"focuses":["cellular and molecular neuroscience","molecular and genetic basis of sex and species-specific social behavior"],"expertises":[{"id":"neuroscience","name":"Neuroscience"}]},"affiliations":[{"name":["Harvard University"],"address":{"formatted":["United States"],"components":{"country":"United States"}}}],"competingInterests":"Catherine Dulac receives funding from the Howard Hughes Medical Institute and the National Institutes of Health. She is a member of the editorial boards of Current Opinion in Neurobiology and The Journal of Comparative Neurology. She is a member of selection committees for the following awards and prizes: McKnight Foundation Technical Innovation Award, Radcliffe Institute for Advanced Study Fellowship Program, The Esther A. and Joseph Klingenstein Fund, the New York Stem Cell Foundation Innovator Awards in Neuroscience, the Smith Family Awards Program for Excellence in Biomedical Research and the Searle Scholars. She also serves on the Scientific Advisory Boards for the following organizations: Senomyx, Allen Institute, Friedrich Miescher Institute for Biomedical Research, and the Max Planck Institute for Medical Research. She is a member of the Visiting Committee for MIT\u2019s Department of Brain and Cognitive Sciences, and she serves as a reviewer for the National Institutes of Health Somatosensory and Chemosensory Study Section."}

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756380583187149
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756380583187149
@@ -1,0 +1,24 @@
+GET /people/0da30b85
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:50:05 GMT
+content-type: application/vnd.elife.person+json;version=1
+transfer-encoding: chunked
+connection: close
+cache-control: max-age=300, public, stale-if-error=86400, stale-while-revalidate=300
+vary: Accept, Authorization
+etag: "7dcda9349fc173ad5fb10f0c3efdfe10"
+x-ua-compatible: IE=edge
+content-language: en
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-consumer-groups-filtered: user
+x-consumer-groups-remote-addr: 34.226.197.243
+access-control-allow-origin: *
+x-kong-upstream-latency: 93
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id":"0da30b85","type":{"id":"senior-editor","label":"Senior Editor"},"name":{"surname":"Dikic","givenNames":"Ivan","preferred":"Ivan Dikic","index":"Dikic, Ivan"},"image":{"uri":"https:\/\/iiif.elifesciences.org\/journal-cms\/person%2F2018-01%2Fa06w3779.jpg","alt":"","source":{"mediaType":"image\/jpeg","uri":"https:\/\/iiif.elifesciences.org\/journal-cms\/person%2F2018-01%2Fa06w3779.jpg\/full\/full\/0\/default.jpg","filename":"a06w3779.jpg"},"size":{"width":3600,"height":2400},"focalPoint":{"x":50,"y":50}},"profile":[{"text":"Ivan Dikic is a Professor and Chairman of Institute of Biochemistry II at the Medical School Goethe University and a member of the Buchmann Institute for Molecular Life Sciences in Frankfurt. He was trained as a medical doctor at Zagreb University and obtained his PhD in molecular biology with Joseph Schlessinger. His career is focused on studying intracellular signaling initially via protein tyrosine kinases where he revealed how multiple monoubiquitination controls EGFR endocytosis. His lab has pioneered a concept of Ubiquitin as a multivalent cellular signal that regulates multitude of physiological and pathophysiological processes including DNA repair, inflammation, cancer, infection and proteasomal degradation. Ivan\u2019s group also provided structural and functional evidence for a new type of Ub chains that are Met1-linked (called linear ubiquitination) in promoting the NF-kB signaling. His current interests focus on selective autophagy, which is essential for the clearance of protein aggregates, pathogens, and damaged mitochondria from the cell. He has received many awards for his work including the AACR Award for Outstanding Achievement in Cancer Research, the Award of European Association for Cancer Research, the Hans Krebs Prize, the Leibniz Award and the Ernst Jung Award in Medicine. He is a Member of the German Academy for Sciences Leopoldina, Academia Europaea, Croatian Academy of Medical Sciences and the European Molecular Biology Organization.","type":"paragraph"}],"research":{"focuses":["ubiquitination","autophagy","endocytosis","inflammation","cancer biology"],"expertises":[{"id":"biochemistry-chemical-biology","name":"Biochemistry and Chemical Biology"},{"id":"cell-biology","name":"Cell Biology"}]},"affiliations":[{"name":["Goethe University Frankfurt"],"address":{"formatted":["Germany"],"components":{"country":"Germany"}}}],"competingInterests":"Ivan Dikic receives funding from the Deutsche Forshungsemeinschaft and European Union, and serves as a Scientific Advisory Board member of the Novo Nordisk Foundation Center of Protein Research Copenhagen, MRC Phosphorylation and Ubiquitination Unit Dundee, DKFZ-ZMBH Allianz. He is a chairman of the EMBO Publication Committee and is on the editorial boards of Cell, Molecular Cell, Developmental Cell, EMBO Journal, EMBO Reports, BMC Biology, Biochemical Journal, and Cell Death and Differentiation."}

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756381472457376
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756381472457376
@@ -1,0 +1,24 @@
+GET /people/95f6b52d
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:50:14 GMT
+content-type: application/vnd.elife.person+json;version=1
+transfer-encoding: chunked
+connection: close
+cache-control: max-age=300, public, stale-if-error=86400, stale-while-revalidate=300
+vary: Accept, Authorization
+etag: "58383e05e42cbcca7b559b4d24d38f2e"
+x-ua-compatible: IE=edge
+content-language: en
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-consumer-groups-filtered: user
+x-consumer-groups-remote-addr: 34.226.197.243
+access-control-allow-origin: *
+x-kong-upstream-latency: 98
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id":"95f6b52d","type":{"id":"reviewing-editor","label":"Reviewing Editor"},"name":{"surname":"Faraldo-Gomez","givenNames":"Jose","preferred":"Jose Faraldo-Gomez","index":"Faraldo-Gomez, Jose"},"research":{"focuses":["Computational biophysics","molecular computation","membrane proteins"],"expertises":[{"id":"biochemistry-chemical-biology","name":"Biochemistry and Chemical Biology"},{"id":"structural-biology-molecular-biophysics","name":"Structural Biology and Molecular Biophysics"}]},"affiliations":[{"name":["National Heart, Lung and Blood Institute, National Institutes of Health"],"address":{"formatted":["United States"],"components":{"country":"United States"}}}]}

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756381472613084
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756381472613084
@@ -1,0 +1,24 @@
+GET /people/de896256
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:50:14 GMT
+content-type: application/vnd.elife.person+json;version=1
+transfer-encoding: chunked
+connection: close
+cache-control: max-age=300, public, stale-if-error=86400, stale-while-revalidate=300
+vary: Accept, Authorization
+etag: "8a5de57233d07a5afeea34dc6db70610"
+x-ua-compatible: IE=edge
+content-language: en
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-consumer-groups-filtered: user
+x-consumer-groups-remote-addr: 34.226.197.243
+access-control-allow-origin: *
+x-kong-upstream-latency: 96
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id":"de896256","type":{"id":"reviewing-editor","label":"Reviewing Editor"},"name":{"surname":"Solnica-Krezel","givenNames":"Lilianna","preferred":"Lilianna Solnica-Krezel","index":"Solnica-Krezel, Lilianna"},"research":{"focuses":["gastrulation","vertebrate embryogenesis","patterning","cell movement","cell signalling","morphogenesis"],"organisms":["zebrafish"],"expertises":[{"id":"developmental-biology","name":"Developmental Biology"},{"id":"stem-cells-regenerative-medicine","name":"Stem Cells and Regenerative Medicine"}]},"affiliations":[{"name":["Washington University School of Medicine"],"address":{"formatted":["United States"],"components":{"country":"United States"}}}]}

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756381576218980
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/154756381576218980
@@ -1,0 +1,24 @@
+GET /people/bd98e2b7
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:50:15 GMT
+content-type: application/vnd.elife.person+json;version=1
+transfer-encoding: chunked
+connection: close
+cache-control: max-age=300, public, stale-if-error=86400, stale-while-revalidate=300
+vary: Accept, Authorization
+etag: "4b763541f5a8ae2bc62d877c55d19414"
+x-ua-compatible: IE=edge
+content-language: en
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-consumer-groups-filtered: user
+x-consumer-groups-remote-addr: 34.226.197.243
+access-control-allow-origin: *
+x-kong-upstream-latency: 96
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id":"bd98e2b7","type":{"id":"reviewing-editor","label":"Reviewing Editor"},"name":{"surname":"Diedrichsen","givenNames":"J\u00f6rn","preferred":"J\u00f6rn Diedrichsen","index":"Diedrichsen, J\u00f6rn"},"research":{"focuses":["motor control","fMRI"],"organisms":["human"],"expertises":[{"id":"neuroscience","name":"Neuroscience"}]},"affiliations":[{"name":["University of Western Ontario"],"address":{"formatted":["Canada"],"components":{"country":"Canada"}}}]}

--- a/test/http-mocks/success/prod--gateway.elifesciences.org-443/15475638157654040
+++ b/test/http-mocks/success/prod--gateway.elifesciences.org-443/15475638157654040
@@ -1,0 +1,24 @@
+GET /people/12658b47
+accept-encoding: gzip, deflate
+
+HTTP/1.1 200 OK
+server: nginx
+date: Tue, 15 Jan 2019 14:50:15 GMT
+content-type: application/vnd.elife.person+json;version=1
+transfer-encoding: chunked
+connection: close
+cache-control: max-age=300, public, stale-if-error=86400, stale-while-revalidate=300
+vary: Accept, Authorization
+etag: "94bc4585914359ffaad6f52808e637ec"
+x-ua-compatible: IE=edge
+content-language: en
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-consumer-groups-filtered: user
+x-consumer-groups-remote-addr: 34.226.197.243
+access-control-allow-origin: *
+x-kong-upstream-latency: 99
+x-kong-proxy-latency: 0
+via: kong/0.9.5
+
+{"id":"12658b47","type":{"id":"reviewing-editor","label":"Reviewing Editor"},"name":{"surname":"Bloodgood","givenNames":"Brenda","preferred":"Brenda Bloodgood","index":"Bloodgood, Brenda"},"research":{"focuses":["synaptic signaling","activity-dependent gene expression","animal behavior and disease states","hippocampus"],"organisms":["mouse"],"expertises":[{"id":"neuroscience","name":"Neuroscience"}]},"affiliations":[{"name":["University of California, San Diego"],"address":{"formatted":["United States"],"components":{"country":"United States"}}}]}


### PR DESCRIPTION
#### Background

The eLife api returns people ordered by surname however the app is sorting people on the client side by full name (which by design means they are ordered by first name). The people picker should also display people in order of surname so this client side sort needs to be removed.

#### Any relevant tickets

closes #1260

#### How has this been tested?

Ordering is carried out via the external api, this PR simply removes functionality. There were no existing tests for this client side sort so I haven't had to remove any unit tests.