### PR TITLE
1209 & 1049 - dashboard styling

### DIFF
--- a/app/components/pages/Dashboard/DashboardContent.js
+++ b/app/components/pages/Dashboard/DashboardContent.js
@@ -15,7 +15,7 @@ const MobileOnlySubmissionsContainer = styled(Box).attrs({ mx: -3 })`
 `
 
 const TabbedSubmissions = styled(Tabs)`
-  min-height: 300px;
+  min-height: 475px;
   margin-bottom: ${th('space.3')};
 `
 

--- a/app/components/ui/molecules/Tabs.js
+++ b/app/components/ui/molecules/Tabs.js
@@ -39,7 +39,6 @@ const Tab = styled(UnstyledTab).attrs({
   }
 
   &.disabled {
-    color: ${th('colorTextSecondary')};
     cursor: default;
   }
 `

--- a/app/components/ui/molecules/Tabs.js
+++ b/app/components/ui/molecules/Tabs.js
@@ -25,16 +25,17 @@ const Tab = styled(UnstyledTab).attrs({
   padding: ${th('space.3')};
   list-style: none;
   cursor: pointer;
-  color: ${th('colorText')};
+
   border-bottom: 4px solid transparent;
   margin-bottom: -1px;
-
+  color: ${th('colorTextSecondary')};
   &:hover {
     color: ${th('colorPrimary')};
   }
 
   &.selected {
     border-bottom-color: ${th('colorPrimary')};
+    color: ${th('colorText')};
   }
 
   &.disabled {

--- a/app/components/ui/molecules/Tabs.js
+++ b/app/components/ui/molecules/Tabs.js
@@ -25,7 +25,6 @@ const Tab = styled(UnstyledTab).attrs({
   padding: ${th('space.3')};
   list-style: none;
   cursor: pointer;
-
   border-bottom: 4px solid transparent;
   margin-bottom: -1px;
   color: ${th('colorTextSecondary')};


### PR DESCRIPTION
#### Background

Increases the `min-height` of the dashboard list so that the text forwarding the user to ejp is lower down. Change the text colour of inactive tabs to `colorTextSecondary` as shown in designs.

#### Any relevant tickets

closes #1209 
closes #1049 

#### How has this been tested?

Styling change so visually

#### UI Changes

- [ ] Has been reviewed against Designs
