### PR TITLE
fix misalignment on progress bar titles for ie11

### DIFF
--- a/client/elife-theme/src/elements/ui/Steps.js
+++ b/client/elife-theme/src/elements/ui/Steps.js
@@ -42,6 +42,9 @@ export const Steps = {
     font-size: ${th('fontSizeBaseSmall')};
     color: ${({ isCurrent }) =>
       isCurrent ? th('colorText') : th('colorFurniture')};
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+      left: -50px;
+    }
   `,
 
   Bullet: css`


### PR DESCRIPTION
#### Background
on ie11 titles on progress bar are being displayed on the right of the bullet
 
What does this PR do?
fix the misalignment

closes #1037 

