### PR TITLE
fixing touch scroll on mobile

### DIFF
--- a/app/components/ui/molecules/ModalOverlay.js
+++ b/app/components/ui/molecules/ModalOverlay.js
@@ -46,22 +46,34 @@ function cssTimeToMilliseconds(timeString) {
   }
 }
 
-const ModalOverlay = ({ children, open, theme, transparentBackground }) => (
-  <Root aria-live="assertive">
-    <CSSTransition
-      classNames="modal"
-      in={open}
-      mountOnEnter
-      timeout={cssTimeToMilliseconds(theme.transitionDuration)}
-      unmountOnExit
-    >
-      <Container transparentBackground={transparentBackground}>
-        {children}
-        <ScrollLock />
-      </Container>
-    </CSSTransition>
-  </Root>
-)
+class ModalOverlay extends React.Component {
+  constructor(props) {
+    super(props)
+    this.overlay = React.createRef()
+  }
+
+  render() {
+    const { children, open, theme, transparentBackground } = this.props
+    return (
+      <Root aria-live="assertive">
+        <CSSTransition
+          classNames="modal"
+          in={open}
+          mountOnEnter
+          timeout={cssTimeToMilliseconds(theme.transitionDuration)}
+          unmountOnExit
+        >
+          <Container transparentBackground={transparentBackground} ref={this.overlay}>
+            {children}
+            {this.overlay.current &&
+              <ScrollLock touchScrollTarget={this.overlay.current} />
+            }
+          </Container>
+        </CSSTransition>
+      </Root>
+    )
+  }
+}
 
 ModalOverlay.propTypes = {
   open: PropTypes.bool.isRequired,


### PR DESCRIPTION
#### Background

Sets the element to be scrolled when modal is open. See https://github.com/elifesciences/elife-xpub/issues/1048#issuecomment-455122639 for more background.

This was more work than initially thought. `react-scrolllock` doesn't make it easy to set the scrollable element. We've had to pass refs around to get this to work. There is already an outstanding issue against the library to address this: https://github.com/jossmac/react-scrolllock/issues/33

You can read up more on refs [here](https://reactjs.org/docs/refs-and-the-dom.html#accessing-refs)

#### Any relevant tickets

Closes #1052 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
