### PR TITLE
Remove function that is self-recursive

### DIFF
--- a/server/xpub-model/entities/file/index.js
+++ b/server/xpub-model/entities/file/index.js
@@ -19,12 +19,6 @@ class File extends BaseModel {
     }
   }
 
-  static async find(id) {
-    const file = await this.find(id)
-
-    return file
-  }
-
   static async findByManuscriptId(manuscriptId) {
     const files = await this.query().where({
       manuscript_id: manuscriptId,


### PR DESCRIPTION
Bug found when debugging using this function. Removing it means that `File.find` uses the default implementation from `BaseModel` rather than getting in an infinite loop