### PR TITLE
1348 - Add hotjar globally and store id in config

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,6 +4,7 @@ import createHistory from 'history/createBrowserHistory'
 import { withClientState } from 'apollo-link-state'
 import ReactGA from 'react-ga'
 import config from 'config'
+import { hotjar } from 'react-hotjar'
 
 import { configureStore, Root } from 'pubsweet-client'
 
@@ -21,6 +22,7 @@ const initializeReactGA = googleAnalyticsId => {
 }
 
 initializeReactGA(config.googleAnalytics)
+hotjar.initialize(config.hotJar.id, config.hotJar.snippetVersion)
 
 const makeApolloConfig = ({ cache, link }) => {
   const clientStateLink = withClientState({

--- a/app/components/pages/ThankYou/ThankYou.js
+++ b/app/components/pages/ThankYou/ThankYou.js
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import { Box } from '@rebass/grid'
 import PropTypes from 'prop-types'
 import { H1 } from '@pubsweet/ui'
-import { hotjar } from 'react-hotjar'
 
 import NativeLink from '../../ui/atoms/NativeLink'
 import ButtonLink from '../../ui/atoms/ButtonLink'
@@ -19,20 +18,12 @@ const BookmarkLink = styled(NativeLink)`
   clear: both;
 `
 
-const hotJarId = 443270
-const hotjarSnippetVersion = 6
-
 class ThankYou extends React.Component {
   componentDidMount() {
     window.hj('trigger', 'thank_you_page_hotjar_feedback')
   }
 
-  shouldComponentUpdate() {
-    return false
-  }
-
   render() {
-    hotjar.initialize(hotJarId, hotjarSnippetVersion)
     const { title } = this.props
     return (
       <CenteredContent mx="auto" width={[1, 1, 1, 600]}>

--- a/config/default.js
+++ b/config/default.js
@@ -131,4 +131,8 @@ module.exports = {
     applicationID: '',
   },
   schema: {}, // schema extensions for pubsweet-server
+  hotJar: {
+    isPublic: true,
+    snippetVersion: 6,
+  },
 }

--- a/config/prod.js
+++ b/config/prod.js
@@ -33,5 +33,8 @@ module.exports = {
     licenseKey: 'c53c018d69',
     applicationID: '162983119',
   },
+  hotJar: {
+    id: 443270,
+  },
   googleAnalytics: 'UA-132441389-1',
 }

--- a/config/staging.js
+++ b/config/staging.js
@@ -28,5 +28,8 @@ module.exports = {
     licenseKey: 'c7fdeadcfa',
     applicationID: '162979288',
   },
+  hotJar: {
+    id: 1131309,
+  },
   googleAnalytics: 'UA-132441389-2',
 }


### PR DESCRIPTION
#### Background

Hotjar is currently initialised in the `ThankYou.js` page so is not tracking throughout the whole app. This PR moves the initialisation into the `app.js` allowing user interactions to be tracked throughout the app. The id has now been moved to config to provide a different group of metrics for staging and prod.
 
#### Any relevant tickets
One part of  #1348

