### PR TITLE
Enabling Google Analytics debugging

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -17,7 +17,7 @@ const history = createHistory()
 const store = configureStore(history, {})
 
 const initializeReactGA = googleAnalyticsId => {
-  const debug = googleAnalyticsId === 'test' ? true : false
+  const debug = googleAnalyticsId === 'test'
   ReactGA.initialize(googleAnalyticsId, { debug })
   ReactGA.pageview('/')
 }

--- a/app/app.js
+++ b/app/app.js
@@ -16,13 +16,13 @@ import * as AuthorDetailsSchema from './components/pages/SubmissionWizard/steps/
 const history = createHistory()
 const store = configureStore(history, {})
 
-const initializeReactGA = googleAnalyticsId => {
-  const debug = googleAnalyticsId === 'test'
-  ReactGA.initialize(googleAnalyticsId, { debug })
+const initializeReactGA = ({trackingId='test', debug}) => {
+  if (trackingId === '') trackingId = 'test'
+  ReactGA.initialize(trackingId, { debug })
   ReactGA.pageview('/')
 }
 
-initializeReactGA(config.googleAnalytics.id)
+initializeReactGA(config.googleAnalytics)
 hotjar.initialize(config.hotJar.id, config.hotJar.snippetVersion)
 
 

--- a/app/app.js
+++ b/app/app.js
@@ -16,9 +16,9 @@ import * as AuthorDetailsSchema from './components/pages/SubmissionWizard/steps/
 const history = createHistory()
 const store = configureStore(history, {})
 
-const initializeReactGA = ({trackingId='test', debug}) => {
-  if (trackingId === '') trackingId = 'test'
-  ReactGA.initialize(trackingId, { debug })
+const initializeReactGA = ({trackingId='test', debug} = {}) => {
+  const id = (trackingId === '') ? 'test' : trackingId
+  ReactGA.initialize(id, { debug })
   ReactGA.pageview('/')
 }
 

--- a/app/app.js
+++ b/app/app.js
@@ -17,7 +17,8 @@ const history = createHistory()
 const store = configureStore(history, {})
 
 const initializeReactGA = googleAnalyticsId => {
-  ReactGA.initialize(googleAnalyticsId)
+  const debug = googleAnalyticsId === 'test' ? true : false
+  ReactGA.initialize(googleAnalyticsId, { debug })
   ReactGA.pageview('/')
 }
 

--- a/config/ci.js
+++ b/config/ci.js
@@ -11,4 +11,7 @@ module.exports = {
       disableUpload: true,
     },
   },
+  googleAnalytics: {
+    debug: true
+  }
 }

--- a/config/default.js
+++ b/config/default.js
@@ -132,7 +132,7 @@ module.exports = {
   },
   googleAnalytics: {
     isPublic: true,
-    id: '',
+    id: 'test',
   },
   schema: {}, // schema extensions for pubsweet-server
   hotJar: {

--- a/config/default.js
+++ b/config/default.js
@@ -132,7 +132,7 @@ module.exports = {
   },
   googleAnalytics: {
     isPublic: true,
-    id: 'test',
+    trackingId: '',
   },
   schema: {}, // schema extensions for pubsweet-server
   hotJar: {

--- a/config/development.js
+++ b/config/development.js
@@ -59,4 +59,8 @@ module.exports = {
     },
     apiKey: 'abcd1234',
   },
+
+  googleAnalytics: {
+    debug: true
+  }
 }


### PR DESCRIPTION
- Suppresses Google Analytics warnings locally and on review environments.
- Prints out debugging information on Google Analytics, including setup and events. 

This is useful for us to test out changes to Google Analytics outside of Staging and Production.

This is enabled by default, and only disabled in Staging and Production, or any environments with a GA ID configured.

The output can be pretty verbose, so I'm open to suggestions. You can view the debugging output by going to the review environment and viewing the console.