### PR TITLE
Disable google analytics debugging locally

### DIFF
--- a/config/development.js
+++ b/config/development.js
@@ -59,8 +59,5 @@ module.exports = {
     },
     apiKey: 'abcd1234',
   },
-
-  googleAnalytics: {
-    debug: true
-  }
+  
 }


### PR DESCRIPTION
The Google Analytics debug output is too verbose and it's making it hard to use the console for our own logging. This problem is compounded by hot reloading.

This change will mean that we only have Google Analytics debug output within review environments only.