### PR TITLE
Update email subject

### DIFF
--- a/server/xpub-controller/notification.js
+++ b/server/xpub-controller/notification.js
@@ -64,7 +64,7 @@ class Notification {
     mailer
       .send({
         to: emailList,
-        subject: 'Libero Submission System: New Submission',
+        subject: 'Your eLife submission',
         from: 'editorial@elifesciences.org',
         text,
         html,

--- a/server/xpub-server/entities/manuscript/resolvers/updateManuscript.test.js
+++ b/server/xpub-server/entities/manuscript/resolvers/updateManuscript.test.js
@@ -80,7 +80,7 @@ describe('Manuscript resolvers', () => {
       // Check the dashboard email
       expect(allEmails[0]).toMatchObject({
         to: 'mymail@mail.com',
-        subject: 'Libero Submission System: New Submission',
+        subject: 'Your eLife submission',
       })
 
       const actualManuscript = await Manuscript.find(manuscript.id, userId)


### PR DESCRIPTION
#### Background

Given the user has not been exposed to any Libero branding, it makes sense to remove it from the email subject line.

#### How has this been tested? 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [x] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
