### PR TITLE
1385 - Email dashboard link pointing to correct config option

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -16,7 +16,6 @@ module.exports = {
       '@elifesciences/xpub-client-config',
       '@pubsweet/component-send-email',
     ],
-    base_url: 'http://localhost:3000',
   },
   'pubsweet-server': {
     db: {

--- a/server/xpub-controller/notification.js
+++ b/server/xpub-controller/notification.js
@@ -47,17 +47,18 @@ class Notification {
 
     const textCompile = pug.compileFile('templates/dashboard-email-text.pug')
     const htmlCompile = pug.compileFile('templates/dashboard-email-html.pug')
+
     const firstNameList = this.people
       .map(person => person.alias.firstName)
       .join(',')
 
     const text = textCompile({
       authorName: firstNameList,
-      linkDashboard: this.config.pubsweet.base_url,
+      linkDashboard: this.config['pubsweet-server'].baseUrl,
     })
     const html = htmlCompile({
       authorName: firstNameList,
-      linkDashboard: this.config.pubsweet.base_url,
+      linkDashboard: this.config['pubsweet-server'].baseUrl,
     })
 
     let sent = false


### PR DESCRIPTION
#### Background

Previously the email sent when changing the submitters email contained a link to xpub which was always `localhost:3000` even when environment variables for `PUBSWEET_BASEURL` were set to the staging / production url in use. This fix removes a bespoke config option of `pubseet.base_url` only used for these email links and instead uses the `pubsweet-server.baseUrl` used elsewhere in the app.

#### Any relevant tickets

closes #1385

#### How has this been tested?

Local logging and email checking
