### PR TITLE
1362 - File upload statuses displaying correctly after refresh

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
@@ -152,7 +152,9 @@ class SupportingUpload extends React.Component {
       files: props.files.map((file, index) => ({
         file,
         id: index,
-        success: true,
+        success: file.status === 'STORED',
+        loading: file.status === 'CREATED' || file.status === 'UPLOADED',
+        error: file.status === 'CANCELLED',
       })),
     }
   }


### PR DESCRIPTION
#### Background

Currently the default client display for an uploaded supporting file is the upload successful state. When refreshing the app while a transaction is still in progress, it doesn't correctly represent the state in which the file data is in the db so files still in the process of being stored in S3 are showing as successful.

This PR adds in the correct initial display of the files state on, refresh however further work will be needed in a separate piece of work to reconnect to a web-socket to track the progress in real time.
 
#### Any relevant tickets

closes #1362

