### PR TITLE
Add external link to ORCiD profile and associated test

### DIFF
--- a/app/components/global/AppBar/ProfileMenu.js
+++ b/app/components/global/AppBar/ProfileMenu.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import config from 'config'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Box } from '@rebass/grid'
 import { Link } from 'react-router-dom'
 import { th } from '@pubsweet/ui-toolkit'
@@ -72,7 +72,7 @@ const MenuHeading = styled.div`
   text-overflow: ellipsis;
 `
 
-const MenuItemLink = styled(Link)`
+const menuItemLinkStyling = css`
   display: block;
   padding: ${th('space.2')};
   padding-right: ${th('space.3')};
@@ -84,17 +84,11 @@ const MenuItemLink = styled(Link)`
     color: ${th('colorTextReverse')};
   }
 `
+const MenuItemLink = styled(Link)`
+  ${menuItemLinkStyling};
+`
 const MenuItemExternalLink = styled.a`
-  display: block;
-  padding: ${th('space.2')};
-  padding-right: ${th('space.3')};
-  color: ${th('colorText')};
-  text-decoration: none;
-
-  &:hover {
-    background-color: ${th('colorPrimary')};
-    color: ${th('colorTextReverse')};
-  }
+  ${menuItemLinkStyling};
 `
 
 const LoginWrapper = styled(Box)`

--- a/app/components/global/AppBar/ProfileMenu.js
+++ b/app/components/global/AppBar/ProfileMenu.js
@@ -84,6 +84,18 @@ const MenuItemLink = styled(Link)`
     color: ${th('colorTextReverse')};
   }
 `
+const MenuItemExternalLink = styled.a`
+  display: block;
+  padding: ${th('space.2')};
+  padding-right: ${th('space.3')};
+  color: ${th('colorText')};
+  text-decoration: none;
+
+  &:hover {
+    background-color: ${th('colorPrimary')};
+    color: ${th('colorTextReverse')};
+  }
+`
 
 const LoginWrapper = styled(Box)`
   ${media.tabletPortraitUp`
@@ -141,6 +153,15 @@ class ProfileMenu extends React.Component {
                   <MenuHeading>{user.identities[0].name}</MenuHeading>
                 </MenuItem>
                 <MenuItem>
+                  <MenuItem>
+                    <MenuItemExternalLink
+                      data-test-id="manage-orcid"
+                      href="https://orcid.org/my-orcid"
+                      target="_blank"
+                    >
+                      Manage ORCID
+                    </MenuItemExternalLink>
+                  </MenuItem>
                   <MenuItemLink data-test-id="logout" to="/logout">
                     Logout
                   </MenuItemLink>

--- a/app/components/global/AppBar/ProfileMenu.test.js
+++ b/app/components/global/AppBar/ProfileMenu.test.js
@@ -29,20 +29,24 @@ describe('ProfileMenu', () => {
   it('does not show menu by default', () => {
     const wrapper = makeWrapper()
     expect(wrapper.find('[data-test-id="logout"]')).toHaveLength(0)
+    expect(wrapper.find('[data-test-id="manage-orcid"]')).toHaveLength(0)
   })
 
   it('shows menu on button click', () => {
     const wrapper = makeWrapper()
     wrapper.find('button[data-test-id="profile-menu"]').simulate('click')
     expect(wrapper.find('a[data-test-id="logout"]')).toHaveLength(1)
+    expect(wrapper.find('a[data-test-id="manage-orcid"]')).toHaveLength(1)
   })
 
   it('hides menu on second button click', () => {
     const wrapper = makeWrapper()
     wrapper.find('button[data-test-id="profile-menu"]').simulate('click')
     expect(wrapper.find('a[data-test-id="logout"]')).toHaveLength(1)
+    expect(wrapper.find('a[data-test-id="manage-orcid"]')).toHaveLength(1)
     wrapper.find('button[data-test-id="profile-menu"]').simulate('click')
     expect(wrapper.find('a[data-test-id="logout"]')).toHaveLength(0)
+    expect(wrapper.find('a[data-test-id="manage-orcid"]')).toHaveLength(0)
   })
 
   it('hides menu on click outside of container', () => {
@@ -59,9 +63,11 @@ describe('ProfileMenu', () => {
 
     wrapper.find('button[data-test-id="profile-menu"]').simulate('click')
     expect(wrapper.find('a[data-test-id="logout"]')).toHaveLength(1)
+    expect(wrapper.find('a[data-test-id="manage-orcid"]')).toHaveLength(1)
     const div = wrapper.find('#outside').instance()
     documentClickHandler({ target: div })
     wrapper.update()
     expect(wrapper.find('a[data-test-id="logout"]')).toHaveLength(0)
+    expect(wrapper.find('a[data-test-id="manage-orcid"]')).toHaveLength(0)
   })
 })


### PR DESCRIPTION
#### Background

Adds an external link to the profile menu allowing a user to manage their ORCiD ID.

#### Any relevant tickets

Closes #1047 

#### How has this been tested?

- [ ] Unit / Integration tests
- [x] Browser tests
- [x] End2end tests

#### UI Changes

- [x] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
