### PR TITLE
Add config to enable/disable hotjar

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -16,15 +16,17 @@ import * as AuthorDetailsSchema from './components/pages/SubmissionWizard/steps/
 const history = createHistory()
 const store = configureStore(history, {})
 
-const initializeReactGA = ({trackingId='test', debug} = {}) => {
-  const id = (trackingId === '') ? 'test' : trackingId
+const initializeReactGA = ({ trackingId = 'test', debug } = {}) => {
+  const id = trackingId === '' ? 'test' : trackingId
   ReactGA.initialize(id, { debug })
   ReactGA.pageview('/')
 }
 
 initializeReactGA(config.googleAnalytics)
-hotjar.initialize(config.hotJar.id, config.hotJar.snippetVersion)
 
+if (config.hotJar.enabled) {
+  hotjar.initialize(config.hotJar.id, config.hotJar.snippetVersion)
+}
 
 const makeApolloConfig = ({ cache, link }) => {
   const clientStateLink = withClientState({

--- a/app/components/pages/ThankYou/ThankYou.js
+++ b/app/components/pages/ThankYou/ThankYou.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { Box } from '@rebass/grid'
 import PropTypes from 'prop-types'
 import { H1 } from '@pubsweet/ui'
+import config from 'config'
 
 import NativeLink from '../../ui/atoms/NativeLink'
 import ButtonLink from '../../ui/atoms/ButtonLink'
@@ -20,7 +21,9 @@ const BookmarkLink = styled(NativeLink)`
 
 class ThankYou extends React.Component {
   componentDidMount() {
-    window.hj('trigger', 'thank_you_page_hotjar_feedback')
+    if (config.hotJar.enabled) {
+      window.hj('trigger', 'thank_you_page_hotjar_feedback')
+    }
   }
 
   render() {

--- a/config/default.js
+++ b/config/default.js
@@ -136,6 +136,7 @@ module.exports = {
   schema: {}, // schema extensions for pubsweet-server
   hotJar: {
     isPublic: true,
+    enabled: true,
     snippetVersion: 6,
   },
 }

--- a/config/development.js
+++ b/config/development.js
@@ -61,4 +61,7 @@ module.exports = {
     },
     apiKey: 'abcd1234',
   },
+  hotJar: {
+    enabled: false,
+  },
 }


### PR DESCRIPTION
#### Background

Adds a config option to enable/disable hotjar to prevent an error from being thrown by the client when developing on a local environment where a hotjar id may not be set.

