### PR TITLE
Work around permissions problem on formula repository

### DIFF
--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -17,6 +17,8 @@ if [ ! -d /tmp/elife-xpub-formula ]; then
     cd /tmp/elife-xpub-formula
 else
     cd /tmp/elife-xpub-formula
+    # workaround for https://github.com/elifesciences/issues/issues/4634
+    git reset --hard
     git pull origin master
 fi
 


### PR DESCRIPTION
Avoids review environments deployment breaking on changes to `elife-xpub-formula`.

For full description of the issue: https://github.com/elifesciences/issues/issues/4634