### PR TITLE
Fix the typo showing the error for large files

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
@@ -265,7 +265,7 @@ class SupportingUpload extends React.Component {
                 </FileName>
                 {file.rejected && (
                   <ErrorMessage data-test-id="file-block-error">
-                    {errorMessageMapping.MAX_SIZE_EXECEEDED}
+                    {errorMessageMapping.MAX_SIZE_EXCEEDED}
                   </ErrorMessage>
                 )}
               </FileHolder>


### PR DESCRIPTION
Fixes the typing error made while extracting the error message.
