### PR TITLE
WIP: added migration for auto-incrementing ID in ejp_name

### DIFF
--- a/server/meca/migrations/1548773811-ejp-name-id.sql
+++ b/server/meca/migrations/1548773811-ejp-name-id.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ejp_name
+    DROP COLUMN id;
+
+ALTER TABLE ejp_name
+    ADD COLUMN id SERIAL PRIMARY KEY;


### PR DESCRIPTION
#### Background

Allows IDs to be automatically generated when adding names to the `ejp_names` table. This is useful when exporting thousands of rows given to us by EJP.

#### Any relevant tickets

#925 

#### How has this been tested?
Unit tests run the migrations, these should be passing.