### PR TITLE
adding id to the state once uploading a new file

### DIFF
--- a/app/components/pages/SubmissionWizard/operations.js
+++ b/app/components/pages/SubmissionWizard/operations.js
@@ -51,6 +51,7 @@ const manuscriptFragment = gql`
       filename
       type
       status
+      id
     }
     coverLetter
     author {

--- a/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/SupportingUpload.js
@@ -138,6 +138,7 @@ function* fileUploadGenerator(files, uploadFile) {
     yield {
       upload: uploadFile(files[fileIndex].file),
       fileId: files[fileIndex].id,
+      filename: files[fileIndex].file.name,
     }
     fileIndex += 1
   }
@@ -168,10 +169,17 @@ class SupportingUpload extends React.Component {
       } else {
         result.value.upload
           .then(data => {
-            this.updateFileState(result.value.fileId, {
-              success: true,
-              loading: false,
-            })
+            const updatedFile = data.data.uploadSupportingFile.files.filter(
+              file => file.filename === result.value.filename,
+            )[0]
+            this.updateFileState(
+              result.value.fileId,
+              {
+                success: true,
+                loading: false,
+              },
+              updatedFile.id,
+            )
           })
           .catch(() => {
             this.updateFileState(result.value.fileId, {
@@ -185,11 +193,13 @@ class SupportingUpload extends React.Component {
     loop(iterator.next())
   }
 
-  updateFileState = (fileId, newState) => {
+  updateFileState = (fileId, newState, id) => {
     const newFilesState = [...this.state.files]
     const fileIndex = newFilesState.findIndex(file => file.id === fileId)
     if (fileIndex > -1) {
-      newFilesState[fileIndex] = { ...newFilesState[fileIndex], ...newState }
+      const updatingState = { ...newFilesState[fileIndex] }
+      updatingState.file.id = id
+      newFilesState[fileIndex] = { ...updatingState, ...newState }
       this.setState({ files: newFilesState })
     }
   }

--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -19,6 +19,7 @@ const UPLOAD_MANUSCRIPT_MUTATION = gql`
         filename
         type
         status
+        id
       }
     }
   }
@@ -35,6 +36,7 @@ const UPLOAD_SUPPORTING_MUTATION = gql`
         filename
         type
         status
+        id
       }
     }
   }
@@ -48,6 +50,7 @@ const DELETE_MANUSCRIPT_MUTATION = gql`
         filename
         type
         status
+        id
       }
     }
   }
@@ -61,6 +64,7 @@ const DELETE_SUPPORTING_FILES_MUTATION = gql`
         filename
         type
         status
+        id
       }
     }
   }


### PR DESCRIPTION
we have to add id in order to be able to replace the supporting file, once a new upload is coming with the same name 

closes #1424  
unblocks #1383 
