### PR TITLE
[EXT] Fix for error message not displayed when upload fails

### DIFF
--- a/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/ManuscriptUpload.js
@@ -90,21 +90,6 @@ const DropzoneContent = ({
   dropzoneOpen,
   fileName,
 }) => {
-  if (conversion.converting) {
-    return (
-      <React.Fragment>
-        <StyledUploadIcon percentage={conversion.progress} />
-        <FileName>{fileName}</FileName>
-        <UploadInstruction
-          data-test-conversion="converting"
-          data-test-id="dropzoneMessage"
-        >
-          Manuscript is uploading {conversion.progress}%
-        </UploadInstruction>
-      </React.Fragment>
-    )
-  }
-
   if (errorMessage) {
     return (
       <React.Fragment>
@@ -123,6 +108,21 @@ const DropzoneContent = ({
       </React.Fragment>
     )
   }
+  if (conversion.converting) {
+    return (
+      <React.Fragment>
+        <StyledUploadIcon percentage={conversion.progress} />
+        <FileName>{fileName}</FileName>
+        <UploadInstruction
+          data-test-conversion="converting"
+          data-test-id="dropzoneMessage"
+        >
+          Manuscript is uploading {conversion.progress}%
+        </UploadInstruction>
+      </React.Fragment>
+    )
+  }
+
   if (conversion.completed) {
     return (
       <React.Fragment>


### PR DESCRIPTION
#### Background

What does this PR do?

Fixes lack of error message if upload of manuscript fails.

#### Any relevant tickets

None

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
