### PR TITLE
Re-enabled linting on paths

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,6 @@
   "parser": "babel-eslint",
   "rules": {
     "global-require": 0,
-    "import/no-unresolved": "off",
     "class-methods-use-this": [
       "error",
       {


### PR DESCRIPTION
Closes #1458 

Addresses https://github.com/elifesciences/elife-xpub/pull/1454#discussion_r254618743

> Is there any way to whitelist this rule? I feel we'll be losing some useful checks by disabling it globally just to allow aliases for the ui components. Maybe we can look into creating `package.json` files for the ui molecules similar to how we're using the `xpub-server` and `xpub-model` in the server?