### PR TITLE
1476 Bug fix - add aliases to styleguide.webpack.config

### DIFF
--- a/webpack/webpack.styleguide.config.js
+++ b/webpack/webpack.styleguide.config.js
@@ -24,6 +24,8 @@ module.exports = {
   resolve: {
     alias: {
       config: path.join(__dirname, '../styleguide/config.json'),
+      ui: path.resolve(__dirname, '../app/components/ui'),
+      global: path.resolve(__dirname, '../app/components/global'),
     },
   },
   plugins: [new CopyWebpackPlugin([{ from: './assets', to: 'assets' }])],


### PR DESCRIPTION
#### Background
Adds the required fields for module resolve to webpack.styleguide.config.js by repeating the common-resolve aliases.

#### Any relevant tickets
Closes #1476 

