### PR TITLE
Locked down the version of lodash to 4.17.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
     "client/*",
     "server/*"
   ],
+  "resolutions": {
+    "lodash": ">=4.17.11"
+  },
   "dependencies": {
     "@elifesciences/elife-theme": "^1.0.0",
     "@pubsweet/ui": "^9.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8699,17 +8699,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.10, "lodash@4.6.1 || ^4.16.1", lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
-
-lodash@4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-  integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
-
-lodash@^4.0.0, lodash@^4.17.4:
+lodash@4.17.10, lodash@4.17.5, "lodash@4.6.1 || ^4.16.1", lodash@>=4.17.11, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.14.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
#### Background

Lodash 4.17.10 contains a vulnerability as described in #1488

Most of our dependencies don't rely on this specific version and accept newer versions of lodash, so a simple update should suffice.

Unfortunately, we have the following dependency chain within `elife-xpub`

`testcafe` --> `testcafe-hammerhead` --> `lodash@4.17.10`

This means that `lodash@4.17.10` gets used as a common denominator for a bunch of dependencies which depend on lodash.

Upgrading `testcafe` or `testcafe-hammerhead` would fix the issue, but it would also [introduce breaking changes](https://github.com/DevExpress/testcafe/releases/tag/v1.0.0), so our current option is to lock down the version of lodash instead.

This change uses [resolutions](https://yarnpkg.com/lang/en/docs/selective-version-resolutions/) to force a specific version of lodash for all dependencies within the chain.

#1500 has been created to upgrade testcafe going forward.

#### Any relevant tickets

Closes #1488 