### PR TITLE
1496 send email when MECA import fails

### DIFF
--- a/server/jest-setup.js
+++ b/server/jest-setup.js
@@ -4,12 +4,14 @@ const replaySetup = require('../test/helpers/replay-setup')
 replaySetup('success')
 
 jest.mock('@pubsweet/component-send-email', () => ({
+  _sendPromise: null,
   mails: [],
   send(mailData) {
-    return new Promise((resolve, reject) => {
+    this._sendPromise = new Promise((resolve, reject) => {
       this.mails.push(mailData)
       resolve()
     })
+    return this._sendPromise
   },
   getMails() {
     return this.mails

--- a/server/meca/routes.test.js
+++ b/server/meca/routes.test.js
@@ -26,6 +26,7 @@ describe('MECA HTTP callback handler', () => {
     const identities = [{ type: 'elife', identifier: profileId }]
     const user = await new User({ identities }).save()
     userId = user.id
+    mailer.clearMails()
   })
 
   it('rejects wrong API key', async () => {


### PR DESCRIPTION
#### Background

Sends an email when EJP request the callback route to let us know that importing failed.

#### Any relevant tickets

Closes #1496 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests
