### PR TITLE
add pre-commit hook to test the coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,14 @@
       "<rootDir>/{client,app,server}/**/*.js",
       "!**/*.{config,test}.js"
     ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 60,
+        "functions": 61,
+        "lines": 65,
+        "statements": -1000
+      }
+    },
     "projects": [
       "<rootDir>/client",
       "<rootDir>/app",
@@ -157,6 +165,7 @@
     "lint-staged": "^7.2.2",
     "mime": "^2.3.1",
     "pdf2json": "^1.1.8",
+    "pre-commit": "^1.2.2",
     "prettier": "^1.8.2",
     "pubsweet": "^3.0.13",
     "react-styleguidist": "^7.1.0",
@@ -171,5 +180,8 @@
     "webpack": "^3.8.1",
     "webpack-dev-middleware": "^3.1.3",
     "webpack-hot-middleware": "^2.22.1"
-  }
+  },
+  "pre-commit": [
+    "test"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -165,7 +165,6 @@
     "lint-staged": "^7.2.2",
     "mime": "^2.3.1",
     "pdf2json": "^1.1.8",
-    "pre-commit": "^1.2.2",
     "prettier": "^1.8.2",
     "pubsweet": "^3.0.13",
     "react-styleguidist": "^7.1.0",
@@ -180,8 +179,5 @@
     "webpack": "^3.8.1",
     "webpack-dev-middleware": "^3.1.3",
     "webpack-hot-middleware": "^2.22.1"
-  },
-  "pre-commit": [
-    "test"
-  ]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11104,15 +11104,6 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-pre-commit@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
-  integrity sha1-287g7p3nI15X95xW186UZBpp7sY=
-  dependencies:
-    cross-spawn "^5.0.1"
-    spawn-sync "^1.0.15"
-    which "1.2.x"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11104,6 +11104,15 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
+pre-commit@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
+  integrity sha1-287g7p3nI15X95xW186UZBpp7sY=
+  dependencies:
+    cross-spawn "^5.0.1"
+    spawn-sync "^1.0.15"
+    which "1.2.x"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"


### PR DESCRIPTION
adds a pre-commit hook, that avoids performing any commit if the coverage gets down or the tests are broken
