### PR TITLE
1519 doesn't send an error response when email fails

### DIFF
--- a/server/meca/routes.js
+++ b/server/meca/routes.js
@@ -37,7 +37,14 @@ module.exports = app => {
 
     Manuscript.updateStatus(manuscriptId, status)
       .then(() => res.sendStatus(204))
-      .then(() => {
+      .catch(err => {
+        logger.error('Failed to process MECA callback', {
+          manuscriptId,
+          error: err.message,
+        })
+        res.status(500).send({ error: err.message })
+      })
+      .finally(() => {
         if (status === Manuscript.statuses.MECA_IMPORT_FAILED) {
           return mailer.send({
             to: config.get('meca.notificationEmail'),
@@ -51,12 +58,6 @@ Manuscript ID: ${manuscriptId}
         }
         return Promise.resolve()
       })
-      .catch(err => {
-        logger.error('Failed to process MECA callback', {
-          manuscriptId,
-          error: err.message,
-        })
-        res.status(500).send({ error: err.message })
-      })
+
   })
 }


### PR DESCRIPTION
#### Background

We currently have an unhandled promise in the MECA callback. We return a successful response back, but if the subsequent email fails, we attempt to send a second response back even though we've already sent a success. This gives us the unhandled promise error.

#### Any relevant tickets

Addresses https://github.com/elifesciences/elife-xpub/issues/1519#issuecomment-463616414

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests