### PR TITLE
1519 fixing Promise error for MECA import emails

### DIFF
--- a/server/meca/routes.js
+++ b/server/meca/routes.js
@@ -35,32 +35,20 @@ module.exports = app => {
         ? Manuscript.statuses.MECA_IMPORT_SUCCEEDED
         : Manuscript.statuses.MECA_IMPORT_FAILED
 
-    const updateStatus = () => new Promise((resolve, reject) => {
-      console.log('--- updating manuscript status to ', status)
-      try {
-        resolve(Manuscript.updateStatus(manuscriptId, status))
-      } catch(err) {
-        reject(err)
-      }
-    })
+    const updateStatus = () => Manuscript.updateStatus(manuscriptId, status)
 
-    const sendEmail = () => new Promise((resolve, reject) => {
-      console.log('--- sending email')
-      resolve(
-        mailer.send({
-          to: config.get('meca.notificationEmail'),
-          from: config.get('meca.fromAddressEmail'),
-          subject: 'MECA import failed',
-          text: `
+    const sendEmail = () => mailer.send({
+      to: config.get('meca.notificationEmail'),
+      from: config.get('meca.fromAddressEmail'),
+      subject: 'MECA import failed',
+      text: `
 EJP failed to import MECA package.
 Manuscript ID: ${manuscriptId}
-          `,
-        }).catch((err) => {
-          throw new Error(`Import failure email failed to send. ${err}`)
-        })
-      )
+      `,
+    }).catch((err) => {
+      throw new Error(`MECA import failure email failed to send. ${err}`)
     })
-
+      
     updateStatus()
       .then(() => {
         if (status === Manuscript.statuses.MECA_IMPORT_FAILED) {
@@ -70,7 +58,6 @@ Manuscript ID: ${manuscriptId}
       })
       .then(() => res.sendStatus(204))
       .catch(err => {
-        console.log('--- some error thrown', err)
         logger.error('Failed to process MECA callback', {
           manuscriptId,
           error: err.message,

--- a/server/meca/routes.js
+++ b/server/meca/routes.js
@@ -35,28 +35,47 @@ module.exports = app => {
         ? Manuscript.statuses.MECA_IMPORT_SUCCEEDED
         : Manuscript.statuses.MECA_IMPORT_FAILED
 
-    Manuscript.updateStatus(manuscriptId, status)
+    const updateStatus = () => new Promise((resolve, reject) => {
+      console.log('--- updating manuscript status to ', status)
+      try {
+        resolve(Manuscript.updateStatus(manuscriptId, status))
+      } catch(err) {
+        reject(err)
+      }
+    })
+
+    const sendEmail = () => new Promise((resolve, reject) => {
+      console.log('--- sending email')
+      resolve(
+        mailer.send({
+          to: config.get('meca.notificationEmail'),
+          from: config.get('meca.fromAddressEmail'),
+          subject: 'MECA import failed',
+          text: `
+EJP failed to import MECA package.
+Manuscript ID: ${manuscriptId}
+          `,
+        }).catch((err) => {
+          throw new Error(`Import failure email failed to send. ${err}`)
+        })
+      )
+    })
+
+    updateStatus()
+      .then(() => {
+        if (status === Manuscript.statuses.MECA_IMPORT_FAILED) {
+          return sendEmail()
+        }
+        return Promise.resolve()
+      })
       .then(() => res.sendStatus(204))
       .catch(err => {
+        console.log('--- some error thrown', err)
         logger.error('Failed to process MECA callback', {
           manuscriptId,
           error: err.message,
         })
         res.status(500).send({ error: err.message })
-      })
-      .finally(() => {
-        if (status === Manuscript.statuses.MECA_IMPORT_FAILED) {
-          return mailer.send({
-            to: config.get('meca.notificationEmail'),
-            from: config.get('meca.fromAddressEmail'),
-            subject: 'MECA import failed',
-            text: `
-EJP failed to import MECA package.
-Manuscript ID: ${manuscriptId}
-            `,
-          })
-        }
-        return Promise.resolve()
       })
 
   })


### PR DESCRIPTION
#### Background

#1523 introduced a silent error when calling the MECA callback route due to Promises with handles being left open (which is my best guess). Unfortunately this didn't fail the unit tests.

The impact of this change is that we now wait for the email to finish sending before we send back a response. This means that the request currently takes up to 5 seconds, from the results when testing locally.

The output is currently:
```
root@b0a8f28ed4b0:~# ./scripts/send-meca-result.sh 6a6460f5-83e7-471d-a331-813844d95fbe
{"message":"Manuscript.updateStatus(...).then(...).catch(...).finally is not a function"}
```

With this fix, the output should now be empty, since we return a status of 204 with an empty body.

#### Any relevant tickets

Relates to #1519 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests