### PR TITLE
Added vim to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR ${HOME}
 RUN curl -sL http://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list
 RUN apt-get update \
-    && apt-get install -y google-chrome-stable socat \
+    && apt-get install -y google-chrome-stable socat vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Background

Adds Vim to Dockerfile. This makes it easier to edit files within environments such as Staging and Production. This is useful when editing scripts within the `/scripts` directory, since a lot of these are hardcoded to work only within specific environments.

For example, https://github.com/elifesciences/elife-xpub/blob/develop/scripts/send-meca-result.sh is hardcoded to request production, even if it's executed from Staging.

At the moment, I manually install vim within the docker container when needed, but this isn't persisted between deployments.