### PR TITLE
Increase time out for jest before/after hooks

### DIFF
--- a/server/jest-setup.js
+++ b/server/jest-setup.js
@@ -4,6 +4,7 @@ const replaySetup = require('../test/helpers/replay-setup')
 replaySetup('success')
 
 // The pipeline complains at the default of 5s - so double it!
+// https://jestjs.io/docs/en/jest-object#jestsettimeouttimeout
 jest.setTimeout(10000)
 
 jest.mock('@pubsweet/component-send-email', () => ({

--- a/server/jest-setup.js
+++ b/server/jest-setup.js
@@ -3,6 +3,9 @@ const replaySetup = require('../test/helpers/replay-setup')
 
 replaySetup('success')
 
+// The pipeline complains at the default of 5s - so double it!
+jest.setTimeout(10000)
+
 jest.mock('@pubsweet/component-send-email', () => ({
   _sendPromise: null,
   mails: [],


### PR DESCRIPTION
#### Background

Prevent the tests from timing out in the pipeline.

#### Any relevant tickets

Closes #1546

#### How has this been tested?

This would be a bit "meta" :stuck_out_tongue_closed_eyes: 