### PR TITLE
1521 error catch

### DIFF
--- a/server/xpub-controller/helpers/files.js
+++ b/server/xpub-controller/helpers/files.js
@@ -58,6 +58,26 @@ class FilesHelper {
     throw new Error('Invalid parameters to calculate the upload file progress.')
   }
 
+  static startFileProgress(
+    pubsub,
+    ON_UPLOAD_PROGRESS,
+    startedTime,
+    predictedTime,
+    manuscriptId,
+    interval,
+  ) {
+    return setInterval(
+      FilesHelper.publishPredictedProgress(
+        pubsub,
+        ON_UPLOAD_PROGRESS,
+        startedTime,
+        predictedTime,
+        manuscriptId,
+      ),
+      interval,
+    )
+  }
+
   static endFileProgress(pubsub, ON_UPLOAD_PROGRESS, progress, manuscriptId) {
     pubsub.publish(`${ON_UPLOAD_PROGRESS}.${manuscriptId}`, {
       manuscriptUploadProgress: 100,

--- a/server/xpub-controller/helpers/manuscript.js
+++ b/server/xpub-controller/helpers/manuscript.js
@@ -11,14 +11,7 @@ class ManuscriptHelper {
     this.filesHelper = filesHelper
   }
 
-  async uploadManuscriptFile(
-    pubsub,
-    ON_UPLOAD_PROGRESS,
-    fileData,
-    fileSize,
-    manuscriptId,
-    progress,
-  ) {
+  async uploadManuscriptFile(fileData, fileSize, manuscriptId) {
     const { stream } = fileData
     let { fileEntity } = fileData
     const { id: fileId, filename, mimeType } = fileEntity
@@ -53,12 +46,6 @@ class ManuscriptHelper {
         `Manuscript was not uploaded to S3: ${err} | ${manuscriptId}`,
       )
       await fileEntity.delete()
-      FilesHelper.endFileProgress(
-        pubsub,
-        ON_UPLOAD_PROGRESS,
-        progress,
-        manuscriptId,
-      )
       throw err
     }
 

--- a/server/xpub-controller/manuscript.js
+++ b/server/xpub-controller/manuscript.js
@@ -26,7 +26,7 @@ class Manuscript {
     this.filesHelper.validateFileSize(fileSize)
 
     // ensure user can view manuscript
-    const manuscript = await ManuscriptModel.find(manuscriptId, this.userId)
+    await ManuscriptModel.find(manuscriptId, this.userId)
 
     const fileData = await FilesHelper.generateFileEntity(file, manuscriptId)
 
@@ -50,7 +50,7 @@ class Manuscript {
       await this.manuscriptHelper.uploadManuscriptFile(
         fileData,
         fileSize,
-        manuscript.id,
+        manuscriptId,
       )
     } catch (error) {
       FilesHelper.endFileProgress(

--- a/server/xpub-controller/manuscript.js
+++ b/server/xpub-controller/manuscript.js
@@ -48,12 +48,9 @@ class Manuscript {
 
     try {
       await this.manuscriptHelper.uploadManuscriptFile(
-        pubsub,
-        ON_UPLOAD_PROGRESS,
         fileData,
         fileSize,
         manuscript.id,
-        progress,
       )
     } catch (error) {
       FilesHelper.endFileProgress(

--- a/server/xpub-controller/manuscript.js
+++ b/server/xpub-controller/manuscript.js
@@ -35,17 +35,14 @@ class Manuscript {
     // Predict upload time - The analysis was done on #839
     const predictedTime = 5 + 4.67e-6 * fileSize
     const startedTime = Date.now()
-    const progress = setInterval(
-      FilesHelper.publishPredictedProgress(
-        pubsub,
-        ON_UPLOAD_PROGRESS,
-        startedTime,
-        predictedTime,
-        manuscriptId,
-      ),
+    const progress = FilesHelper.startFileProgress(
+      pubsub,
+      ON_UPLOAD_PROGRESS,
+      startedTime,
+      predictedTime,
+      manuscriptId,
       200,
     )
-
     try {
       await this.manuscriptHelper.uploadManuscriptFile(
         fileData,

--- a/server/xpub-controller/manuscript.js
+++ b/server/xpub-controller/manuscript.js
@@ -46,14 +46,24 @@ class Manuscript {
       200,
     )
 
-    await this.manuscriptHelper.uploadManuscriptFile(
-      pubsub,
-      ON_UPLOAD_PROGRESS,
-      fileData,
-      fileSize,
-      manuscript.id,
-      progress,
-    )
+    try {
+      await this.manuscriptHelper.uploadManuscriptFile(
+        pubsub,
+        ON_UPLOAD_PROGRESS,
+        fileData,
+        fileSize,
+        manuscript.id,
+        progress,
+      )
+    } catch (error) {
+      FilesHelper.endFileProgress(
+        pubsub,
+        ON_UPLOAD_PROGRESS,
+        progress,
+        manuscriptId,
+      )
+      throw error
+    }
 
     FilesHelper.endFileProgress(
       pubsub,

--- a/server/xpub-controller/manuscript.test.js
+++ b/server/xpub-controller/manuscript.test.js
@@ -1,0 +1,66 @@
+const { createTables } = require('@pubsweet/db-manager')
+const User = require('../xpub-model/entities/user')
+const Manuscript = require('../xpub-model/entities/manuscript')
+const ManuscriptController = require('./manuscript')
+const { FilesHelper } = require('./helpers')
+
+describe('upload', () => {
+  let userId
+
+  beforeEach(async () => {
+    await createTables(true)
+    const profileId = 'ewwboc7m'
+    const identities = [{ type: 'elife', identifier: profileId }]
+    const user = await new User({ identities }).save()
+    userId = user.id
+  })
+
+  it('stops sending progress updates if error is thrown when uplaoding file', async () => {
+    jest.useFakeTimers()
+    // Mock depenencies
+    FilesHelper.generateFileEntity = jest.fn()
+    const config = { get: () => 0 }
+    const publishMock = jest.fn()
+    const ON_UPLOAD_PROGRESS = 'ON_UPLOAD_PROGRESS'
+
+    // create instance of controller with mock params
+    const manuscriptController = new ManuscriptController(
+      config,
+      userId,
+      {},
+      {},
+      {
+        asyncIterators: { ON_UPLOAD_PROGRESS },
+        getPubsub: () => ({ publish: publishMock }),
+      },
+    )
+
+    // Mocks internally stored helper object.
+    // Can be refactored as part of #1551
+    manuscriptController.manuscriptHelper.uploadManuscriptFile = jest.fn(
+      () =>
+        new Promise((resolve, reject) => {
+          reject(new Error('Error'))
+        }),
+    )
+
+    const manuscript = new Manuscript({ createdBy: userId })
+    const { id: manuscriptId } = await manuscript.save()
+
+    // https://jestjs.io/docs/en/tutorial-async#error-handling
+    expect.assertions(4)
+    try {
+      await manuscriptController.upload(manuscriptId, {}, 0)
+    } catch (e) {
+      expect(e).toEqual(new Error('Error'))
+      expect(
+        manuscriptController.manuscriptHelper.uploadManuscriptFile,
+      ).toBeCalledTimes(1)
+      expect(clearInterval).toHaveBeenCalledTimes(1)
+      expect(publishMock).toHaveBeenLastCalledWith(
+        `${ON_UPLOAD_PROGRESS}.${manuscriptId}`,
+        { manuscriptUploadProgress: 100 },
+      )
+    }
+  })
+})


### PR DESCRIPTION
#### Background

 Currently there is a bug that causes the progress of a manuscript upload to get stuck at 99% if an error is thrown due to the setInterval continuing to broadcast progress messages to the client.

This PR wraps the entire `uploadManuscriptFile` process in a `try catch`, clearing the interval and sending a 100% message to the client so that it knows the process has ended (albeit in an error state). The `uploadManuscriptFile` function originally had this clearing functionality at its scienceBeam extraction stage. This has been removed so that `uploadManuscriptFile` no longer has knowledge of the progress tracking task and this is all taken care of in the controller.

#### Any relevant tickets

Closes #1521 

