### PR TITLE
1563 remove file on error

### DIFF
--- a/server/xpub-controller/helpers/manuscript.js
+++ b/server/xpub-controller/helpers/manuscript.js
@@ -11,6 +11,24 @@ class ManuscriptHelper {
     this.filesHelper = filesHelper
   }
 
+  static async clearPendingFile(manuscript) {
+    const pendingFileIndex = manuscript.files.findIndex(
+      element => element.type === 'MANUSCRIPT_SOURCE_PENDING',
+    )
+
+    if (pendingFileIndex >= 0) {
+      const pendingFile = await FileModel.find(
+        manuscript.files[pendingFileIndex].id,
+      )
+      await pendingFile.delete()
+      logger.info(
+        `Pending file removed ${pendingFileIndex} ${
+          manuscript.files[pendingFileIndex].filename
+        } | ${manuscript.id}`,
+      )
+    }
+  }
+
   async uploadManuscriptFile(fileData, fileSize, manuscriptId) {
     const { stream } = fileData
     let { fileEntity } = fileData

--- a/server/xpub-controller/helpers/manuscript.test.js
+++ b/server/xpub-controller/helpers/manuscript.test.js
@@ -29,7 +29,7 @@ describe('clearPendingFile()', () => {
       url: '/',
     })
     await fileEntity.save()
-    await fileEntity2.save()
+    const sourceFile = await fileEntity2.save()
     manuscript = await Manuscript.find(id, userId)
     expect(manuscript.files).toHaveLength(2)
 
@@ -37,5 +37,7 @@ describe('clearPendingFile()', () => {
     manuscript = await Manuscript.find(id, userId)
 
     expect(manuscript.files).toHaveLength(1)
+    expect(manuscript.files[0].id).toEqual(sourceFile.id)
+    expect(manuscript.files[0].type).not.toEqual('MANUSCRIPT_SOURCE_PENDING')
   })
 })

--- a/server/xpub-controller/helpers/manuscript.test.js
+++ b/server/xpub-controller/helpers/manuscript.test.js
@@ -1,0 +1,41 @@
+const { createTables } = require('@pubsweet/db-manager')
+const { User, Manuscript, File } = require('@elifesciences/xpub-model')
+const ManuscriptHelper = require('./manuscript')
+
+describe('clearPendingFile()', () => {
+  let userId
+
+  beforeEach(async () => {
+    await createTables(true)
+    const profileId = 'ewwboc7m'
+    const identities = [{ type: 'elife', identifier: profileId }]
+    const user = await new User({ identities }).save()
+    userId = user.id
+  })
+
+  it('removes any file with type MANUSCRIPT_SOURCE_PENDING related to this manuscript', async () => {
+    let manuscript = new Manuscript({ createdBy: userId })
+    const { id } = await manuscript.save()
+    const fileEntity = new File({
+      manuscriptId: id,
+      type: 'MANUSCRIPT_SOURCE_PENDING',
+      filename: 'foo.jpg',
+      url: '/',
+    })
+    const fileEntity2 = new File({
+      manuscriptId: id,
+      type: 'MANUSCRIPT_SOURCE',
+      filename: 'bar.jpg',
+      url: '/',
+    })
+    await fileEntity.save()
+    await fileEntity2.save()
+    manuscript = await Manuscript.find(id, userId)
+    expect(manuscript.files).toHaveLength(2)
+
+    await ManuscriptHelper.clearPendingFile(manuscript)
+    manuscript = await Manuscript.find(id, userId)
+
+    expect(manuscript.files).toHaveLength(1)
+  })
+})

--- a/server/xpub-controller/manuscript.js
+++ b/server/xpub-controller/manuscript.js
@@ -1,6 +1,6 @@
 const logger = require('@pubsweet/logger')
 const ManuscriptModel = require('@elifesciences/xpub-model').Manuscript
-
+const FileModel = require('@elifesciences/xpub-model').File
 const Notification = require('./notification')
 const { FilesHelper, ManuscriptHelper } = require('./helpers')
 
@@ -18,6 +18,24 @@ class Manuscript {
       this.storage,
       this.filesHelper,
     )
+  }
+
+  static async clearPendingFile(manuscript) {
+    const pendingFileIndex = manuscript.files.findIndex(
+      element => element.type === 'MANUSCRIPT_SOURCE_PENDING',
+    )
+
+    if (pendingFileIndex >= 0) {
+      const pendingFile = await FileModel.find(
+        manuscript.files[pendingFileIndex].id,
+      )
+      await pendingFile.delete()
+      logger.info(
+        `Pending file removed ${pendingFileIndex} ${
+          manuscript.files[pendingFileIndex].filename
+        } | ${manuscript.id}`,
+      )
+    }
   }
 
   async upload(manuscriptId, file, fileSize) {

--- a/server/xpub-controller/manuscript.js
+++ b/server/xpub-controller/manuscript.js
@@ -1,6 +1,5 @@
 const logger = require('@pubsweet/logger')
 const ManuscriptModel = require('@elifesciences/xpub-model').Manuscript
-const FileModel = require('@elifesciences/xpub-model').File
 const Notification = require('./notification')
 const { FilesHelper, ManuscriptHelper } = require('./helpers')
 
@@ -18,24 +17,6 @@ class Manuscript {
       this.storage,
       this.filesHelper,
     )
-  }
-
-  static async clearPendingFile(manuscript) {
-    const pendingFileIndex = manuscript.files.findIndex(
-      element => element.type === 'MANUSCRIPT_SOURCE_PENDING',
-    )
-
-    if (pendingFileIndex >= 0) {
-      const pendingFile = await FileModel.find(
-        manuscript.files[pendingFileIndex].id,
-      )
-      await pendingFile.delete()
-      logger.info(
-        `Pending file removed ${pendingFileIndex} ${
-          manuscript.files[pendingFileIndex].filename
-        } | ${manuscript.id}`,
-      )
-    }
   }
 
   async upload(manuscriptId, file, fileSize) {
@@ -74,6 +55,8 @@ class Manuscript {
         progress,
         manuscriptId,
       )
+      const manuscript = await ManuscriptModel.find(manuscriptId, this.userId)
+      await ManuscriptHelper.clearPendingFile(manuscript)
       throw error
     }
 

--- a/server/xpub-controller/manuscript.test.js
+++ b/server/xpub-controller/manuscript.test.js
@@ -95,8 +95,7 @@ describe('clearPendingFile', () => {
     manuscript = await Manuscript.find(id, userId)
     expect(manuscript.files).toHaveLength(2)
 
-    const manuscriptController = new ManuscriptController()
-    await manuscriptController.clearPendingFile(manuscript)
+    await ManuscriptController.clearPendingFile(manuscript)
     manuscript = await Manuscript.find(id, userId)
 
     expect(manuscript.files).toHaveLength(1)


### PR DESCRIPTION
#### Background

Adds a new manuscript helper function that deletes any `File` entities with the type `MANUSCRIPT_SOURCE_PENDING` that are related to a passed in manuscript. This function is then called if the `uploadManuscriptFile` function ever throws an error to ensure the manuscript is in a valid state to re-try uploading a new file.

#### Any relevant tickets

Closes #1563 

#### How has this been tested?
- [x] Unit / Integration tests

