### PR TITLE
1538 small controller refactor

### DIFF
--- a/server/xpub-controller/helpers/files.js
+++ b/server/xpub-controller/helpers/files.js
@@ -41,7 +41,6 @@ class FilesHelper {
     manuscriptId,
   ) {
     if (
-      typeof pubsub.publish === 'function' &&
       manuscriptId.length === 36 &&
       predictedTime > 0
     ) {

--- a/server/xpub-controller/helpers/files.js
+++ b/server/xpub-controller/helpers/files.js
@@ -17,7 +17,7 @@ class FilesHelper {
     }
   }
 
-  static async generateFileEntity(file, manuscriptId) {
+  static async getFileData(file, manuscriptId) {
     const { stream, filename, mimetype: mimeType } = await file
 
     const fileEntity = await new FileModel({

--- a/server/xpub-controller/helpers/files.test.js
+++ b/server/xpub-controller/helpers/files.test.js
@@ -24,7 +24,7 @@ describe('FilesHelper', () => {
     })
   })
 
-  describe('generateFileEntity', () => {
+  describe('getFileData', () => {
     it('returns the file stream and file entity', async () => {
       const userId = uuid()
       await createTables(true)
@@ -36,7 +36,7 @@ describe('FilesHelper', () => {
       }
       const filePromise = Promise.resolve(file)
 
-      const fileData = await FilesHelper.generateFileEntity(filePromise, id)
+      const fileData = await FilesHelper.getFileData(filePromise, id)
       expect(fileData.stream).toEqual(file.stream)
       expect(fileData.fileEntity).toMatchObject({
         manuscriptId: id,

--- a/server/xpub-controller/manuscript.js
+++ b/server/xpub-controller/manuscript.js
@@ -27,7 +27,7 @@ class Manuscript {
     // ensure user can view manuscript
     await ManuscriptModel.find(manuscriptId, this.userId)
 
-    const fileData = await FilesHelper.generateFileEntity(file, manuscriptId)
+    const fileData = await FilesHelper.getFileData(file, manuscriptId)
 
     const pubsub = await this.pubsubManager.getPubsub()
 

--- a/server/xpub-controller/manuscript.test.js
+++ b/server/xpub-controller/manuscript.test.js
@@ -33,7 +33,7 @@ describe('upload', () => {
 
   it('stops sending progress updates if error is thrown when uplaoding file', async () => {
     // Mock uneeded creation of file
-    FilesHelper.generateFileEntity = jest.fn()
+    FilesHelper.getFileData = jest.fn()
     // Mock functions that use timers
     FilesHelper.startFileProgress = jest.fn()
     FilesHelper.endFileProgress = jest.fn()


### PR DESCRIPTION
#### Background

- removed type check according to https://github.com/elifesciences/elife-xpub/pull/1536#discussion_r258060139
- renamed `FileHelpers.generateFileEntity` to `FileHelpers.getFileData` according to https://github.com/elifesciences/elife-xpub/pull/1536#discussion_r258038607

#### Any relevant tickets

Closes #1551 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests
