### PR TITLE
1584 redirect placeholder page

### DIFF
--- a/app/components/pages/LandingRedirect/LandingRedirect.js
+++ b/app/components/pages/LandingRedirect/LandingRedirect.js
@@ -1,16 +1,8 @@
 import React from 'react'
 import { H1 } from '@pubsweet/ui'
 
-// eslint-disable-next-line react/prefer-stateless-function
-class LandingRedirect extends React.Component {
-  // eslint-disable-next-line no-useless-constructor
-  constructor(props) {
-    super(props)
-  }
-
-  render() {
-    return <H1>We&#39;re redirecting you</H1>
-  }
-}
+const LandingRedirect = () => (
+  <H1>We&#39;re redirecting you</H1>
+)
 
 export default LandingRedirect

--- a/app/components/pages/LandingRedirect/LandingRedirect.js
+++ b/app/components/pages/LandingRedirect/LandingRedirect.js
@@ -1,15 +1,15 @@
 import React from 'react'
 import { H1 } from '@pubsweet/ui'
 
+// eslint-disable-next-line react/prefer-stateless-function
 class LandingRedirect extends React.Component {
+  // eslint-disable-next-line no-useless-constructor
   constructor(props) {
     super(props)
   }
 
   render() {
-    return (
-      <H1>We're redirecting you</H1>
-    )
+    return <H1>We&#39;re redirecting you</H1>
   }
 }
 

--- a/app/components/pages/LandingRedirect/LandingRedirect.js
+++ b/app/components/pages/LandingRedirect/LandingRedirect.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { H1 } from '@pubsweet/ui'
+
+const LandingRedirect = props => (
+  <React.Fragment>
+    <H1>We're redirecting you</H1>
+  </React.Fragment>
+)
+
+export default LandingRedirect

--- a/app/components/pages/LandingRedirect/LandingRedirect.js
+++ b/app/components/pages/LandingRedirect/LandingRedirect.js
@@ -1,10 +1,16 @@
 import React from 'react'
 import { H1 } from '@pubsweet/ui'
 
-const LandingRedirect = props => (
-  <React.Fragment>
-    <H1>We're redirecting you</H1>
-  </React.Fragment>
-)
+class LandingRedirect extends React.Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    return (
+      <H1>We're redirecting you</H1>
+    )
+  }
+}
 
 export default LandingRedirect

--- a/app/components/pages/LandingRedirect/LandingRedirect.md
+++ b/app/components/pages/LandingRedirect/LandingRedirect.md
@@ -1,0 +1,3 @@
+```js
+<LandingRedirect />
+```

--- a/app/components/pages/LandingRedirect/index.js
+++ b/app/components/pages/LandingRedirect/index.js
@@ -1,3 +1,3 @@
-import LandingRedirect from '.'
+import LandingRedirect from './LandingRedirect'
 
 export default LandingRedirect

--- a/app/components/pages/LandingRedirect/index.js
+++ b/app/components/pages/LandingRedirect/index.js
@@ -1,0 +1,3 @@
+import LandingRedirect from '.'
+
+export default LandingRedirect

--- a/app/routes.js
+++ b/app/routes.js
@@ -18,26 +18,28 @@ import ThankYouPage from './components/pages/ThankYou'
 import TrackedRoute from './trackedRoute'
 
 const Routes = () => (
-  <Layout>
-    <ErrorBoundary>
-      <Switch>
-        <TrackedRoute component={LandingRedirect} exact path="/redirect" />
-        <TrackedRoute component={LoginPage} exact path="/login" />
-        <TrackedRoute component={LogoutPage} exact path="/logout" />
-        <TrackedRoute component={AuthorGuide} path="/author-guide" />
-        <TrackedRoute component={ReviewerGuide} path="/reviewer-guide" />
-        <TrackedRoute component={ContactUs} path="/contact-us" />
-        <AuthenticatedComponent>
-          <Switch>
-            <TrackedRoute component={ThankYouPage} path="/thankyou/:id" />
-            <Route component={SubmissionWizard} path="/submit/:id" />
-            <TrackedRoute component={DashboardPage} exact path="/" />
-            <ErrorPage error="404: page not found" />
-          </Switch>
-        </AuthenticatedComponent>
-      </Switch>
-    </ErrorBoundary>
-  </Layout>
+  <Switch>
+    <TrackedRoute component={LandingRedirect} exact path="/redirect" />
+    <Layout>
+      <ErrorBoundary>
+        <Switch>
+          <TrackedRoute component={LoginPage} exact path="/login" />
+          <TrackedRoute component={LogoutPage} exact path="/logout" />
+          <TrackedRoute component={AuthorGuide} path="/author-guide" />
+          <TrackedRoute component={ReviewerGuide} path="/reviewer-guide" />
+          <TrackedRoute component={ContactUs} path="/contact-us" />
+          <AuthenticatedComponent>
+            <Switch>
+              <TrackedRoute component={ThankYouPage} path="/thankyou/:id" />
+              <Route component={SubmissionWizard} path="/submit/:id" />
+              <TrackedRoute component={DashboardPage} exact path="/" />
+              <ErrorPage error="404: page not found" />
+            </Switch>
+          </AuthenticatedComponent>
+        </Switch>
+      </ErrorBoundary>
+    </Layout>
+  </Switch>
 )
 
 export default Routes

--- a/app/routes.js
+++ b/app/routes.js
@@ -4,6 +4,7 @@ import { Route, Switch } from 'react-router-dom'
 import { AuthenticatedComponent, Layout } from './components/global'
 import ErrorBoundary from './components/global/ErrorBoundary'
 
+import LandingRedirect from './components/pages/LandingRedirect'
 import LoginPage from './components/pages/Login'
 import LogoutPage from './components/pages/Logout/index'
 import DashboardPage from './components/pages/Dashboard'
@@ -20,6 +21,7 @@ const Routes = () => (
   <Layout>
     <ErrorBoundary>
       <Switch>
+        <TrackedRoute component={LandingRedirect} exact path="/redirect" />
         <TrackedRoute component={LoginPage} exact path="/login" />
         <TrackedRoute component={LogoutPage} exact path="/logout" />
         <TrackedRoute component={AuthorGuide} path="/author-guide" />

--- a/server/xpub-server/routes.js
+++ b/server/xpub-server/routes.js
@@ -64,8 +64,4 @@ module.exports = app => {
   app.get('/status', nocache, async (req, res) => {
     res.status(200).send({})
   })
-
-  app.get('/redirect', nocache, async (req, res) => {
-    res.status(200).send({})
-  })
 }

--- a/server/xpub-server/routes.js
+++ b/server/xpub-server/routes.js
@@ -64,4 +64,8 @@ module.exports = app => {
   app.get('/status', nocache, async (req, res) => {
     res.status(200).send({})
   })
+
+  app.get('/redirect', nocache, async (req, res) => {
+    res.status(200).send({})
+  })
 }

--- a/server/xpub-server/routes.test.js
+++ b/server/xpub-server/routes.test.js
@@ -15,29 +15,6 @@ describe('ping route test', () => {
   }
 
   beforeEach(() => {
-    jest.mock('config', () => ({
-      publicConfig: {
-        isPublic: true,
-        key: 'value',
-      },
-      privateConfig: {
-        secret: 'password',
-      },
-      aws: {
-        credentials: {
-          region: '',
-          accessKeyId: '',
-          secretAccessKey: '',
-        },
-        s3: {
-          s3ForcePathStyle: true,
-          params: {
-            Bucket: 'dev-elife-xpub',
-          },
-        },
-      },
-    }))
-
     routes = require('./routes')
     health.checkDataBase.mockResolvedValue(14)
     setS3Success(1)
@@ -129,29 +106,6 @@ describe('status route test', () => {
   }
 
   beforeEach(() => {
-    jest.mock('config', () => ({
-      publicConfig: {
-        isPublic: true,
-        key: 'value',
-      },
-      privateConfig: {
-        secret: 'password',
-      },
-      aws: {
-        credentials: {
-          region: '',
-          accessKeyId: '',
-          secretAccessKey: '',
-        },
-        s3: {
-          s3ForcePathStyle: true,
-          params: {
-            Bucket: 'dev-elife-xpub',
-          },
-        },
-      },
-    }))
-
     routes = require('./routes')
   })
 

--- a/server/xpub-server/routes.test.js
+++ b/server/xpub-server/routes.test.js
@@ -114,22 +114,3 @@ describe('status route test', () => {
     await request.get('/status').expect(200)
   })
 })
-
-describe('redirect route', () => {
-  let routes
-
-  const makeApp = () => {
-    const app = express()
-    routes(app)
-    return supertest(app)
-  }
-
-  beforeEach(() => {
-    routes = require('./routes')
-  })
-
-  it('returns success', async () => {
-    const request = makeApp()
-    await request.get('/redirect').expect(200)
-  })
-})

--- a/server/xpub-server/routes.test.js
+++ b/server/xpub-server/routes.test.js
@@ -114,3 +114,22 @@ describe('status route test', () => {
     await request.get('/status').expect(200)
   })
 })
+
+describe('redirect route', () => {
+  let routes
+
+  const makeApp = () => {
+    const app = express()
+    routes(app)
+    return supertest(app)
+  }
+
+  beforeEach(() => {
+    routes = require('./routes')
+  })
+
+  it('returns success', async () => {
+    const request = makeApp()
+    await request.get('/redirect').expect(200)
+  })
+})


### PR DESCRIPTION
#### Background

- Creates a placeholder page for the `/redirect` route. Page is ready for content to be added.
- Added a browser test
- Deleted unnecessary config mocking

#### Any relevant tickets

Closes #1584 
Closes #1613 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests