### PR TITLE
1522 - Legacy Safari styling fixes

### DIFF
--- a/app/components/ui/PeoplePicker/PodContainer.js
+++ b/app/components/ui/PeoplePicker/PodContainer.js
@@ -73,6 +73,14 @@ const StyledPod = styled(Flex)`
   height: 120px;
 `
 
+// This is needed for legacy safari support
+const ButtonContainer = styled(Flex).attrs({
+  flexDirection: 'column',
+  justifyContent: 'center',
+})`
+  height: 100%;
+`
+
 const PodContainer = ({
   isSelectButtonClickable,
   togglePersonSelection,
@@ -82,7 +90,7 @@ const PodContainer = ({
 }) => (
   <StyledPod justifyContent="space-between">
     {children}
-    <Flex flexDirection="column" justifyContent="center">
+    <ButtonContainer>
       {selectButtonType === 'remove' && (
         <StyledButton
           data-test-id="person-pod-button"
@@ -113,7 +121,7 @@ const PodContainer = ({
           <StyledAddIcon />
         </StyledButton>
       )}
-    </Flex>
+    </ButtonContainer>
   </StyledPod>
 )
 


### PR DESCRIPTION
#### Background

The people picker has a bad ux due to rendering issues in Yosemite/Safari 10.1.2. This PR contains styling fixes to improve some of these issues in preparation for 100% user redirection.

closes #1522