### PR TITLE
Added missing package to yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4447,6 +4447,11 @@ entities@1.1.1, entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
   integrity sha1-blwtClYhtdra7O+AuQ7ftc13cvA=
 
+entities@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
 enzyme-adapter-react-16@^1.1.1, enzyme-adapter-react-16@^1.2.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.5.0.tgz#50af8d76a45fe0915de932bd95d34cdca75c0be3"


### PR DESCRIPTION
Running `yarn` results in a local change to the `yarn.lock` file. This change commits this to the codebase.

This is happening due to #1626 where we introduced `entities@^1.1.2` to the meca package.