### PR TITLE
1528 - ScienceBeam feedback

### DIFF
--- a/server/xpub-controller/helpers/files.js
+++ b/server/xpub-controller/helpers/files.js
@@ -1,5 +1,7 @@
 const logger = require('@pubsweet/logger')
 const FileModel = require('@elifesciences/xpub-model').File
+const SemanticExtractionModel = require('@elifesciences/xpub-model')
+  .SemanticExtraction
 
 class FilesHelper {
   constructor(config, scienceBeamApi) {
@@ -40,10 +42,7 @@ class FilesHelper {
     predictedTime,
     manuscriptId,
   ) {
-    if (
-      manuscriptId.length === 36 &&
-      predictedTime > 0
-    ) {
+    if (manuscriptId.length === 36 && predictedTime > 0) {
       return () => {
         const elapsed = Date.now() - startedTime
         let progress = parseInt((100 * elapsed) / 1000 / predictedTime, 10)
@@ -127,6 +126,14 @@ class FilesHelper {
         filename,
       })
     }
+
+    const semanticExtractionEntity = new SemanticExtractionModel({
+      manuscriptId,
+      fieldName: 'title',
+      value: title,
+    })
+    await semanticExtractionEntity.save()
+
     return title
   }
 

--- a/server/xpub-controller/helpers/files.js
+++ b/server/xpub-controller/helpers/files.js
@@ -127,11 +127,10 @@ class FilesHelper {
       })
     }
 
-    const semanticExtractionEntity = new SemanticExtractionModel({
+    const semanticExtractionEntity = SemanticExtractionModel.createTitleEntity(
       manuscriptId,
-      fieldName: 'title',
-      value: title,
-    })
+      title,
+    )
     await semanticExtractionEntity.save()
 
     return title

--- a/server/xpub-model/entities/semanticExtraction/index.js
+++ b/server/xpub-model/entities/semanticExtraction/index.js
@@ -7,7 +7,7 @@ class AuditLog extends BaseModel {
 
   static get schema() {
     return {
-      required: ['manuscriptId', 'fieldName', 'value'],
+      required: ['manuscriptId', 'fieldName'],
       properties: {
         manuscriptId: { type: 'uuid' },
         fieldName: { type: 'string' },

--- a/server/xpub-model/entities/semanticExtraction/index.js
+++ b/server/xpub-model/entities/semanticExtraction/index.js
@@ -16,6 +16,14 @@ class SemanticExtraction extends BaseModel {
     }
   }
 
+  static createTitleEntity(manuscriptId, value) {
+    return new SemanticExtraction({
+      manuscriptId,
+      fieldName: 'title',
+      value,
+    })
+  }
+
   async delete() {
     throw new Error('Unsupported operation')
   }

--- a/server/xpub-model/entities/semanticExtraction/index.js
+++ b/server/xpub-model/entities/semanticExtraction/index.js
@@ -1,0 +1,24 @@
+const BaseModel = require('@pubsweet/base-model')
+
+class AuditLog extends BaseModel {
+  static get tableName() {
+    return 'semantic_extraction'
+  }
+
+  static get schema() {
+    return {
+      required: ['manuscriptId', 'fieldName', 'value'],
+      properties: {
+        manuscriptId: { type: 'uuid' },
+        fieldName: { type: 'string' },
+        value: { type: 'string' },
+      },
+    }
+  }
+
+  async delete() {
+    throw new Error('Unsupported operation')
+  }
+}
+
+module.exports = AuditLog

--- a/server/xpub-model/entities/semanticExtraction/index.js
+++ b/server/xpub-model/entities/semanticExtraction/index.js
@@ -1,6 +1,6 @@
 const BaseModel = require('@pubsweet/base-model')
 
-class AuditLog extends BaseModel {
+class SemanticExtraction extends BaseModel {
   static get tableName() {
     return 'semantic_extraction'
   }
@@ -21,4 +21,4 @@ class AuditLog extends BaseModel {
   }
 }
 
-module.exports = AuditLog
+module.exports = SemanticExtraction

--- a/server/xpub-model/entities/semanticExtraction/index.test.js
+++ b/server/xpub-model/entities/semanticExtraction/index.test.js
@@ -7,24 +7,37 @@ describe('SemanticExtraction', () => {
     await createTables(true)
   })
 
-  it('should save to the database', async () => {
-    const semanticExtraction = await new SemanticExtraction({
-      manuscriptId: uuid(),
-      fieldName: 'title',
-      value: 'test_title',
-    }).save()
-    expect(semanticExtraction.id).toBeTruthy()
+  describe('save()', () => {
+    it('should save to the database', async () => {
+      const semanticExtraction = await new SemanticExtraction({
+        manuscriptId: uuid(),
+        fieldName: 'title',
+        value: 'test_title',
+      }).save()
+      expect(semanticExtraction.id).toBeTruthy()
+    })
   })
 
-  it('if should throw an unsupported error', async () => {
-    const semanticExtraction = new SemanticExtraction()
-    const error = new Error('Unsupported operation')
-    let response
-    try {
-      response = await semanticExtraction.delete()
-    } catch (err) {
-      response = err
-    }
-    expect(response).toEqual(error)
+  describe('delete()', () => {
+    it('if should throw an unsupported error', async () => {
+      const semanticExtraction = new SemanticExtraction()
+      const error = new Error('Unsupported operation')
+      let response
+      try {
+        response = await semanticExtraction.delete()
+      } catch (err) {
+        response = err
+      }
+      expect(response).toEqual(error)
+    })
+  })
+
+  describe('createTitleEntity', () => {
+    it('return an entity with title filedName when called', () => {
+      const titleExtraction = SemanticExtraction.createTitleEntity(
+        'manuscriptId',
+      )
+      expect(titleExtraction.fieldName).toBe('title')
+    })
   })
 })

--- a/server/xpub-model/entities/semanticExtraction/index.test.js
+++ b/server/xpub-model/entities/semanticExtraction/index.test.js
@@ -1,0 +1,30 @@
+const { createTables } = require('@pubsweet/db-manager')
+const uuid = require('uuid')
+const SemanticExtraction = require('.')
+
+describe('SemanticExtraction', () => {
+  beforeEach(async () => {
+    await createTables(true)
+  })
+
+  it('should save to the database', async () => {
+    const semanticExtraction = await new SemanticExtraction({
+      manuscriptId: uuid(),
+      fieldName: 'title',
+      value: 'test_title',
+    }).save()
+    expect(semanticExtraction.id).toBeTruthy()
+  })
+
+  it('if should throw an unsupported error', async () => {
+    const semanticExtraction = new SemanticExtraction()
+    const error = new Error('Unsupported operation')
+    let response
+    try {
+      response = await semanticExtraction.delete()
+    } catch (err) {
+      response = err
+    }
+    expect(response).toEqual(error)
+  })
+})

--- a/server/xpub-model/index.js
+++ b/server/xpub-model/index.js
@@ -4,6 +4,7 @@ const Manuscript = require('./entities/manuscript')
 const Team = require('./entities/team')
 const User = require('./entities/user')
 const AuditLog = require('./entities/auditLog')
+const SemanticExtraction = require('./entities/semanticExtraction')
 
 module.exports = {
   File,
@@ -11,5 +12,6 @@ module.exports = {
   Manuscript,
   Team,
   User,
-  AuditLog
+  AuditLog,
+  SemanticExtraction,
 }

--- a/server/xpub-model/migrations/1551872573-semantic-extraction.sql
+++ b/server/xpub-model/migrations/1551872573-semantic-extraction.sql
@@ -4,5 +4,5 @@ CREATE TABLE semantic_extraction (
     updated TIMESTAMP WITH TIME ZONE,
     manuscript_id UUID NOT NULL,
     field_name TEXT NOT NULL,
-    value TEXT NOT NULL
+    value TEXT
 );

--- a/server/xpub-model/migrations/1551872573-semantic-extraction.sql
+++ b/server/xpub-model/migrations/1551872573-semantic-extraction.sql
@@ -1,0 +1,7 @@
+CREATE TABLE semantic_extraction (
+    id UUID PRIMARY KEY,
+    created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
+    manuscript_id UUID NOT NULL REFERENCES manuscript,
+    field_name TEXT,
+    value TEXT
+);

--- a/server/xpub-model/migrations/1551872573-semantic-extraction.sql
+++ b/server/xpub-model/migrations/1551872573-semantic-extraction.sql
@@ -1,7 +1,8 @@
 CREATE TABLE semantic_extraction (
     id UUID PRIMARY KEY,
     created TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT current_timestamp,
-    manuscript_id UUID NOT NULL REFERENCES manuscript,
-    field_name TEXT,
-    value TEXT
+    updated TIMESTAMP WITH TIME ZONE,
+    manuscript_id UUID NOT NULL,
+    field_name TEXT NOT NULL,
+    value TEXT NOT NULL
 );


### PR DESCRIPTION
#### Background

Adds a SemanticExtraction model to the app. An instance of this extraction is created and saved when ScienceBeam extracts a manuscripts title. This information will then be used in conjunction with the `Manuscript` title once it has been fully submitted to provide feedback to guide improvments.

#### Any relevant tickets

closes #1528 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

- [x] Unit / Integration tests

