### PR TITLE
Convert publish function to take data not callback

### DIFF
--- a/server/xpub-client/pubsub.js
+++ b/server/xpub-client/pubsub.js
@@ -9,23 +9,23 @@ class PubsubClient {
     this.pubsub = await this.manager.getPubsub()
   }
 
-  publish(message, dataCallback) {
-    this.pubsub.publish(message, dataCallback())
+  publish(message, data) {
+    this.pubsub.publish(message, data)
   }
 
   startPublishingOnInterval(message, dataCallback, interval) {
     this.publishingInterval = setInterval(
-      () => this.pubsub.publish(message, dataCallback()),
+      () => this.publish(message, dataCallback()),
       interval,
     )
   }
 
-  stopPublishingOnInterval(message, dataCallback) {
+  stopPublishingOnInterval(message, data) {
     clearInterval(this.publishingInterval)
     this.publishingInterval = null
 
-    if (message && dataCallback) {
-      this.pubsub.publish(message, dataCallback())
+    if (message && data) {
+      this.publish(message, data)
     }
   }
 }

--- a/server/xpub-client/pubsub.test.js
+++ b/server/xpub-client/pubsub.test.js
@@ -32,7 +32,7 @@ describe('PubsubClient', () => {
       const pubsub = createPubsub(null, mockPubsub)
       await pubsub.initialize()
 
-      pubsub.publish(UPLOAD_MESSAGE, () => mockMessage, 1000)
+      pubsub.publish(UPLOAD_MESSAGE, mockMessage, 1000)
       expect(mockPublish).toHaveBeenCalledTimes(1)
       expect(mockPublish).toBeCalledWith(UPLOAD_MESSAGE, mockMessage)
     })
@@ -112,7 +112,7 @@ describe('PubsubClient', () => {
       await pubsub.initialize()
 
       const startIntervalAndStopWithArguments = (message, data) => {
-        pubsub.startPublishingOnInterval('', () => {}, 1000)
+        pubsub.startPublishingOnInterval('', 'Bar', 1000)
         expect(mockPublish).toHaveBeenCalledTimes(0)
         pubsub.stopPublishingOnInterval(message, data)
       }
@@ -124,7 +124,7 @@ describe('PubsubClient', () => {
       expect(mockPublish).toHaveBeenCalledTimes(0)
 
       // Must be passed both params
-      startIntervalAndStopWithArguments('foo', () => {})
+      startIntervalAndStopWithArguments('foo', 'Bar')
       expect(mockPublish).toHaveBeenCalledTimes(1)
     })
   })


### PR DESCRIPTION
#### Background
Changes the `PubsubClient.publish` to take a second parameter of data rather than a callback function. This makes it more of a proxy to the internal `pubsub` instance and take more intuitive parameters.
 