### PR TITLE
1469 file status virtual attribute

### DIFF
--- a/server/xpub-model/entities/file/index.test.js
+++ b/server/xpub-model/entities/file/index.test.js
@@ -11,6 +11,31 @@ describe('File', () => {
     await createTables(true)
   })
 
+  describe('constructor', () => {
+    it('sets the status to undefined, even with a default within the schema', async () => {
+      const file = new File({
+        manuscriptId: '1',
+        filename: 'thisfile.txt',
+        url: '/an/url',
+      })
+      expect(file.status).toBe(undefined)
+    })
+  })
+
+  describe('save()', () => {
+    it('should set the status to CREATED', async () => {
+      const manuscript = await new Manuscript({
+        createdBy: userId,
+      }).save()
+      const file = await new File({
+        manuscriptId: manuscript.id,
+        filename: 'thisfile.txt',
+        url: '/an/url',
+      }).save()
+      expect(file.status).toBe('CREATED')
+    })
+  })
+
   describe('delete()', () => {
     it('should fail if id is not provided when deleting the file', async () => {
       const file = new File()
@@ -38,17 +63,6 @@ describe('File', () => {
   })
 
   describe('updateStatus()', () => {
-    it('should be initialised in the CREATED state', async () => {
-      const manuscript = await new Manuscript({
-        createdBy: userId,
-      }).save()
-      const file = await new File({
-        manuscriptId: manuscript.id,
-        filename: 'thisfile.txt',
-        url: '/an/url',
-      }).save()
-      expect(file.status).toBe('CREATED')
-    })
     it('sets file status to value passed', async () => {
       const manuscript = await new Manuscript({
         createdBy: userId,

--- a/server/xpub-model/entities/manuscript/index.js
+++ b/server/xpub-model/entities/manuscript/index.js
@@ -103,7 +103,6 @@ class Manuscript extends BaseModel {
         isReady: false
       }
     ]
-    if(this.files.length === 0) return 'READY'
     return this.files
       .map((file) => FILE_STATUSES
         .find(f => (f.uploadStatuses.includes(file.status)))

--- a/server/xpub-model/entities/manuscript/index.js
+++ b/server/xpub-model/entities/manuscript/index.js
@@ -93,21 +93,22 @@ class Manuscript extends BaseModel {
   }
 
   get fileStatus() {
-    const fileStatuses = [
+    const FILE_STATUSES = [
       {
         uploadStatuses: ['STORED', 'CANCELLED'],
-        fileStatus: 'READY'
+        isReady: true
       },
       {
         uploadStatuses: ['UPLOADED', 'CREATED'],
-        fileStatus: 'CHANGING'
+        isReady: false
       }
     ]
     if(this.files.length === 0) return 'READY'
-    const file = this.files[0]
-    return fileStatuses
-      .find(f => (f.uploadStatuses.includes(file.status)))
-      .fileStatus
+    return this.files
+      .map((file) => FILE_STATUSES
+        .find(f => (f.uploadStatuses.includes(file.status)))
+        .isReady)
+      .every(status => status) ? 'READY' : 'CHANGING'
   }
 
   static get statuses() {

--- a/server/xpub-model/entities/manuscript/index.js
+++ b/server/xpub-model/entities/manuscript/index.js
@@ -92,6 +92,14 @@ class Manuscript extends BaseModel {
     }
   }
 
+  static get virtualAttributes() {
+    return ['fileStatus'];
+  }
+
+  fileStatus() {
+    return null
+  }
+
   static get statuses() {
     return {
       INITIAL: 'INITIAL',

--- a/server/xpub-model/entities/manuscript/index.js
+++ b/server/xpub-model/entities/manuscript/index.js
@@ -93,7 +93,7 @@ class Manuscript extends BaseModel {
   }
 
   get fileStatus() {
-    return 'READY'
+    if(this.files.length === 0) return 'READY'
   }
 
   static get statuses() {

--- a/server/xpub-model/entities/manuscript/index.js
+++ b/server/xpub-model/entities/manuscript/index.js
@@ -92,12 +92,8 @@ class Manuscript extends BaseModel {
     }
   }
 
-  static get virtualAttributes() {
-    return ['fileStatus'];
-  }
-
-  fileStatus() {
-    return null
+  get fileStatus() {
+    return 'READY'
   }
 
   static get statuses() {

--- a/server/xpub-model/entities/manuscript/index.js
+++ b/server/xpub-model/entities/manuscript/index.js
@@ -93,7 +93,21 @@ class Manuscript extends BaseModel {
   }
 
   get fileStatus() {
+    const fileStatuses = [
+      {
+        uploadStatuses: ['STORED', 'CANCELLED'],
+        fileStatus: 'READY'
+      },
+      {
+        uploadStatuses: ['UPLOADED', 'CREATED'],
+        fileStatus: 'CHANGING'
+      }
+    ]
     if(this.files.length === 0) return 'READY'
+    const file = this.files[0]
+    return fileStatuses
+      .find(f => (f.uploadStatuses.includes(file.status)))
+      .fileStatus
   }
 
   static get statuses() {

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -579,7 +579,7 @@ const getThreeVersions = async userId => {
 }
 
 const setStatusOfFile = async (file, manuscript, status) => {
-  file.status = status
+  file.status = status // eslint-disable-line no-param-reassign
   await file.save()
   return Manuscript.find(manuscript.id, manuscript.createdBy)
 }

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -151,28 +151,28 @@ describe('Manuscript', () => {
       })
     })
 
-    describe.skip('given there is a single manuscript file', () => {
-      it('returns READY when the file is stored')
-      it('returns READY when the file upload was cancelled')
-      it('returns CHANGING when the file has been uploaded to the app server')
-      it('returns CHANGING when the file has been created in the database')
+    describe('given there is a single manuscript file', () => {
+      it.skip('returns READY when the file is stored', () => {})
+      it.skip('returns READY when the file upload was cancelled', () => {})
+      it.skip('returns CHANGING when the file has been uploaded to the app server', () => {})
+      it.skip('returns CHANGING when the file has been created in the database', () => {})
     })
 
     describe.skip('given there is a manuscript file and a supporting file', () => {
-      it('returns READY when both files are stored')
-      it('returns READY when both files are cancelled')
-      it('returns READY when one file is stored and once is cancelled')
-      it('returns CHANGING when one file has been uploaded to the app server')
-      it('returns CHANGING when one file has been created in the database')
-      it('returns CHANGING when both files have been uploaded to the app server')
-      it('returns CHANGING when both files have been created in the database')
+      it.skip('returns READY when both files are stored', () => {})
+      it.skip('returns READY when both files are cancelled', () => {})
+      it.skip('returns READY when one file is stored and once is cancelled', () => {})
+      it.skip('returns CHANGING when one file has been uploaded to the app server', () => {})
+      it.skip('returns CHANGING when one file has been created in the database', () => {})
+      it.skip('returns CHANGING when both files have been uploaded to the app server', () => {})
+      it.skip('returns CHANGING when both files have been created in the database', () => {})
     })
 
-    describe.skip('given there is a manuscript file and multiple supporting files', () => {
-      it('returns READY when all files are stored')
-      it('returns READY when all files are cancelled')
-      it('returns CHANGING when all files have been uploaded to the app server')
-      it('returns CHANGING when all files have been created in the database')
+    describe('given there is a manuscript file and multiple supporting files', () => {
+      it.skip('returns READY when all files are stored', () => {})
+      it.skip('returns READY when all files are cancelled', () => {})
+      it.skip('returns CHANGING when all files have been uploaded to the app server', () => {})
+      it.skip('returns CHANGING when all files have been created in the database', () => {})
     })
   })
 

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -141,18 +141,18 @@ describe('Manuscript', () => {
   })
 
   describe('get fileStatus()', () => {
-    describe('given there are no files', () => {
+    describe.skip('given there are no files', () => {
       it('returns READY')
     })
 
-    describe('given there is a single manuscript file', () => {
+    describe.skip('given there is a single manuscript file', () => {
       it('returns READY when the file is stored')
       it('returns READY when the file upload was cancelled')
       it('returns CHANGING when the file has been uploaded to the app server')
       it('returns CHANGING when the file has been created in the database')
     })
 
-    describe('given there is a manuscript file and a supporting file', () => {
+    describe.skip('given there is a manuscript file and a supporting file', () => {
       it('returns READY when both files are stored')
       it('returns READY when both files are cancelled')
       it('returns READY when one file is stored and once is cancelled')
@@ -162,7 +162,7 @@ describe('Manuscript', () => {
       it('returns CHANGING when both files have been created in the database')
     })
 
-    describe('given there is a manuscript file and multiple supporting files', () => {
+    describe.skip('given there is a manuscript file and multiple supporting files', () => {
       it('returns READY when all files are stored')
       it('returns READY when all files are cancelled')
       it('returns CHANGING when all files have been uploaded to the app server')

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -161,9 +161,8 @@ describe('Manuscript', () => {
         manuscript = await createInitialManuscript(userId)
         manuscript = await addFileToManuscript(manuscript)
         file = await File.find(manuscript.files[0].id)
-        await file.save()
         setStatusOfFirstFile = setStatusOfFile.bind(null,
-          file.id, manuscript.id, userId
+          file, manuscript
         )
       })
 
@@ -202,10 +201,10 @@ describe('Manuscript', () => {
         )
         expect(file1.id).not.toEqual(file2.id)
         setStatusOfFirstFile = setStatusOfFile.bind(null,
-          file1.id, manuscript.id, userId
+          file1, manuscript
         )
         setStatusOfSecondFile = setStatusOfFile.bind(null,
-          file2.id, manuscript.id, userId
+          file2, manuscript
         )
       })
 
@@ -579,11 +578,10 @@ const getThreeVersions = async userId => {
   return { v1, v2, v3 }
 }
 
-const setStatusOfFile = async (fileId, manuscriptId, userId, status) => {
-  const file = await File.find(fileId)
+const setStatusOfFile = async (file, manuscript, status) => {
   file.status = status
   await file.save()
-  return Manuscript.find(manuscriptId, userId)
+  return Manuscript.find(manuscript.id, manuscript.createdBy)
 }
 
 const addFileToManuscript = async (manuscript) => {

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -213,9 +213,23 @@ describe('Manuscript', () => {
         )
       })
 
-      it.skip('returns READY when both files are stored', () => {})
-      it.skip('returns READY when both files are cancelled', () => {})
-      it.skip('returns READY when one file is stored and once is cancelled', () => {})
+      it('returns READY when both files are stored', async () => {
+        manuscript = await setStatusOfManuscriptFile('STORED')
+        manuscript = await setStatusOfSupportingFile('STORED')
+        expect(manuscript.fileStatus).toEqual('READY')
+      })
+
+      it('returns READY when both files are cancelled', async () => {
+        manuscript = await setStatusOfManuscriptFile('CANCELLED')
+        manuscript = await setStatusOfSupportingFile('CANCELLED')
+        expect(manuscript.fileStatus).toEqual('READY')
+      })
+
+      it('returns READY when one file is stored and once is cancelled', async () => {
+        manuscript = await setStatusOfManuscriptFile('STORED')
+        manuscript = await setStatusOfSupportingFile('CANCELLED')
+        expect(manuscript.fileStatus).toEqual('READY')
+      })
 
       it('returns CHANGING when one file has been uploaded to the app server', async () => {
         manuscript = await setStatusOfManuscriptFile('STORED')
@@ -223,9 +237,23 @@ describe('Manuscript', () => {
         expect(manuscript.fileStatus).toEqual('CHANGING')
       })
 
-      it.skip('returns CHANGING when one file has been created in the database', () => {})
-      it.skip('returns CHANGING when both files have been uploaded to the app server', () => {})
-      it.skip('returns CHANGING when both files have been created in the database', () => {})
+      it('returns CHANGING when one file has been created in the database', async () => {
+        manuscript = await setStatusOfManuscriptFile('STORED')
+        manuscript = await setStatusOfSupportingFile('CREATED')
+        expect(manuscript.fileStatus).toEqual('CHANGING')
+      })
+
+      it('returns CHANGING when both files have been uploaded to the app server', async () => {
+        manuscript = await setStatusOfManuscriptFile('UPLOADED')
+        manuscript = await setStatusOfSupportingFile('UPLOADED')
+        expect(manuscript.fileStatus).toEqual('CHANGING')
+      })
+
+      it('returns CHANGING when both files have been created in the database', async () => {
+        manuscript = await setStatusOfManuscriptFile('CREATED')
+        manuscript = await setStatusOfSupportingFile('CREATED')
+        expect(manuscript.fileStatus).toEqual('CHANGING')
+      })
     })
 
     describe('given there is a manuscript file and multiple supporting files', () => {

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -158,7 +158,8 @@ describe('Manuscript', () => {
       let setStatusOfFirstFile
 
       beforeEach(async () => {
-        manuscript = await createManuscriptWithOneFile(userId)
+        manuscript = await createInitialManuscript(userId)
+        manuscript = await addFileToManuscript(manuscript)
         file = await File.find(manuscript.files[0].id)
         await file.save()
         setStatusOfFirstFile = setStatusOfFile.bind(null,
@@ -193,7 +194,9 @@ describe('Manuscript', () => {
       let setStatusOfFirstFile, setStatusOfSecondFile
 
       beforeEach(async () => {
-        manuscript = await createManuscriptWithTwoFiles(userId);
+        manuscript = await createInitialManuscript(userId)
+        manuscript = await addFileToManuscript(manuscript)
+        manuscript = await addFileToManuscript(manuscript);
         [ file1, file2 ] = await Promise.all(
           manuscript.files.map(({ id }) => File.find(id))
         )
@@ -583,8 +586,7 @@ const setStatusOfFile = async (fileId, manuscriptId, userId, status) => {
   return Manuscript.find(manuscriptId, userId)
 }
 
-const createManuscriptWithOneFile = async (userId) => {
-  let manuscript = await createInitialManuscript(userId)
+const addFileToManuscript = async (manuscript) => {
   const file = new File({
     manuscriptId: manuscript.id,
     filename: 'test.txt',
@@ -592,28 +594,7 @@ const createManuscriptWithOneFile = async (userId) => {
     type: 'test_file',
   })
   await file.save()
-  manuscript = await Manuscript.find(manuscript.id, userId)
-  return manuscript
-}
-
-const createManuscriptWithTwoFiles = async (userId) => {
-  let manuscript = await createInitialManuscript(userId)
-  const file1 = new File({
-    manuscriptId: manuscript.id,
-    filename: 'test1.txt',
-    url: '-',
-    type: 'test_file',
-  })
-  const file2 = new File({
-    manuscriptId: manuscript.id,
-    filename: 'test2.txt',
-    url: '-',
-    type: 'test_file',
-  })
-  await file1.save()
-  await file2.save()
-  manuscript = await Manuscript.find(manuscript.id, userId)
-  return manuscript
+  return Manuscript.find(manuscript.id, manuscript.createdBy)
 }
 
 const createInitialManuscript = async (userId, title = 'Alpha') => {

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -140,6 +140,13 @@ describe('Manuscript', () => {
     })
   })
 
+  describe('fileStatus()', () => {
+    it('is a virtual attribute', () => {
+      const manuscript = new Manuscript({})
+      expect(manuscript).toHaveProperty(fileStatus)
+    })
+  })
+
   describe('addTeam()', () => {
     it('adds team', () => {
       const team = {

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -141,8 +141,14 @@ describe('Manuscript', () => {
   })
 
   describe('get fileStatus()', () => {
-    describe.skip('given there are no files', () => {
-      it('returns READY')
+    describe('given there are no files', () => {
+      it('returns READY', () => {
+        const manuscript = new Manuscript({
+          createdBy: userId,
+        })
+        manuscript.files = []
+        expect(manuscript.fileStatus).toEqual('READY')
+      })
     })
 
     describe.skip('given there is a single manuscript file', () => {

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -141,12 +141,32 @@ describe('Manuscript', () => {
   })
 
   describe('get fileStatus()', () => {
-    it('can be saved', async () => {
-      const manuscript = new Manuscript({
-        createdBy: userId,
-      })
-      expect(manuscript.fileStatus).toBe('READY')
-      await manuscript.save()
+    describe('given there are no files', () => {
+      it('returns READY')
+    })
+
+    describe('given there is a single manuscript file', () => {
+      it('returns READY when the file is stored')
+      it('returns READY when the file upload was cancelled')
+      it('returns CHANGING when the file has been uploaded to the app server')
+      it('returns CHANGING when the file has been created in the database')
+    })
+
+    describe('given there is a manuscript file and a supporting file', () => {
+      it('returns READY when both files are stored')
+      it('returns READY when both files are cancelled')
+      it('returns READY when one file is stored and once is cancelled')
+      it('returns CHANGING when one file has been uploaded to the app server')
+      it('returns CHANGING when one file has been created in the database')
+      it('returns CHANGING when both files have been uploaded to the app server')
+      it('returns CHANGING when both files have been created in the database')
+    })
+
+    describe('given there is a manuscript file and multiple supporting files', () => {
+      it('returns READY when all files are stored')
+      it('returns READY when all files are cancelled')
+      it('returns CHANGING when all files have been uploaded to the app server')
+      it('returns CHANGING when all files have been created in the database')
     })
   })
 

--- a/server/xpub-model/entities/manuscript/index.test.js
+++ b/server/xpub-model/entities/manuscript/index.test.js
@@ -140,10 +140,13 @@ describe('Manuscript', () => {
     })
   })
 
-  describe('fileStatus()', () => {
-    it('is a virtual attribute', () => {
-      const manuscript = new Manuscript({})
-      expect(manuscript).toHaveProperty(fileStatus)
+  describe('get fileStatus()', () => {
+    it('can be saved', async () => {
+      const manuscript = new Manuscript({
+        createdBy: userId,
+      })
+      expect(manuscript.fileStatus).toBe('READY')
+      await manuscript.save()
     })
   })
 

--- a/server/xpub-model/model.test.js
+++ b/server/xpub-model/model.test.js
@@ -5,7 +5,7 @@ const File = require('./entities/file')
 
 describe('creating getters still allows models to be saved', () => {
   class ModelWithGetter extends Manuscript {
-    get someGetter() {
+    get someGetter() { // eslint-disable-line class-methods-use-this
       return true
     }
   }

--- a/server/xpub-model/model.test.js
+++ b/server/xpub-model/model.test.js
@@ -3,6 +3,29 @@ const uuid = require('uuid')
 const Manuscript = require('./entities/manuscript')
 const File = require('./entities/file')
 
+describe('creating getters still allows models to be saved', () => {
+  class ModelWithGetter extends Manuscript {
+    get someGetter() {
+      return true
+    }
+  }
+
+  let userId
+
+  beforeEach(async () => {
+    userId = uuid()
+    await createTables(true)
+  })
+
+  it('should save successfully', async () => {
+    const instance = new ModelWithGetter({
+      createdBy: userId,
+    })
+    await instance.save()
+    expect(instance.someGetter).toBe(true)
+  })
+})
+
 describe('related objects behave as we expect', () => {
   let userId
 


### PR DESCRIPTION
#### Background

Adds `manuscript.fileStatus`.

This is implemented as a getter, which can be called by referencing the `manuscript.fileStatus` property.

#### Any relevant tickets

Closes #1469 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests