### PR TITLE
Ignoring folders slowing down eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,7 @@
 _build
+_build_styleguide
+.github
+migrations-*
 coverage
 node_modules
 assets


### PR DESCRIPTION
The following folders have been slowing down eslint locally, specifically the `_build_styleguide` folder.

This change ignores them from the linting tasks.