### PR TITLE
Adding validation for fileStatus on client side

### DIFF
--- a/app/components/pages/SubmissionWizard/SubmissionOperations.js
+++ b/app/components/pages/SubmissionWizard/SubmissionOperations.js
@@ -25,6 +25,7 @@ function runMutation(formValues, mutation, { refetchQueries = [] } = {}) {
     'teams',
     'status',
     'clientStatus',
+    'fileStatus',
     'lastStepVisited',
   ]
 

--- a/app/components/pages/SubmissionWizard/operations.js
+++ b/app/components/pages/SubmissionWizard/operations.js
@@ -65,6 +65,7 @@ const manuscriptFragment = gql`
     cosubmission
     submitterSignature
     disclosureConsent
+    fileStatus
   }
   ${editorFragment}
   ${reviewerFragment}

--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -39,6 +39,7 @@ const UPLOAD_SUPPORTING_MUTATION = gql`
         status
         id
       }
+      fileStatus
     }
   }
 `
@@ -211,13 +212,20 @@ const FilesPageContainer = ({
                             })
                           }
                           uploadFile={file =>
-                            new Promise((resolve, reject) =>
-                              uploadSupportFiles({
+                            new Promise((resolve, reject) => {
+                              setFieldValue('fileStatus', 'CHANGING')
+                              return uploadSupportFiles({
                                 variables: { file, id: values.id },
                               })
-                                .then(data => resolve(data))
-                                .catch(err => reject(err)),
-                            )
+                                .then(data => {
+                                  setFieldValue(
+                                    'fileStatus',
+                                    data.data.uploadSupportingFile.fileStatus,
+                                  )
+                                  resolve(data)
+                                })
+                                .catch(err => reject(err))
+                            })
                           }
                         />
                       )}

--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -233,7 +233,11 @@ const FilesPageContainer = ({
                   )}
                 </Mutation>
               </Box>
-              <ValidatedField name="fileStatus" type="hidden" />
+              <ValidatedField
+                name="fileStatus"
+                type="hidden"
+                data-test-id="ongoing-upload-error"
+              />
             </React.Fragment>
           )}
         </Mutation>

--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -21,6 +21,7 @@ const UPLOAD_MANUSCRIPT_MUTATION = gql`
         status
         id
       }
+      fileStatus
     }
   }
 `
@@ -104,6 +105,7 @@ export const onFileDrop = (
     )
 
   formFunctions.setFieldTouched('files', true, false)
+  formFunctions.setFieldValue('fileStatus', 'CHANGING')
   if (files.length > 1) {
     validationError(errorMessageMapping.MULTIPLE)
     return
@@ -118,6 +120,7 @@ export const onFileDrop = (
   }).then(({ data }) => {
     formFunctions.setFieldValue('meta.title', data.uploadManuscript.meta.title)
     formFunctions.setFieldValue('files', data.uploadManuscript.files)
+    formFunctions.setFieldValue('fileStatus', data.uploadManuscript.fileStatus)
   })
 }
 
@@ -222,11 +225,7 @@ const FilesPageContainer = ({
                   )}
                 </Mutation>
               </Box>
-              <ValidatedField
-                name="files.fileStatus"
-                type="hidden"
-                value="READY"
-              />
+              <ValidatedField name="fileStatus" type="hidden" />
             </React.Fragment>
           )}
         </Mutation>

--- a/app/components/pages/SubmissionWizard/steps/Files/index.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/index.js
@@ -222,6 +222,11 @@ const FilesPageContainer = ({
                   )}
                 </Mutation>
               </Box>
+              <ValidatedField
+                name="files.fileStatus"
+                type="hidden"
+                value="READY"
+              />
             </React.Fragment>
           )}
         </Mutation>

--- a/app/components/pages/SubmissionWizard/steps/Files/schema.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/schema.js
@@ -18,6 +18,10 @@ const schema = yup.object().shape({
       value => stripHtml(value).split(/\s+/).length > MIN_WORDS,
     ),
   files: yup.array().min(1, errorMessageMapping.EMPTY),
+  fileStatus: yup
+    .string()
+    .required()
+    .oneOf(['READY'], 'There is some uploads on going, wait while they finish'),
 })
 
 export { schema }

--- a/app/components/pages/SubmissionWizard/steps/Files/schema.js
+++ b/app/components/pages/SubmissionWizard/steps/Files/schema.js
@@ -21,7 +21,7 @@ const schema = yup.object().shape({
   fileStatus: yup
     .string()
     .required()
-    .oneOf(['READY'], 'There is some uploads on going, wait while they finish'),
+    .oneOf(['READY'], 'Please wait until all files have uploaded.'),
 })
 
 export { schema }

--- a/test/multiFileUpload.browser.js
+++ b/test/multiFileUpload.browser.js
@@ -1,0 +1,52 @@
+import config from 'config'
+import startSshServer from '@elifesciences/xpub-meca-export/test/mock-sftp-server'
+import { profile, files } from './pageObjects'
+import setFixtureHooks from './helpers/set-fixture-hooks'
+import NavigationHelper from './helpers/navigationHelper'
+
+const f = fixture('MultiFile Upload')
+setFixtureHooks(f)
+
+const manuscript = {
+  title: 'The Relationship Between Lamport Clocks and Interrupts Using Obi',
+  file: './fixtures/dummy-manuscript-2.pdf',
+  supportingFiles: [
+    './fixtures/dummy-supporting-1.pdf',
+    './fixtures/dummy-supporting-2.docx',
+    './fixtures/dummy-supporting-2.docx',
+    './fixtures/dummy-supporting-2.docx',
+    './fixtures/dummy-supporting-2.docx',
+    './fixtures/dummy-supporting-2.docx',
+    './fixtures/dummy-supporting-2.docx',
+    './fixtures/dummy-supporting-2.docx',
+  ],
+}
+
+test('should display an error when files are still uploading', async t => {
+  const { server } = await startSshServer(
+    config.get('meca.sftp.connectionOptions.port'),
+  )
+
+  const navigationHelper = new NavigationHelper(t)
+
+  navigationHelper.login()
+
+  await t.expect(profile.name, { 'data-hj-suppress': '' }).ok()
+  navigationHelper.newSubmission()
+
+  // author's page
+  navigationHelper.preFillAuthorDetailsWithOrcid()
+  navigationHelper.setAuthorEmail('example@example.org')
+  navigationHelper.navigateForward()
+
+  // files' page
+  navigationHelper.fillCoverletter('\nPlease consider this for publication')
+  navigationHelper.uploadManuscript(manuscript)
+  navigationHelper.uploadSupportingFiles(manuscript.supportingFiles)
+  navigationHelper.navigateForward()
+  await t.expect(files.ongoingFileUploadError.count).eql(1)
+
+  await new Promise((resolve, reject) =>
+    server.close(err => (err ? reject(err) : resolve())),
+  )
+})

--- a/test/pageObjects/files.js
+++ b/test/pageObjects/files.js
@@ -13,6 +13,7 @@ const files = {
   supportingFileError: Selector('[data-test-id=file-block-error]'),
   fileName: Selector('[data-test-id=fileName]'),
   dropzoneMessage: Selector('[data-test-id=dropzoneMessage]'),
+  ongoingFileUploadError: Selector('[data-test-id=ongoing-upload-error]'),
 }
 
 export default files


### PR DESCRIPTION
#### Background
whereas there are files  ongoing uploading,  a bug has been detected that allows the user to navigate to the next page, 

What does this PR do?
adds validation on the Schema to avoid the navigation in case the upload is still ongoing, based on virtual field fileStatus see #1469 
Closes #1669 

depends on #1469
- [x] Browser tests

pending task:

- [x] block the navigation depending on the field fileStatus
- [x] display the validation error
- [x] integrate with #1469 
 