### PR TITLE
Refactored export failure tests

### DIFF
--- a/server/xpub-server/entities/manuscript/resolvers/submitManuscript.js
+++ b/server/xpub-server/entities/manuscript/resolvers/submitManuscript.js
@@ -40,7 +40,7 @@ async function submitManuscript(_, { data }, { user, ip }) {
     Manuscript.statuses.MECA_EXPORT_PENDING,
   )
 
-  mecaExport(manuscript, S3Storage.getContent, ip)
+  await mecaExport(manuscript, S3Storage.getContent, ip)
     .then(() => {
       logger.info(`Manuscript ${manuscript.id} successfully exported`)
       return Manuscript.updateStatus(


### PR DESCRIPTION
Split up the export failure email test within the resolvers, since the email test code was mixed together with other assertions against the model and the logger.

This change makes it easier to write a new test involving emails, which will help to address https://github.com/elifesciences/elife-xpub/pull/1674#discussion_r265626280