### PR TITLE
1471- Throw error if fileStatus is not READY when submitting

### DIFF
--- a/server/xpub-server/entities/manuscript/resolvers/submitManuscript.js
+++ b/server/xpub-server/entities/manuscript/resolvers/submitManuscript.js
@@ -35,6 +35,13 @@ async function submitManuscript(_, { data }, { user, ip }) {
   }
 
   await manuscript.save()
+
+  if (manuscript.fileStatus !== 'READY') {
+    throw new Error('Manuscript fileStatus is CHANGING', {
+      manuscriptId: manuscript.id,
+    })
+  }
+
   manuscript = await Manuscript.updateStatus(
     manuscript.id,
     Manuscript.statuses.MECA_EXPORT_PENDING,


### PR DESCRIPTION
#### Background

Checks the new `fileStatus` property on the manuscript entity when submitting a manuscript. This should throw an error and prevent the meca export process from starting if there are any files that are not `READY` or `CANCELLED`

#### Any relevant tickets

closes #1471

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
