### PR TITLE
[WIP] Update green 'Login with Orcid' screen with new designs

### DIFF
--- a/app/components/pages/LandingRedirect/LandingRedirect.js
+++ b/app/components/pages/LandingRedirect/LandingRedirect.js
@@ -1,20 +1,12 @@
 import React from 'react'
-import styled from 'styled-components'
 import { Box } from '@rebass/grid'
 import { H1 } from '@pubsweet/ui'
 import Paragraph from 'ui/atoms/Paragraph'
 import ButtonLink from 'ui/atoms/ButtonLink'
 import FooterText from 'ui/atoms/FooterText'
 import NativeLink from 'ui/atoms/NativeLink'
+import ImageBlock from 'ui/atoms/ImageBlock'
 import { RedirectLayout, TwoColumnLayout } from '../../global'
-
-const ImageBlock = styled(Box)`
-  width:75%
-  height: 100%;
-  background-image: url("/assets/redirect.png");
-  background-size: cover;
-  background-position: center;
-`
 
 const LandingRedirect = () => (
   <RedirectLayout>
@@ -40,7 +32,7 @@ const LandingRedirect = () => (
           continue
         </ButtonLink>
       </Box>
-      <ImageBlock ml="auto" />
+      <ImageBlock ml="auto" image="/assets/redirect.png" />
     </TwoColumnLayout>
     <FooterText onlyCenterDesktop>
       Read our{' '}

--- a/app/components/ui/atoms/ImageBlock.js
+++ b/app/components/ui/atoms/ImageBlock.js
@@ -1,0 +1,15 @@
+import { Box } from '@rebass/grid'
+import styled, { css } from 'styled-components'
+
+const ImageBlock = styled(Box)`
+  width:75%
+  height: 100%;
+  ${props =>
+    css`
+      background-image: url(${props.image});
+    `}
+  background-size: cover;
+  background-position: center;
+`
+
+export default ImageBlock

--- a/app/components/ui/atoms/ImageBlock.md
+++ b/app/components/ui/atoms/ImageBlock.md
@@ -1,0 +1,13 @@
+Image block to display the images
+
+### Redirect page image
+
+```js
+<ImageBlock ml="auto" image="/assets/redirect.png" />
+```
+
+### Welcome page image
+
+```js
+<ImageBlock ml="auto" image="/assets/welcome.png" />
+```

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -66,4 +66,5 @@ module.exports = {
   },
   styleguideDir: '_build_styleguide',
   skipComponentsWithoutExample: true,
+  assetsDir: 'assets',
 }


### PR DESCRIPTION
#### Background
There are new designs for login and redirect pages
![image](https://user-images.githubusercontent.com/32770804/54530420-a08ddc00-497a-11e9-8d50-7aa09bce17bb.png)

### Dev requirements
- [x] Create a new ImageBlock atom to hold all the images
- [x] Add necessary updates to styleguide
- [ ] Create FooterPrivicy molecule to be reused in all similar instances.
- [ ] Investigate why assets are not working in styleguide

### Product requirements
- [x] Repurpose the current 'green' version of the login screen to include the updated text
- [ ] Add new grid layout
- [ ] Add new image asset
- [ ] Include internal and external links
- [x] 'author guide' is an internal link to https://reviewer.elifesciences.org/author-guide
- [ ] 'Terms and conditions' is an external link to https://elifesciences.org/terms
- [ ] 'Privacy policy' is an external link to https://elifesciences.org/privacy
- [ ] Request review against designs

#### Any relevant tickets

Closes #1575 

Design: https://app.zeplin.io/project/5bacf042615a8b6e20e84a5f/screen/5c742bfd30283132e874a726

#### How has this been tested?

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests
