### PR TITLE
[WIP] Add wrapper script

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,7 @@ services:
   app:
     build:
       dockerfile: ./Dockerfile-development
-    command: sh -c "yarn install --frozen-lockfile && ./scripts/wait-for-it.sh postgres:5432 -s -t 40 -- npx pubsweet server"
+      command: ["./scripts/server-start.sh"]
     volumes:
       - ./:/home/xpub
     depends_on:

--- a/scripts/server-start.sh
+++ b/scripts/server-start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# wrapper script for wait-for-it.sh and pubsweet server
+
+pid=0
+
+sigterm_handler () {
+  if [ $pid -ne 0 ]; then
+    kill -SIGTERM "$pid"
+    wait "$pid"
+  fi
+  exit 143;
+}
+
+trap 'kill ${!}; sigterm_handler' SIGTERM
+
+./scripts/wait-for-it.sh postgres:5432 -s -t 40
+
+npx pubsweet server &
+pid="$!"
+
+while true
+do
+  tail -f /dev/null & wait ${!}
+done

--- a/server/xpub-model/entities/auditLog/index.js
+++ b/server/xpub-model/entities/auditLog/index.js
@@ -12,7 +12,7 @@ class AuditLog extends BaseModel {
         userId: { type: 'uuid' }, // Currently not used
         action: {
           type: 'string',
-          enum: ['CREATED', 'UPDATED', 'DELETED', 'MECA_RESULT'],
+          enum: ['CREATED', 'UPDATED', 'DELETED', 'MECA_RESULT', 'APPLICATION'],
         },
         value: { type: ['string', 'null'] },
         objectId: { type: 'uuid' },

--- a/server/xpub-model/migrations/1552580166-app-audit.sql
+++ b/server/xpub-model/migrations/1552580166-app-audit.sql
@@ -1,0 +1,4 @@
+ALTER TYPE auditaction RENAME TO auditaction_old;
+CREATE TYPE auditaction AS ENUM( 'CREATED', 'UPDATED', 'DELETED', 'MECA_RESULT', 'APPLICATION' );
+ALTER TABLE audit_log ALTER COLUMN action TYPE auditaction USING action::text::auditaction;
+DROP TYPE auditaction_old;

--- a/server/xpub-server/cleanup.js
+++ b/server/xpub-server/cleanup.js
@@ -1,35 +1,65 @@
-// https://stackoverflow.com/a/21947851
-//
-// Object to capture target exits and call app specific cleanup function
+const nodeCleanup = require('node-cleanup')
 
 const noOp = () => {}
 
-exports.Cleanup = function Cleanup(target, logger, cb) {
-  // attach user callback to the target event emitter
-  // if no callback, it will still exit gracefully on Ctrl-C
+const CleanupUnwrapped = (exitCode, signal, target, logger, cb) => {
   const callback = cb || noOp
-  target.on('cleanup', callback)
-
-  // do app specific cleaning before exiting
-  target.on('exit', () => {
-    target.emit('cleanup')
+  target.on('cleanup', () => {
+    // the return value of the callback can return a function that is async
+    // taking a callback function with will kill the target
+    const ret = callback()
+    if (ret) {
+      ret(() => target.kill(target.pid, signal))
+    }
   })
 
-  // catch ctrl+c event and exit normally
-  target.on('SIGINT', () => {
-    logger.info('Ctrl-C...')
-    target.exit(2)
-  })
-
-  target.on('SIGTERM', () => {
-    logger.info('SIGTERM...')
-    target.exit(3)
-  })
-
-  // catch uncaught exceptions, trace, then exit normally
+  // uncaughtException gets handled here so we have access to the exception
+  // itself.
   target.on('uncaughtException', e => {
     logger.error('Uncaught Exception...')
     logger.error(e.stack)
-    target.exit(9)
+    target.emit('cleanup')
+    target.exit(exitCode)
   })
+
+  const killProcess = false
+
+  if (signal) {
+    switch (signal) {
+      case 'uncaughtException': {
+        // Overridden else where!
+        break
+      }
+      case 'SIGINT': {
+        logger.info('Ctrl-C...')
+        target.emit('cleanup')
+        target.exit(exitCode)
+        break
+      }
+      case 'SIGTERM': {
+        logger.info('SIGTERM...')
+        target.emit('cleanup')
+        break
+      }
+      case 'exit': {
+        target.emit('cleanup')
+        break
+      }
+      default:
+        break
+    }
+
+    nodeCleanup.uninstall() // don't call cleanup handler again
+  }
+  return killProcess
+}
+
+const Cleanup = (target, logger, cb) =>
+  nodeCleanup((exitCode, signal) =>
+    CleanupUnwrapped(exitCode, signal, target, logger, cb),
+  )
+
+module.exports = {
+  Cleanup,
+  CleanupUnwrapped,
 }

--- a/server/xpub-server/cleanup.test.js
+++ b/server/xpub-server/cleanup.test.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events')
-const cleanup = require('./cleanup')
+const cleanup = require('./cleanup').CleanupUnwrapped
 
 // eslint-disable-next-line no-unused-vars
 
@@ -21,47 +21,78 @@ describe('handle exiting', () => {
   let process
   let logger
   let stopServer
+  let asyncFnCalled
 
   beforeEach(() => {
+    asyncFnCalled = false
     stopServer = jest.fn()
     logger = {
       info: jest.fn(),
       error: jest.fn(),
     }
     process = new DummyProcess()
-    cleanupHandler = cleanup.Cleanup(process, logger, stopServer)
+    process.kill = jest.fn()
   })
 
   it('exit calls stopServer', () => {
-    process.emit('exit')
+    cleanupHandler = cleanup(1, 'exit', process, logger, stopServer)
     expect(stopServer).toHaveBeenCalledTimes(1)
   })
 
   it('SIGINT exits as expected', () => {
-    process.emit('SIGINT')
+    cleanupHandler = cleanup(2, 'SIGINT', process, logger, stopServer)
     expect(process.exitValue).toBe(2)
     expect(stopServer).toHaveBeenCalledTimes(1)
     expect(logger.info).toHaveBeenCalledTimes(1)
     expect(logger.error).toHaveBeenCalledTimes(0)
+    expect(process.kill).toHaveBeenCalledTimes(0)
   })
 
-  it('SIGTERM exits as expected', () => {
-    process.emit('SIGTERM')
-    expect(process.exitValue).toBe(3)
+  it('SIGTERM does not exit as expected', () => {
+    cleanupHandler = cleanup(3, 'SIGTERM', process, logger, stopServer)
+    expect(process.exitValue).toBeNull()
     expect(stopServer).toHaveBeenCalledTimes(1)
     expect(logger.info).toHaveBeenCalledTimes(1)
     expect(logger.error).toHaveBeenCalledTimes(0)
+    expect(process.kill).toHaveBeenCalledTimes(0)
   })
 
   it('uncaughtException exits as expected', () => {
+    cleanupHandler = cleanup(
+      9,
+      'uncaughtException',
+      process,
+      logger,
+      stopServer,
+    )
     process.emit('uncaughtException', { stack: 'divide by zero' })
     expect(process.exitValue).toBe(9)
     expect(stopServer).toHaveBeenCalledTimes(1)
     expect(logger.info).toHaveBeenCalledTimes(0)
     expect(logger.error).toHaveBeenCalledTimes(2)
+    expect(process.kill).toHaveBeenCalledTimes(0)
     expect(logger.error.mock.calls).toEqual([
       ['Uncaught Exception...'],
       ['divide by zero'],
     ])
+  })
+
+  const timeout = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+  const someAsyncTask = async () => {
+    await timeout(200)
+    asyncFnCalled = true
+  }
+
+  it('SIGTERM kills the process after async task', done => {
+    const asyncFn = async cb => {
+      await someAsyncTask()
+      cb() // invoke callback to kill the task
+      expect(process.kill).toHaveBeenCalledTimes(1)
+      expect(asyncFnCalled).toBe(true)
+      done() // tell jest we are done
+    }
+    stopServer = () => asyncFn
+    cleanupHandler = cleanup(3, 'SIGTERM', process, logger, stopServer)
   })
 })

--- a/server/xpub-server/package.json
+++ b/server/xpub-server/package.json
@@ -17,6 +17,7 @@
     "joi": "^13.6.0",
     "jsonwebtoken": "^8.3.0",
     "lodash": "^4.17.5",
+    "node-cleanup": "^2.1.2",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "uuid": "^3.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9520,6 +9520,11 @@ nocache@2.0.0:
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.0.0.tgz#202b48021a0c4cbde2df80de15a17443c8b43980"
   integrity sha1-ICtIAhoMTL3i34DeFaF0Q8i0OYA=
 
+node-cleanup@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
+  integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
+
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"


### PR DESCRIPTION
#### Background

Adds a wrapper script around wait-for-it.sh and the pubsweet start command so that termination signals are handled in a container environment and can be sent to the pubsweet node process.

#### Any relevant tickets

closes #1724 

#### How has this been tested?

Tests need to be done manually, checking that entry for stopping application is present in the audit log when running `docker-compose down` or `docker-compose kill -s SIGTERM app`