### PR TITLE
[ON HOLD] Added server-start.sh wrapper scripts to allow for graceful termination

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,7 +4,7 @@ services:
   app:
     build:
       dockerfile: ./Dockerfile-development
-    command: sh -c "yarn install --frozen-lockfile && ./scripts/wait-for-it.sh postgres:5432 -s -t 40 -- npx pubsweet server"
+      command: ["./scripts/server-start.sh"]
     volumes:
       - ./:/home/xpub
     depends_on:

--- a/scripts/server-start.sh
+++ b/scripts/server-start.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# wrapper script for wait-for-it.sh and pubsweet server
+
+pid=0
+
+sigterm_handler () {
+  if [ $pid -ne 0 ]; then
+    kill -SIGTERM "$pid"
+    wait "$pid"
+  fi
+  exit 143;
+}
+
+trap 'kill ${!}; sigterm_handler' SIGTERM
+
+./scripts/wait-for-it.sh postgres:5432 -s -t 40
+
+npx pubsweet server &
+pid="$!"
+
+while true
+do
+  tail -f /dev/null & wait ${!}
+done


### PR DESCRIPTION
#### Background
Adds a wrapper script around wait-for-it.sh and the pubsweet start command so that termination signals are handled in a container environment and can be sent to the pubsweet node process.

#### Any relevant tickets
closes #1724

#### How has this been tested?
Tests need to be done manually, checking that entry for stopping application is present in the audit log when running docker-compose down or docker-compose kill -s SIGTERM app
