### PR TITLE
Remove collectCoverageFrom to stop errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,6 @@
   },
   "jest": {
     "collectCoverage": true,
-    "collectCoverageFrom": [
-      "<rootDir>/{client,app,server,packages}/**/*.js",
-      "!**/*.{config,test}.js",
-      "!**/jest*.js"
-    ],
     "coverageThreshold": {
       "global": {
         "branches": 60,


### PR DESCRIPTION
#### Background

Stops the errors when running tests with coverage.


#### How has this been tested?

Locally and visually looks sound.