### PR TITLE
move logger into logger package and add email filtering.

### DIFF
--- a/config/end2end.js
+++ b/config/end2end.js
@@ -1,10 +1,10 @@
-const logger = require('./non-serializable/logger')
+const { mockLogger } = require('@elifesciences/component-logger')
 
-logger.transports.console.level = 'debug'
+mockLogger.transports.console.level = 'debug'
 
 module.exports = {
   'pubsweet-server': {
-    logger,
+    mockLogger,
   },
   server: {
     api: {

--- a/config/prod.js
+++ b/config/prod.js
@@ -1,4 +1,4 @@
-const logger = require('./non-serializable/logger')
+const { logger } = require('@elifesciences/component-logger')
 
 module.exports = {
   'pubsweet-server': {
@@ -16,8 +16,8 @@ module.exports = {
   meca: {
     email: {
       recipient: 'xpub-tech-alerts@elifesciences.org',
-      subjectPrefix: '[Production] '
-    }
+      subjectPrefix: '[Production] ',
+    },
   },
   mailer: {
     from: 'editorial@elifesciences.org',

--- a/config/staging.js
+++ b/config/staging.js
@@ -1,4 +1,4 @@
-const logger = require('./non-serializable/logger')
+const { logger } = require('@elifesciences/component-logger')
 
 module.exports = {
   'pubsweet-server': {
@@ -20,8 +20,8 @@ module.exports = {
   meca: {
     email: {
       recipient: 'xpub-tech-alerts@elifesciences.org',
-      subjectPrefix: '[Staging] '
-    }
+      subjectPrefix: '[Staging] ',
+    },
   },
   aws: {
     s3: {

--- a/config/test.js
+++ b/config/test.js
@@ -1,6 +1,6 @@
 const { deferConfig } = require('config/defer')
 const AWS = require('aws-sdk')
-const logger = require('./non-serializable/mock-logger')
+const { mockLogger } = require('@elifesciences/component-logger')
 
 module.exports = {
   'pubsweet-server': {
@@ -14,7 +14,7 @@ module.exports = {
     ),
     uploads: 'test/temp/uploads',
     secret: 'test',
-    logger,
+    mockLogger,
   },
   login: {
     url: '/mock-token-exchange/ewwboc7m',
@@ -52,7 +52,7 @@ module.exports = {
     apiKey: 'abcd1234',
     email: {
       recipient: 'test@example.com',
-    }
+    },
   },
   mailer: {
     transport: {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
       "<rootDir>/packages/component-dashboard/config/jest.config.client.js",
       "<rootDir>/packages/component-login/config/jest.config.client.js",
       "<rootDir>/packages/component-meca/config/jest.config.server.js",
+      "<rootDir>/packages/component-logger/config/jest.config.server.js",
       "<rootDir>/packages/component-model/config/jest.config.server.js",
       "<rootDir>/packages/component-model-audit-log/config/jest.config.server.js",
       "<rootDir>/packages/component-model-manuscript/config/jest.config.server.js",

--- a/packages/component-logger/config/jest.config.server.js
+++ b/packages/component-logger/config/jest.config.server.js
@@ -1,0 +1,8 @@
+module.exports = {
+  displayName: 'component-logger',
+  rootDir: '../',
+  testMatch: ['<rootDir>/server/**/*.test.js'],
+  transform: {}, // turn off babel for server code
+  transformIgnorePatterns: ['/node_modules/(?!@?pubsweet)'],
+  testEnvironment: 'node',
+}

--- a/packages/component-logger/index.js
+++ b/packages/component-logger/index.js
@@ -1,0 +1,7 @@
+const logger = require('./server/logger')
+const mockLocker = require('./server/mock-logger')
+
+module.exports = {
+  logger,
+  mockLocker,
+}

--- a/packages/component-logger/package.json
+++ b/packages/component-logger/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@elifesciences/component-logger",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/packages/component-logger/server/filters/emailFilter.js
+++ b/packages/component-logger/server/filters/emailFilter.js
@@ -1,0 +1,5 @@
+function emailFilter(level, msg) {
+  return msg.replace(/[^\s@]+@[^@,"]+\.[^\s@,"]+/g, '***@***.***')
+}
+
+module.exports = emailFilter

--- a/packages/component-logger/server/filters/emailFilter.test.js
+++ b/packages/component-logger/server/filters/emailFilter.test.js
@@ -1,0 +1,39 @@
+const emailFilter = require('./emailFilter')
+
+describe('Email Filter', () => {
+  it('should not alter addresses without emails in them', () => {
+    const message = 'hello this is a test'
+    const newMessage = emailFilter('', message)
+    expect(newMessage).toBe(message)
+  })
+
+  it('should replace an email address with ***@***.***', () => {
+    const message = 'bob@bobsemail.com'
+    const newMessage = emailFilter('', message)
+    expect(newMessage).toBe('***@***.***')
+  })
+
+  it('should handle plus addressing', () => {
+    const message = 'stuff+bob@bobsemail.com'
+    const newMessage = emailFilter('', message)
+    expect(newMessage).toBe('***@***.***')
+  })
+
+  it('should replace multiple addresses with ***@***.***', () => {
+    const message =
+      'hello this is bob from bob@bobsemail.com emailing frank@franksemail.com for a chat'
+    const expectedMessage =
+      'hello this is bob from ***@***.*** emailing ***@***.*** for a chat'
+    const newMessage = emailFilter('', message)
+    expect(newMessage).toBe(expectedMessage)
+  })
+
+  it('should handle linebreaks between email addresses', () => {
+    const message =
+      'hello this is bob from bob@bobsemail.com\r emailing frank@franksemail.com for a chat'
+    const expectedMessage =
+      'hello this is bob from ***@***.***\r emailing ***@***.*** for a chat'
+    const newMessage = emailFilter('', message)
+    expect(newMessage).toBe(expectedMessage)
+  })
+})

--- a/packages/component-logger/server/logger.js
+++ b/packages/component-logger/server/logger.js
@@ -1,14 +1,14 @@
 const winston = require('winston')
+const emailFilter = require('./filters/emailFilter')
 
-const logPath = process.env.XPUB_LOG_PATH || './'
-
+// production logger sends JSON lines to file
+const logPath = process.env.XPUB_LOG_PATH || '~/elife-xpub/var/logs'
 const logger = new winston.Logger({
   transports: [
     new winston.transports.Console(),
     new winston.transports.File({ filename: `${logPath}/xpub.log` }),
   ],
+  filters: [emailFilter],
 })
-
-logger.transports.console.level = 'warn'
 
 module.exports = logger

--- a/packages/component-logger/server/logger.js
+++ b/packages/component-logger/server/logger.js
@@ -2,7 +2,7 @@ const winston = require('winston')
 const emailFilter = require('./filters/emailFilter')
 
 // production logger sends JSON lines to file
-const logPath = process.env.XPUB_LOG_PATH || '~/elife-xpub/var/logs'
+const logPath = process.env.XPUB_LOG_PATH || '/srv/elife-xpub/var/logs'
 const logger = new winston.Logger({
   transports: [
     new winston.transports.Console(),

--- a/packages/component-logger/server/mock-logger.js
+++ b/packages/component-logger/server/mock-logger.js
@@ -1,12 +1,16 @@
 const winston = require('winston')
+const emailFilter = require('./filters/emailFilter')
 
-// production logger sends JSON lines to file
-const logPath = process.env.XPUB_LOG_PATH || '/srv/elife-xpub/var/logs'
+const logPath = process.env.XPUB_LOG_PATH || './'
+
 const logger = new winston.Logger({
   transports: [
     new winston.transports.Console(),
     new winston.transports.File({ filename: `${logPath}/xpub.log` }),
   ],
+  filters: [emailFilter],
 })
+
+logger.transports.console.level = 'warn'
 
 module.exports = logger


### PR DESCRIPTION
#### Background

Added a component-log and moved the logs from config/non-serialisable there.
We are now exporting both the logger and the mock logger.
Added email filtering to the logs so all email addresses will be replaced with `***@***.***`

#### Any relevant tickets

Closes #1862 

#### How has this been tested?
- [x] Unit / Integration tests
- [x] Browser tests