### PR TITLE
1930 - remove cover letter default text & add sub headings

### DIFF
--- a/client/elife-theme/src/elements/xpub-edit/index.js
+++ b/client/elife-theme/src/elements/xpub-edit/index.js
@@ -25,4 +25,5 @@ export const MenuButton = {
 
 export const Editor = css`
   border-radius: 0 0 ${th('borderRadius')} ${th('borderRadius')};
+  min-height: 12em;
 `

--- a/packages/component-meca/server/meca/export.test.data.json
+++ b/packages/component-meca/server/meca/export.test.data.json
@@ -19,7 +19,7 @@
     "publicationDates": null,
     "notes": null
   },
-  "coverLetter": "<p><b>How will your work make others in the field think differently and move the field forward?</b></p><p></p><p><b>How does your work relate to the current literature on the topic?</b></p><p></p><p><b>Who do you consider to be the most relevant audience for this work?</b></p><p></p><p><b>Have you made clear in the letter what the work has and has not achieved?</b></p><p>d</p><p>d</p><p>d</p><p>d</p><p>d</p><p>d</p><p>d</p>",
+  "coverLetter": "",
   "previouslyDiscussed": "Talked to bob about it",
   "previouslySubmitted": ["Original Test Title"],
   "cosubmission": ["asdassss", "Another"],

--- a/packages/component-meca/server/meca/file-generators/article.test.data.json
+++ b/packages/component-meca/server/meca/file-generators/article.test.data.json
@@ -20,7 +20,7 @@
     "publicationDates": null,
     "notes": null
   },
-  "coverLetter": "<p><b>How will your work make others in the field think differently and move the field forward?</b></p><p></p><p><b>How does your work relate to the current literature on the topic?</b></p><p></p><p><b>Who do you consider to be the most relevant audience for this work?</b></p><p></p><p><b>Have you made clear in the letter what the work has and has not achieved?</b></p><p>d</p><p>d</p><p>d</p><p>d</p><p>d</p><p>d</p><p>d</p>",
+  "coverLetter": "",
   "previouslyDiscussed": "Talked to bob about it",
   "previouslySubmitted": ["Original Test Title"],
   "cosubmission": ["asdassss", "Another"],

--- a/packages/component-model-manuscript/entities/manuscript/helpers/empty.js
+++ b/packages/component-model-manuscript/entities/manuscript/helpers/empty.js
@@ -11,16 +11,7 @@ const emptyManuscript = {
   opposedReviewingEditorsReason: '',
   opposedReviewersReason: '',
   files: [],
-  coverLetter: `
-<p><strong>How will your work make others in the field think differently and move the field forward?</strong></p>
-<p></p>
-<p><strong>How does your work relate to the current literature on the topic?</strong></p>
-<p></p>
-<p><strong>Who do you consider to be the most relevant audience for this work?</strong></p>
-<p></p>
-<p><strong>Have you made clear in the letter what the work has and has not achieved?</strong></p>
-<p></p>
-`,
+  coverLetter: '',
   status: 'INITIAL',
   previouslyDiscussed: null,
   previouslySubmitted: [],

--- a/packages/component-submission/client/components/WizardStep.js
+++ b/packages/component-submission/client/components/WizardStep.js
@@ -58,7 +58,7 @@ const WizardStep = ({
               <ProgressBar currentStep={step} />
             </Box>
 
-            <FormH2>{title}</FormH2>
+            {title && <FormH2>{title}</FormH2>}
 
             <FormComponent values={values} {...formProps} {...wizardProps} />
 

--- a/packages/component-submission/client/pages/FilesStepPage.js
+++ b/packages/component-submission/client/pages/FilesStepPage.js
@@ -1,13 +1,22 @@
 import React from 'react'
 import { Box } from '@rebass/grid'
+import styled from 'styled-components'
+import { th } from '@pubsweet/ui-toolkit'
 import { compose, withProps } from 'recompose'
-import { ValidatedField } from '@elifesciences/component-elife-ui/client/atoms'
+import {
+  ValidatedField,
+  FormH2,
+  Paragraph,
+} from '@elifesciences/component-elife-ui/client/atoms'
 import CoverLetterEditor from '../components/CoverLetterEditor'
 import ManuscriptUpload from '../components/ManuscriptUpload'
 import SupportingUpload from '../components/SupportingUpload'
 import { errorMessageMapping, manuscriptFileTypes } from '../utils/constants'
 import filesWithGQL from '../graphql/filesWithGQL'
 
+const SmallUL = styled.ul`
+  font-size: ${th('fontSizeBaseSmall')};
+`
 export class FilesStepPageComponent extends React.Component {
   constructor(props) {
     super(props)
@@ -101,6 +110,28 @@ export class FilesStepPageComponent extends React.Component {
     return (
       <React.Fragment>
         <Box mb={3} width={1}>
+          <FormH2>Your cover letter</FormH2>
+          <Paragraph.Small secondary>
+            Please enter or paste in your cover letter below. Your work is more
+            likely to progress if you can consider the following questions:
+          </Paragraph.Small>
+          <SmallUL>
+            <li>
+              How will your work make others in the field think differently and
+              move the field forward?
+            </li>
+            <li>
+              How does your work relate to the current literature on the topic?
+            </li>
+            <li>
+              Who do you consider to be the most relevant audience for this
+              work?
+            </li>
+            <li>
+              Have you made clear in the letter what the work has and has not
+              achieved?
+            </li>
+          </SmallUL>
           <ValidatedField
             component={CoverLetterEditor}
             id="coverLetter"
@@ -110,6 +141,7 @@ export class FilesStepPageComponent extends React.Component {
           />
         </Box>
         <Box mb={3} width={1}>
+          <FormH2>Your manuscript file</FormH2>
           <ManuscriptUpload
             conversion={{
               converting:

--- a/packages/component-submission/client/pages/FilesStepPage.js
+++ b/packages/component-submission/client/pages/FilesStepPage.js
@@ -112,8 +112,7 @@ export class FilesStepPageComponent extends React.Component {
         <Box mb={3} width={1}>
           <FormH2>Your cover letter</FormH2>
           <Paragraph.Small secondary>
-            Please enter or paste in your cover letter below. Your work is more
-            likely to progress if you can consider the following questions:
+            To help with the initial evaluation of your submission, you should aim to answer the following questions in your cover letter:
           </Paragraph.Small>
           <SmallUL>
             <li>
@@ -132,6 +131,9 @@ export class FilesStepPageComponent extends React.Component {
               achieved?
             </li>
           </SmallUL>
+          <Paragraph.Small secondary>
+            In addition, please upload any related studies that you have published recently or have under consideration elsewhere as supporting files and describe them in your cover letter.
+          </Paragraph.Small>
           <ValidatedField
             component={CoverLetterEditor}
             id="coverLetter"

--- a/packages/component-submission/client/pages/FilesStepPage.js
+++ b/packages/component-submission/client/pages/FilesStepPage.js
@@ -112,7 +112,7 @@ export class FilesStepPageComponent extends React.Component {
         <Box mb={3} width={1}>
           <FormH2>Your cover letter</FormH2>
           <Paragraph.Small secondary>
-            To help with the initial evaluation of your submission, you should aim to answer the following questions in your cover letter:
+            Please enter or paste in your cover letter below. To help with the initial evaluation of your submission, you should aim to answer the following questions:
           </Paragraph.Small>
           <SmallUL>
             <li>

--- a/packages/component-submission/client/pages/SubmissionWizard.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.js
@@ -53,7 +53,6 @@ const SubmissionWizard = ({
           nextUrl={`${match.url}/submission`}
           previousUrl={`${match.url}/author`}
           step={1}
-          title="Write your cover letter and upload your manuscript"
           validationSchema={filesSchema}
         />
       )}

--- a/test/helpers/navigationHelper.js
+++ b/test/helpers/navigationHelper.js
@@ -89,7 +89,10 @@ class NavigationHelper {
   }
 
   async fillCoverletter(text) {
-    await this.t.typeText(files.editor, text)
+    await this.t.typeText(
+      files.editor,
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas semper ante sed volutpat tincidunt.\n\n Nullam rutrum tortor in libero cursus, sit amet dictum ex consectetur. In eget quam ac felis suscipit sodales euismod ac urna. Donec varius mollis sapien ac pharetra. Sed non nunc neque.\n\n Aenean at lorem nisi. Etiam tempor, turpis vitae fringilla sodales, ante felis posuere eros, et imperdiet ante nisi vel tellus.',
+    )
   }
 
   async uploadManuscript(manuscript) {
@@ -177,9 +180,7 @@ class NavigationHelper {
     this.navigateForward()
 
     // files' page
-    this.fillCoverletter(
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas semper ante sed volutpat tincidunt.\n Nullam rutrum tortor in libero cursus, sit amet dictum ex consectetur. In eget quam ac felis suscipit sodales euismod ac urna. Donec varius mollis sapien ac pharetra. Sed non nunc neque.\n Aenean at lorem nisi. Etiam tempor, turpis vitae fringilla sodales, ante felis posuere eros, et imperdiet ante nisi vel tellus.',
-    )
+    this.fillCoverletter()
     this.uploadManuscript(manuscript)
     this.wait(1000)
     this.navigateForward()

--- a/test/helpers/navigationHelper.js
+++ b/test/helpers/navigationHelper.js
@@ -177,7 +177,9 @@ class NavigationHelper {
     this.navigateForward()
 
     // files' page
-    this.fillCoverletter('\nPlease consider this for publication')
+    this.fillCoverletter(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas semper ante sed volutpat tincidunt.\n Nullam rutrum tortor in libero cursus, sit amet dictum ex consectetur. In eget quam ac felis suscipit sodales euismod ac urna. Donec varius mollis sapien ac pharetra. Sed non nunc neque.\n Aenean at lorem nisi. Etiam tempor, turpis vitae fringilla sodales, ante felis posuere eros, et imperdiet ante nisi vel tellus.',
+    )
     this.uploadManuscript(manuscript)
     this.wait(1000)
     this.navigateForward()

--- a/test/hotjar.browser.js
+++ b/test/hotjar.browser.js
@@ -41,7 +41,7 @@ test('test suppressions', async t => {
       'data-hj-suppress': '',
     })
     .ok()
-  navigationHelper.fillCoverletter('\nPlease consider this for publication')
+  navigationHelper.fillCoverletter()
   navigationHelper.uploadManuscript(manuscript)
   navigationHelper.navigateForward()
 

--- a/test/multiFileUpload.browser.js
+++ b/test/multiFileUpload.browser.js
@@ -34,7 +34,7 @@ test('should display an error when files are still uploading', async t => {
   navigationHelper.navigateForward()
 
   // files' page
-  navigationHelper.fillCoverletter('\nPlease consider this for publication')
+  navigationHelper.fillCoverletter()
   navigationHelper.uploadManuscript(manuscript)
   navigationHelper.uploadSupportingFiles(manuscript.supportingFiles)
   navigationHelper.navigateForward()

--- a/test/peoplePicker.browser.js
+++ b/test/peoplePicker.browser.js
@@ -44,8 +44,8 @@ test('People Picker', async t => {
     .click(wizardStep.next)
 
   // uploading files - manuscript and cover letter
+  navigationHelper.fillCoverletter()
   await t
-    .typeText(files.editor, '\nPlease consider this for publication')
     .setFilesToUpload(files.manuscriptUpload, manuscript.file)
     // wait for editor onChange
     .wait(1000)

--- a/test/replaceManuscript.browser.js
+++ b/test/replaceManuscript.browser.js
@@ -57,8 +57,8 @@ test('Replace Manuscript on the Submission', async t => {
     .click(wizardStep.next)
 
   // uploading files - manuscript and cover letter
+  navigationHelper.fillCoverletter()
   await t
-    .typeText(files.editor, '\nPlease consider this for publication')
     // Test file type validation is working
     .setFilesToUpload(files.manuscriptUpload, unsupportedManuscriptFile.file)
     .expect(files.dropzoneMessage.textContent)

--- a/test/submission.browser.js
+++ b/test/submission.browser.js
@@ -55,7 +55,7 @@ test('Happy path', async t => {
   navigationHelper.navigateForward()
 
   // uploading files - manuscript and cover letter
-  navigationHelper.fillCoverletter('\nPlease consider this for publication')
+  navigationHelper.fillCoverletter()
   navigationHelper.uploadManuscript(manuscript)
   navigationHelper.uploadSupportingFiles(manuscript.supportingFiles[0])
 


### PR DESCRIPTION
#### Background

The template placeholder questions for the cover letter have been moved from the default field value into a guidance text area with the cover letter field now being blank by default.

#### Any relevant tickets

closes #1930

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
