### PR TITLE
1887 - Redirect from wizard if submission complete

### DIFF
--- a/packages/component-dashboard/client/pages/DashboardPage.js
+++ b/packages/component-dashboard/client/pages/DashboardPage.js
@@ -78,7 +78,7 @@ export default compose(
   ),
   branch(
     props => !props.data || props.data.error,
-    props => <div>{props.error}</div>,
+    props => () => <div>{props.error}</div>,
   ),
   withHandlers({
     createNewSubmission: props => () =>

--- a/packages/component-submission/client/pages/SubmissionWizard.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.js
@@ -142,6 +142,10 @@ export default compose(
     renderComponent(Loading),
   ),
   branch(props => !props.data || props.data.error, renderComponent(ErrorPage)),
+  branch(
+    props => props.data.manuscript.clientStatus !== 'CONTINUE_SUBMISSION',
+    () => () => <Redirect to="/" />,
+  ),
   withProps(props => ({
     initialValues: parseInputToFormData(props.data.manuscript),
   })),


### PR DESCRIPTION
#### Background

This prevents the user from re-visiting any of the wizard step pages by redirecting back to the dashboard if the manuscripts status is `CONTINUE_SUBMISSION`.

It also fixes the error `branch` wrapper on the dashboard page.

#### Any relevant tickets

Closes #1887

