### PR TITLE
Try to inline the base image to see the difference in performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# built from ./Dockerfile-base
-FROM xpub/xpub:20181213-1147
+FROM node:8.14.0
+
+ENV HOME "/home/xpub"
+
+RUN mkdir -p ${HOME}
 
 WORKDIR ${HOME}
 


### PR DESCRIPTION
Purging caches, it builds in 6 minutes on my laptop on a rather slow connection. However it reduces the size from 2.5 GB to 1.9 GB, so it may benefit the time it takes to push and pull the image across the board.