### PR TITLE
set signature version to v4 to fix download link

### DIFF
--- a/packages/component-service-s3/server/s3Storage.js
+++ b/packages/component-service-s3/server/s3Storage.js
@@ -5,6 +5,7 @@ const s3 = new AWS.S3({
   ...config.get('aws.credentials'),
   ...config.get('aws.s3'),
   apiVersion: '2006-03-01',
+  signatureVersion: 'v4',
 })
 
 class S3Storage {


### PR DESCRIPTION
#### Background
Add `signatureVersion` to AWS instance config to fix download links.

#### Any relevant tickets

closes #1962

