### PR TITLE
Only show validation errors when the user attempts to submit

### DIFF
--- a/packages/component-submission/client/components/WizardStep.js
+++ b/packages/component-submission/client/components/WizardStep.js
@@ -14,82 +14,107 @@ import SavePageStatus from './SavePageStatus'
 const BoxNoMinWidth = styled(Box)`
   min-width: 0;
 `
+class WizardStep extends React.Component {
+  constructor(props) {
+    super(props)
 
-const WizardStep = ({
-  component: FormComponent,
-  finalStep,
-  handleAutoSave,
-  handleButtonClick,
-  history,
-  nextUrl,
-  previousUrl,
-  initialValues,
-  title,
-  step,
-  validationSchema,
-  ...wizardProps
-}) => (
-  <Formik
-    initialValues={initialValues}
-    // ensure each page gets a new form instance otherwise all fields are touched
-    key={title}
-    onSubmit={values => {
-      handleButtonClick(values).then(() => history.push(nextUrl))
-    }}
-    render={({
-      values,
-      handleSubmit,
-      isSubmitting,
-      setTouched,
-      submitForm,
-      validateForm,
-      ...formProps
-    }) => (
-      <Flex>
-        <BoxNoMinWidth flex="1 1 100%" mx={[0, 0, 0, '16.666%']}>
-          <form noValidate onSubmit={handleSubmit}>
-            <AutoSave
-              disabled={isSubmitting}
-              onSave={handleAutoSave}
-              values={values}
-            />
-            <SavePageStatus id={values.id} url={history.location.pathname} />
-            <Box my={5}>
-              <ProgressBar currentStep={step} />
-            </Box>
+    this.state = {
+      submissionAttempted: false,
+    }
+  }
 
-            {title && <FormH2>{title}</FormH2>}
+  setSubmissionAttempted = (value = true) => {
+    this.state.submissionAttempted = value
+  }
 
-            <FormComponent values={values} {...formProps} {...wizardProps} />
-
-            <Flex mt={6}>
-              {previousUrl && (
-                <Box mr={3}>
-                  <ButtonLink data-test-id="back" to={previousUrl}>
-                    Back
-                  </ButtonLink>
+  render() {
+    const {
+      component: FormComponent,
+      finalStep,
+      handleAutoSave,
+      handleButtonClick,
+      history,
+      nextUrl,
+      previousUrl,
+      initialValues,
+      title,
+      step,
+      validationSchema,
+      ...wizardProps
+    } = this.props
+    return (
+      <Formik
+        initialValues={initialValues}
+        // ensure each page gets a new form instance otherwise all fields are touched
+        key={title}
+        onSubmit={values => {
+          handleButtonClick(values).then(() => history.push(nextUrl))
+        }}
+        render={({
+          values,
+          handleSubmit,
+          isSubmitting,
+          setTouched,
+          submitForm,
+          validateForm,
+          ...formProps
+        }) => (
+          <Flex>
+            <BoxNoMinWidth flex="1 1 100%" mx={[0, 0, 0, '16.666%']}>
+              <form noValidate onSubmit={handleSubmit}>
+                <AutoSave
+                  disabled={isSubmitting}
+                  onSave={handleAutoSave}
+                  values={values}
+                />
+                <SavePageStatus
+                  id={values.id}
+                  url={history.location.pathname}
+                />
+                <Box my={5}>
+                  <ProgressBar currentStep={step} />
                 </Box>
-              )}
-              <Box>
-                {finalStep ? (
-                  <WizardSubmit
-                    setTouched={setTouched}
-                    submitForm={submitForm}
-                    validateForm={validateForm}
-                  />
-                ) : (
-                  <Button data-test-id="next" primary type="submit">
-                    Next
-                  </Button>
-                )}
-              </Box>
-            </Flex>
-          </form>
-        </BoxNoMinWidth>
-      </Flex>
-    )}
-    validationSchema={yup.object().shape(validationSchema)}
-  />
-)
+
+                {title && <FormH2>{title}</FormH2>}
+
+                <FormComponent
+                  values={values}
+                  {...formProps}
+                  isSubmissionAttempted={this.state.submissionAttempted}
+                  {...wizardProps}
+                />
+
+                <Flex mt={6}>
+                  {previousUrl && (
+                    <Box mr={3}>
+                      <ButtonLink data-test-id="back" to={previousUrl}>
+                        Back
+                      </ButtonLink>
+                    </Box>
+                  )}
+                  <Box>
+                    {finalStep ? (
+                      <WizardSubmit
+                        setSubmissionAttempted={this.setSubmissionAttempted}
+                        setTouched={setTouched}
+                        submitForm={submitForm}
+                        validateForm={validateForm}
+                      />
+                    ) : (
+                      <Button data-test-id="next" primary type="submit">
+                        Next
+                      </Button>
+                    )}
+                  </Box>
+                </Flex>
+              </form>
+            </BoxNoMinWidth>
+          </Flex>
+        )}
+        validationSchema={yup.object().shape(validationSchema)}
+      />
+    )
+  }
+}
 
 export default WizardStep

--- a/packages/component-submission/client/components/WizardStep.js
+++ b/packages/component-submission/client/components/WizardStep.js
@@ -24,7 +24,7 @@ class WizardStep extends React.Component {
   }
 
   setSubmissionAttempted = (value = true) => {
-    this.state.submissionAttempted = value
+    this.setState({ submissionAttempted: value })
   }
 
   render() {

--- a/packages/component-submission/client/components/WizardSubmit.js
+++ b/packages/component-submission/client/components/WizardSubmit.js
@@ -5,13 +5,19 @@ import {
   ModalHistoryState,
 } from '@elifesciences/component-elife-ui/client/molecules'
 
-const WizardSubmit = ({ setTouched, submitForm, validateForm }) => (
+const WizardSubmit = ({
+  setTouched,
+  submitForm,
+  validateForm,
+  setSubmissionAttempted,
+}) => (
   <ModalHistoryState>
     {({ showModal, hideModal, isModalVisible }) => (
       <React.Fragment>
         <Button
           data-test-id="submit"
-          onClick={() =>
+          onClick={() => {
+            setSubmissionAttempted()
             validateForm().then(errors => {
               if (Object.keys(errors).length) {
                 setTouched(errors)
@@ -19,7 +25,7 @@ const WizardSubmit = ({ setTouched, submitForm, validateForm }) => (
                 showModal()
               }
             })
-          }
+          }}
           primary
           type="button"
         >

--- a/packages/component-submission/client/pages/DisclosureStepPage.js
+++ b/packages/component-submission/client/pages/DisclosureStepPage.js
@@ -21,7 +21,7 @@ const ErrorMessage = styled.div`
 const localDate = parse(new Date())
 const formattedLocalDate = format(localDate, 'MMM D, YYYY')
 
-const DisclosureStepPage = ({ values, errors }) => {
+const DisclosureStepPage = ({ values, errors, isSubmissionAttempted }) => {
   const formattedArticleType = values.meta.articleType
     .toUpperCase()
     .replace(/-+/g, ' ')
@@ -80,15 +80,16 @@ const DisclosureStepPage = ({ values, errors }) => {
         name="disclosureConsent"
       />
 
-      {!!Object.keys(errors).length && (
-        <ErrorMessage data-test-id="test-error-message">
-          We&apos;re sorry but there appears to be one or more errors in your
-          submission that require attention before you can submit. Please use
-          the back button to review the{' '}
-          {convertArrayToReadableList(getErrorStepsFromErrors(errors))} steps
-          before trying again.
-        </ErrorMessage>
-      )}
+      {!!Object.keys(errors).length &&
+        isSubmissionAttempted && (
+          <ErrorMessage data-test-id="test-error-message">
+            We&apos;re sorry but there appears to be one or more errors in your
+            submission that require attention before you can submit. Please use
+            the back button to review the{' '}
+            {convertArrayToReadableList(getErrorStepsFromErrors(errors))} steps
+            before trying again.
+          </ErrorMessage>
+        )}
     </React.Fragment>
   )
 }

--- a/packages/component-submission/client/pages/DisclosureStepPage.test.js
+++ b/packages/component-submission/client/pages/DisclosureStepPage.test.js
@@ -14,11 +14,13 @@ describe('DisclosurePage', () => {
     expect(page.find('[data-test-id="test-error-message"]')).toHaveLength(0)
   })
 
-  it('displays error message when passed errors object', () => {
+  it('displays error message when passed errors object and an attempt has been made to submit the form', () => {
     const errors = {
       submitterSignature: 'error',
     }
-    const page = shallow(<DisclosurePage errors={errors} values={values} />)
+    const page = shallow(
+      <DisclosurePage errors={errors} isSubmissionAttempted values={values} />,
+    )
     expect(page.find('[data-test-id="test-error-message"]')).toHaveLength(1)
   })
 })

--- a/test/pageObjects/disclosure.js
+++ b/test/pageObjects/disclosure.js
@@ -9,6 +9,7 @@ const disclosure = {
   consentCheckbox: Selector('[name="disclosureConsent"]').parent(),
   title: Selector('[data-test-id=disclosure-title]'),
   name: Selector('[data-test-id=disclosure-name]'),
+  validationWarning: Selector('[data-test-id=test-error-message]'),
 }
 
 export default disclosure

--- a/test/submission.browser.js
+++ b/test/submission.browser.js
@@ -3,6 +3,7 @@ import {
   author,
   dashboard,
   editors,
+  disclosure,
   files,
   submission,
   login,
@@ -152,9 +153,102 @@ test('Ability to progress through the wizard is tied to validation', async t => 
 
   navigationHelper.setAuthorEmail('anne.author@life.ac.uk')
   navigationHelper.navigateForward()
+
+  // File upload stage
   await t
     .expect(getPageUrl())
     .match(files.url, 'Entering valid inputs enables progress to the next page')
+
+  navigationHelper.navigateForward()
+  await t
+    .expect(getPageUrl())
+    .match(files.url, 'Validation errors prevent progress to the next page')
+
+  navigationHelper.fillCoverletter()
+  navigationHelper.navigateForward()
+  await t
+    .expect(getPageUrl())
+    .match(files.url, 'Entering valid inputs enables progress to the next page')
+
+  navigationHelper.uploadManuscript(manuscript)
+  navigationHelper.uploadSupportingFiles(manuscript.supportingFiles[0])
+  navigationHelper.navigateForward()
+
+  // Submission metadata entry
+  navigationHelper.wait(2000)
+  await t
+    .expect(getPageUrl())
+    .match(
+      submission.url,
+      'Entering valid inputs enables progress to the next page',
+    )
+
+  navigationHelper.navigateForward()
+  await t
+    .expect(getPageUrl())
+    .match(
+      submission.url,
+      'Validation errors prevent progress to the next page',
+    )
+
+  navigationHelper.addManuscriptMetadata()
+  navigationHelper.navigateForward()
+  // Editors
+  navigationHelper.wait(2000)
+  await t
+    .expect(getPageUrl())
+    .match(
+      editors.url,
+      'Entering valid inputs enables progress to the next page',
+    )
+
+  navigationHelper.navigateForward()
+
+  await t
+    .expect(getPageUrl())
+    .match(editors.url, 'Validation errors prevent progress to the next page')
+
+  navigationHelper.openEditorsPicker()
+  navigationHelper.selectPeople([0, 2, 3, 5, 7, 9])
+  navigationHelper.closePeoplePicker()
+
+  navigationHelper.openReviewerPicker()
+  navigationHelper.selectPeople([1, 4, 6, 8, 10, 11])
+  navigationHelper.closePeoplePicker()
+
+  navigationHelper.navigateForward()
+
+  // Disclosure
+  await t
+    .expect(getPageUrl())
+    .match(
+      disclosure.url,
+      'Entering valid inputs enables progress to the next page',
+    )
+
+  navigationHelper.submit()
+  await t
+    .expect(getPageUrl())
+    .match(
+      disclosure.url,
+      'Validation errors prevent progress to the next page',
+    )
+  await t
+    .expect((await disclosure.validationWarning.textContent).length)
+    .gt(0, 'is visible')
+
+  navigationHelper.consentDisclosure()
+  navigationHelper.submit()
+  navigationHelper.accept()
+  navigationHelper.thankyou()
+
+  // dashboard
+  await t
+    .expect(dashboard.titles.textContent)
+    .eql(manuscript.title)
+    .expect(dashboard.statuses.textContent)
+    // TODO this might cause a race condition
+    .eql('Submitted')
 })
 
 test('Form entries are saved when a user navigates to the next page of the wizard', async t => {

--- a/test/submission.browser.js
+++ b/test/submission.browser.js
@@ -209,11 +209,11 @@ test('Ability to progress through the wizard is tied to validation', async t => 
     .match(editors.url, 'Validation errors prevent progress to the next page')
 
   navigationHelper.openEditorsPicker()
-  navigationHelper.selectPeople([0, 2, 3, 5, 7, 9])
+  navigationHelper.selectPeople([0, 2])
   navigationHelper.closePeoplePicker()
 
   navigationHelper.openReviewerPicker()
-  navigationHelper.selectPeople([1, 4, 6, 8, 10, 11])
+  navigationHelper.selectPeople([1, 4])
   navigationHelper.closePeoplePicker()
 
   navigationHelper.navigateForward()


### PR DESCRIPTION
#### Background

There was a UX error where if the user managed to create validation errors earlier on in the submission form and then circumvent the validation to get to the submission page, the validation error message would show as soon as the user started editing an field on the page. This PR fixes it so that the error message is not shown until the user tries to click submit.
 
#### Any relevant tickets
Closes #1960 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.
To test manually:
1. Start new submission
2. Complete form normally, with valid data
3. Before you submit, click the application 'back' button
4. Change the data to become invalid (e.g. remove the reviewers)
5. Use the browser back button to return to the disclosure page
6. The validation warning message should appear only when you click submit, not when you change a field.

- [ ] Unit / Integration tests
- [x] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
