### PR TITLE
1975 - Correct content type is saved in S3 to fix download link

### DIFF
--- a/packages/component-service-s3/server/s3Storage.js
+++ b/packages/component-service-s3/server/s3Storage.js
@@ -30,7 +30,7 @@ class S3Storage {
       .putObject({
         Body: content,
         Key: `${fileObject.url}/${fileObject.id}`,
-        ContentType: fileObject.mimetype,
+        ContentType: fileObject.mimeType,
         ContentLength: size,
         ACL: 'private',
       })


### PR DESCRIPTION
#### Background

There was a typo in the property name passed to the `S3.putObject` which meant an undefined `ContentType` was being sent when storing files. This corrects the typo, allowing previews to be correctly opened when downloaded.

#### Any relevant tickets

Closes #1975 