### PR TITLE
1985 - Use the new Submission aggregate within the Query.manuscript resolver

### DIFF
--- a/packages/component-submission/client/graphql/queries.js
+++ b/packages/component-submission/client/graphql/queries.js
@@ -2,8 +2,8 @@ import gql from 'graphql-tag'
 
 import { manuscriptFragment } from './fragments'
 
-export const GET_MANUSCRIPT = gql`
-  query GetManuscript($id: ID!) {
+export const getSubmission = gql`
+  query getSubmission($id: ID!) {
     manuscript(id: $id) {
       ...WholeManuscript
     }
@@ -11,8 +11,8 @@ export const GET_MANUSCRIPT = gql`
   ${manuscriptFragment}
 `
 
-export const GET_MANUSCRIPT_TITLE = gql`
-  query GetManuscript($id: ID!) {
+export const getSubmissionTitle = gql`
+  query getSubmissionTitle($id: ID!) {
     manuscript(id: $id) {
       meta {
         title

--- a/packages/component-submission/client/graphql/thankYouWithGQL.js
+++ b/packages/component-submission/client/graphql/thankYouWithGQL.js
@@ -1,9 +1,9 @@
 import { graphql } from 'react-apollo'
 import { compose } from 'recompose'
-import { GET_MANUSCRIPT_TITLE } from './queries'
+import { getSubmissionTitle } from './queries'
 
 export default compose(
-  graphql(GET_MANUSCRIPT_TITLE, {
+  graphql(getSubmissionTitle, {
     options: props => ({ variables: { id: props.match.params.id } }),
   }),
 )

--- a/packages/component-submission/client/graphql/withGQL.js
+++ b/packages/component-submission/client/graphql/withGQL.js
@@ -1,7 +1,7 @@
 import { graphql } from 'react-apollo'
 import { compose } from 'recompose'
 import { ALL_MANUSCRIPTS } from '@elifesciences/component-dashboard/client/graphql/queries'
-import { GET_MANUSCRIPT } from './queries'
+import { getSubmission } from './queries'
 import {
   UPDATE_MANUSCRIPT,
   SUBMIT_MANUSCRIPT,
@@ -13,7 +13,7 @@ import {
 import { ON_UPLOAD_PROGRESS } from './subscriptions'
 
 export default compose(
-  graphql(GET_MANUSCRIPT, {
+  graphql(getSubmission, {
     options: props => ({ variables: { id: props.match.params.id } }),
   }),
   graphql(UPDATE_MANUSCRIPT, {

--- a/packages/component-submission/client/graphql/wizardWithGQL.js
+++ b/packages/component-submission/client/graphql/wizardWithGQL.js
@@ -1,11 +1,11 @@
 import { graphql } from 'react-apollo'
 import { compose } from 'recompose'
 import { ALL_MANUSCRIPTS } from '@elifesciences/component-dashboard/client/graphql/queries'
-import { GET_MANUSCRIPT } from './queries'
+import { getSubmission } from './queries'
 import { UPDATE_MANUSCRIPT, SUBMIT_MANUSCRIPT } from './mutations'
 
 export default compose(
-  graphql(GET_MANUSCRIPT, {
+  graphql(getSubmission, {
     options: props => ({ variables: { id: props.match.params.id } }),
   }),
   graphql(UPDATE_MANUSCRIPT, {

--- a/packages/component-submission/server/aggregates/Submission.js
+++ b/packages/component-submission/server/aggregates/Submission.js
@@ -20,9 +20,32 @@ class Submission {
       : []
   }
 
+  filesAreStored() {
+    if (!this.files) return true
+
+    const FILE_STATUSES = [
+      {
+        uploadStatuses: ['STORED', 'CANCELLED'],
+        isReady: true,
+      },
+      {
+        uploadStatuses: ['UPLOADED', 'CREATED'],
+        isReady: false,
+      },
+    ]
+    return [{ status: 'STORED' }]
+      .map(
+        file =>
+          FILE_STATUSES.find(f => f.uploadStatuses.includes(file.status))
+            .isReady,
+      )
+      .every(status => status)
+  }
+
   toJSON() {
     return {
       ...this.manuscript.toJSON(),
+      fileStatus: this.filesAreStored() ? 'READY' : 'CHANGING',
       files: this._getFilesWithDownloadLink(),
     }
   }

--- a/packages/component-submission/server/aggregates/Submission.js
+++ b/packages/component-submission/server/aggregates/Submission.js
@@ -33,7 +33,7 @@ class Submission {
         isReady: false,
       },
     ]
-    return [{ status: 'STORED' }]
+    return this.files
       .map(
         file =>
           FILE_STATUSES.find(f => f.uploadStatuses.includes(file.status))

--- a/packages/component-submission/server/aggregates/index.js
+++ b/packages/component-submission/server/aggregates/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  SubmissionAggregate: require('./Submission'),
+  Submission: require('./Submission'),
 }

--- a/packages/component-submission/server/aggregates/index.js
+++ b/packages/component-submission/server/aggregates/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  SubmissionAggregate: require('./Submission'),
+}

--- a/packages/component-submission/server/resolvers/index.js
+++ b/packages/component-submission/server/resolvers/index.js
@@ -19,7 +19,7 @@ const uploadSupportingFile = require('./uploadSupportingFile')
 const removeSupportingFiles = require('./removeSupportingFiles')
 
 const { Manuscript, getSubmissionUseCase } = require('../use-cases')
-const { SubmissionAggregate } = require('../aggregates')
+const { Submission } = require('../aggregates')
 
 const { ON_UPLOAD_PROGRESS } = asyncIterators
 
@@ -27,7 +27,7 @@ const resolvers = {
   Query: {
     async manuscript(_, { id }, { user }) {
       const userUuid = await User.getUuidForProfile(user)
-      const submissionAggregate = new SubmissionAggregate({
+      const submission = new Submission({
         models: {
           Manuscript: ManuscriptModel,
           File: FileModel,
@@ -38,7 +38,7 @@ const resolvers = {
       })
 
       return getSubmissionUseCase
-        .initialize({ submissionAggregate })
+        .initialize({ submission })
         .execute(id, userUuid)
     },
     async editors(_, { role }) {

--- a/packages/component-submission/server/use-cases/getSubmissionUseCase.js
+++ b/packages/component-submission/server/use-cases/getSubmissionUseCase.js
@@ -1,9 +1,6 @@
-const initialize = ({ submissionAggregate }) => ({
+const initialize = ({ submission }) => ({
   execute: async (manuscriptId, userId) => {
-    const submission = await submissionAggregate.initialize(
-      manuscriptId,
-      userId,
-    )
+    await submission.initialize(manuscriptId, userId)
     return submission.toJSON()
   },
 })

--- a/packages/component-submission/server/use-cases/getSubmissionUseCase.js
+++ b/packages/component-submission/server/use-cases/getSubmissionUseCase.js
@@ -1,0 +1,13 @@
+const initialize = ({ submissionAggregate }) => ({
+  execute: async (manuscriptId, userId) => {
+    const submission = await submissionAggregate.initialize(
+      manuscriptId,
+      userId,
+    )
+    return submission.toJSON()
+  },
+})
+
+module.exports = {
+  initialize,
+}

--- a/packages/component-submission/server/use-cases/getSubmissionUseCase.test.js
+++ b/packages/component-submission/server/use-cases/getSubmissionUseCase.test.js
@@ -1,0 +1,3 @@
+describe('getSubmissionUseCase', () => {
+  it('initiali')
+})

--- a/packages/component-submission/server/use-cases/getSubmissionUseCase.test.js
+++ b/packages/component-submission/server/use-cases/getSubmissionUseCase.test.js
@@ -1,3 +1,22 @@
+const getSubmissionUseCase = require('./getSubmissionUseCase')
+
 describe('getSubmissionUseCase', () => {
-  it('initiali')
+  it('initializes the submission object', async () => {
+    const mockInitialize = jest.fn()
+    const mockSubmission = { initialize: mockInitialize, toJSON: jest.fn() }
+    await getSubmissionUseCase
+      .initialize({ submission: mockSubmission })
+      .execute()
+    expect(mockInitialize).toHaveBeenCalled()
+  })
+  it('calls and returns the value of submission.toJSON()', async () => {
+    const mockToJSON = jest.fn(() => 'foo')
+    const mockSubmission = { initialize: jest.fn(), toJSON: mockToJSON }
+    expect(
+      await getSubmissionUseCase
+        .initialize({ submission: mockSubmission })
+        .execute(),
+    ).toBe('foo')
+    expect(mockToJSON).toHaveBeenCalled()
+  })
 })

--- a/packages/component-submission/server/use-cases/index.js
+++ b/packages/component-submission/server/use-cases/index.js
@@ -1,7 +1,10 @@
 const SupportingFiles = require('./supportingFiles')
 const Manuscript = require('./manuscript')
 
+const getSubmissionUseCase = require('./getSubmissionUseCase')
+
 module.exports = {
+  getSubmissionUseCase,
   SupportingFiles,
   Manuscript,
 }


### PR DESCRIPTION
#### Background

- Renames the `manuscript` Query to `getSubmission`
- Adds a `getSubmissionUseCase` with unit tests and uses this in new `getSubmission` query
- Adds a `filesAreStored` function to the `Submission` aggregate to be used in creating a `fileStatus` property on the object returned by `toJSON`

#### Any relevant tickets

Closes #1985

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [x] Browser tests - existing ones should work
- [x] End2end tests - existing ones should work
