### PR TITLE
1983: Added better validation check for manuscript file being present, updated tests to match

### DIFF
--- a/packages/component-submission/client/utils/ValidationSchemas.js
+++ b/packages/component-submission/client/utils/ValidationSchemas.js
@@ -1,5 +1,9 @@
 import * as yup from 'yup'
-import { EDITOR_LIMITS, errorMessageMapping } from './constants'
+import {
+  EDITOR_LIMITS,
+  errorMessageMapping,
+  manuscriptFileTypes,
+} from './constants'
 
 export const authorSchema = {
   author: yup.object().shape({
@@ -17,7 +21,17 @@ export const filesSchema = {
   coverLetter: yup
     .string()
     .required('Please write or paste in your cover letter.'),
-  files: yup.array().min(1, errorMessageMapping.EMPTY),
+  files: yup
+    .array()
+    .min(1, errorMessageMapping.EMPTY)
+    .test(
+      'at-least-one-manuscript',
+      errorMessageMapping.EMPTY,
+      arr =>
+        arr
+          .map(f => f.type === manuscriptFileTypes.MANUSCRIPT_SOURCE)
+          .filter(f => f).length > 0,
+    ),
   fileStatus: yup
     .string()
     .required()

--- a/packages/component-submission/client/utils/ValidationSchemas.test.js
+++ b/packages/component-submission/client/utils/ValidationSchemas.test.js
@@ -146,7 +146,7 @@ describe('Files schema', () => {
   it('allows valid data', () => {
     const validData = {
       coverLetter: 'Please accept my submission.',
-      files: [{}],
+      files: [{ type: 'MANUSCRIPT_SOURCE' }],
       fileStatus: 'READY',
     }
     expect(() => schema.validateSync(validData)).not.toThrow()
@@ -154,7 +154,7 @@ describe('Files schema', () => {
   it('returns correct error message when cover letter is empty', () => {
     const invalidData = {
       coverLetter: '',
-      files: [{}],
+      files: [{ type: 'MANUSCRIPT_SOURCE' }],
       fileStatus: 'READY',
     }
     let errors
@@ -171,7 +171,7 @@ describe('Files schema', () => {
   it('returns correct error message when files are not all uploaded and saved', () => {
     const invalidData = {
       coverLetter: 'Please accept my submission.',
-      files: [{}],
+      files: [{ type: 'MANUSCRIPT_SOURCE' }],
       fileStatus: 'UPLOADED',
     }
     let errors
@@ -189,6 +189,23 @@ describe('Files schema', () => {
     const invalidData = {
       coverLetter: 'Please accept my submission.',
       files: [],
+      fileStatus: 'READY',
+    }
+    let errors
+    try {
+      schema.validateSync(invalidData, { abortEarly: false })
+    } catch (e) {
+      errors = yupToFormErrors(e)
+    }
+
+    expect(errors).toEqual({
+      files: errorMessageMapping.EMPTY,
+    })
+  })
+  it('returns the correct error message when there are supporting files stored but no manuscripts', () => {
+    const invalidData = {
+      coverLetter: 'Please accept my submission.',
+      files: [{ type: 'SUPPORTING_FILE' }],
       fileStatus: 'READY',
     }
     let errors


### PR DESCRIPTION
#### Background

Updates the front end validation to check whether we actually have a file of type MANUSCRIPT_SOURCE uploaded and stored.

#### Any relevant tickets

Closes #1983 

#### How has this been tested?

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

Not needed
