### PR TITLE
1996 - Add updateManuscript to Submission

### DIFF
--- a/packages/component-submission/server/aggregates/Submission.js
+++ b/packages/component-submission/server/aggregates/Submission.js
@@ -1,3 +1,5 @@
+const { mergeObjects } = require('../utils')
+
 class Submission {
   constructor({ models: { Manuscript, File }, services: { Storage } }) {
     this.ManuscriptModel = Manuscript
@@ -48,6 +50,11 @@ class Submission {
       fileStatus: this.filesAreStored() ? 'READY' : 'CHANGING',
       files: this._getFilesWithDownloadLink(),
     }
+  }
+
+  updateManuscript(manuscriptData) {
+    this.manuscript = mergeObjects(this.manuscript, manuscriptData)
+    this.manuscript.save()
   }
 }
 

--- a/packages/component-submission/server/aggregates/Submission.test.js
+++ b/packages/component-submission/server/aggregates/Submission.test.js
@@ -1,5 +1,8 @@
 const Manuscript = require('@elifesciences/component-model-manuscript').model
 const File = require('@elifesciences/component-model-file').model
+
+jest.mock('../utils')
+const utils = require('../utils')
 const Submission = require('./Submission')
 
 const createMockObject = (values = {}, mockSaveFn) => ({
@@ -184,6 +187,9 @@ describe('Submission', () => {
   describe('updateManuscript', () => {
     it('calls save on manuscript', async () => {
       const mockManuscriptSave = jest.fn()
+      utils.mergeObjects.mockImplementationOnce(
+        jest.fn(manuscript => manuscript),
+      )
       jest
         .spyOn(Manuscript, 'find')
         .mockReturnValue(createMockObject({}, mockManuscriptSave))
@@ -196,6 +202,23 @@ describe('Submission', () => {
 
       submission.updateManuscript({})
       expect(mockManuscriptSave).toBeCalled()
+    })
+
+    it('pases the correct parameters to the mergeWith function', async () => {
+      const mockMergeFunction = jest.fn(manuscript => manuscript)
+      utils.mergeObjects.mockImplementationOnce(mockMergeFunction)
+      const mockManuscriptSave = jest.fn()
+      const manuscriptMock = createMockObject({}, mockManuscriptSave)
+      jest.spyOn(Manuscript, 'find').mockReturnValue(manuscriptMock)
+      jest.spyOn(File, 'findByManuscriptId')
+
+      const submission = await new Submission({
+        models: { Manuscript, File },
+        services: {},
+      }).initialize()
+
+      submission.updateManuscript({})
+      expect(mockMergeFunction).toBeCalledWith(manuscriptMock, {})
     })
   })
 })

--- a/packages/component-submission/server/aggregates/Submission.test.js
+++ b/packages/component-submission/server/aggregates/Submission.test.js
@@ -1,11 +1,11 @@
 const Manuscript = require('@elifesciences/component-model-manuscript').model
 const File = require('@elifesciences/component-model-file').model
-// const { S3Storage } = require('@elifesciences/component-service-s3')
 const Submission = require('./Submission')
 
-const createMockObject = (values = {}) => ({
+const createMockObject = (values = {}, mockSaveFn) => ({
   ...values,
   toJSON: jest.fn(() => values),
+  save: mockSaveFn || jest.fn(),
 })
 
 describe('Submission', () => {
@@ -179,6 +179,23 @@ describe('Submission', () => {
       }).initialize()
 
       expect(submission.filesAreStored()).toBe(false)
+    })
+  })
+  describe('updateManuscript', () => {
+    it('calls save on manuscript', async () => {
+      const mockManuscriptSave = jest.fn()
+      jest
+        .spyOn(Manuscript, 'find')
+        .mockReturnValue(createMockObject({}, mockManuscriptSave))
+      jest.spyOn(File, 'findByManuscriptId')
+
+      const submission = await new Submission({
+        models: { Manuscript, File },
+        services: {},
+      }).initialize()
+
+      submission.updateManuscript({})
+      expect(mockManuscriptSave).toBeCalled()
     })
   })
 })

--- a/packages/component-submission/server/utils/index.js
+++ b/packages/component-submission/server/utils/index.js
@@ -1,5 +1,5 @@
 const mergeObjects = require('./mergeObjects')
 
-exports.modules = {
+module.exports = {
   mergeObjects,
 }

--- a/packages/component-submission/server/utils/index.js
+++ b/packages/component-submission/server/utils/index.js
@@ -1,0 +1,5 @@
+const mergeObjects = require('./mergeObjects')
+
+exports.modules = {
+  mergeObjects,
+}

--- a/packages/component-submission/server/utils/mergeObjects.js
+++ b/packages/component-submission/server/utils/mergeObjects.js
@@ -1,0 +1,16 @@
+const { mergeWith, cloneDeep, isArray } = require('lodash')
+
+// In future this might want to live outside of this bounded context
+module.exports = function mergeObjects(source, ...inputs) {
+  return mergeWith(
+    cloneDeep(source),
+    ...inputs,
+    // always replace arrays instead of merging
+    (objValue, srcValue) => {
+      if (isArray(srcValue)) {
+        return srcValue
+      }
+      return undefined
+    },
+  )
+}

--- a/packages/component-submission/server/utils/mergeObjects.js
+++ b/packages/component-submission/server/utils/mergeObjects.js
@@ -1,9 +1,10 @@
-const { mergeWith, cloneDeep, isArray } = require('lodash')
+const { mergeWith, isArray } = require('lodash')
 
 // In future this might want to live outside of this bounded context
 module.exports = function mergeObjects(source, ...inputs) {
   return mergeWith(
-    cloneDeep(source),
+    {},
+    source,
     ...inputs,
     // always replace arrays instead of merging
     (objValue, srcValue) => {

--- a/packages/component-submission/server/utils/mergeObjects.test.js
+++ b/packages/component-submission/server/utils/mergeObjects.test.js
@@ -1,0 +1,44 @@
+const mergeObjects = require('./mergeObjects')
+
+describe('mergeObjects', () => {
+  it('returns a merged copy of two objects without mutating source', () => {
+    const objectA = { A: 'A' }
+    const objectB = { B: 'B' }
+    expect(mergeObjects(objectA, objectB)).toEqual({ A: 'A', B: 'B' })
+    expect(objectA).toEqual({ A: 'A' })
+    expect(objectB).toEqual({ B: 'B' })
+  })
+
+  it('merges multiple objects without mutating source', () => {
+    const objectA = { A: 'A' }
+    const objectB = { B: 'B' }
+    const objectC = { C: 'C' }
+    expect(mergeObjects(objectA, objectB, objectC)).toEqual({
+      A: 'A',
+      B: 'B',
+      C: 'C',
+    })
+    expect(objectA).toEqual({ A: 'A' })
+    expect(objectB).toEqual({ B: 'B' })
+    expect(objectC).toEqual({ C: 'C' })
+  })
+
+  it('merges nested objects', () => {
+    const objectA = { foo: { A: 'A' } }
+    const objectB = { foo: { B: 'B' } }
+    expect(mergeObjects(objectA, objectB)).toEqual({ foo: { A: 'A', B: 'B' } })
+  })
+
+  it('replaces source array values with input array', () => {
+    const objectA = { A: ['a'] }
+    const objectB = { A: ['b'] }
+    expect(mergeObjects(objectA, objectB).A).toEqual(['b'])
+  })
+  it('merges objects by priority of order passed', () => {
+    const objectA = { A: 'A' }
+    const objectB = { A: 'B' }
+    const objectC = { A: 'C' }
+    expect(mergeObjects(objectA, objectB)).toEqual({ A: 'B' })
+    expect(mergeObjects(objectA, objectB, objectC)).toEqual({ A: 'C' })
+  })
+})


### PR DESCRIPTION
#### Background

In preparation of using the `Submission` aggregate in the future `updateSubmission` use-case. This PR adds an `updateManuscript` function to the `Submission`.

#### Any relevant tickets

Closes #1996

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
