### PR TITLE
Make the manuscript preview link open the file in a new tab

### DIFF
--- a/packages/component-submission/client/components/ManuscriptUpload.js
+++ b/packages/component-submission/client/components/ManuscriptUpload.js
@@ -140,6 +140,7 @@ const DropzoneContent = ({
           <NativeLink
             data-test-id="manusctipt-download-link"
             href={downloadLink}
+            target="_blank"
           >
             preview{' '}
           </NativeLink>


### PR DESCRIPTION
#### Background
It's bad UX for previewing the manuscript to take over the app tab, this just makes it open in a new tab.
