### PR TITLE
fix validation for the opposed reviewers

### DIFF
--- a/packages/component-submission/client/utils/ValidationSchemas.js
+++ b/packages/component-submission/client/utils/ValidationSchemas.js
@@ -86,13 +86,24 @@ export const editorsSchema = {
     ),
   ),
   opposedReviewers: yup.array(
-    yup.object({
-      name: yup.string().required('Name is required'),
-      email: yup
-        .string()
-        .email('Must be a valid email')
-        .required('Email is required'),
-    }),
+    yup.object().shape(
+      {
+        name: yup.string().when('email', {
+          is: email => email && email.length > 0,
+          then: yup.string().required('Name is required'),
+          otherwise: yup.string(),
+        }),
+        email: yup.string().when('name', {
+          is: name => name && name.length > 0,
+          then: yup
+            .string()
+            .email('Must be a valid email')
+            .required('Email is required'),
+          otherwise: yup.string().email('Must be a valid email'),
+        }),
+      },
+      ['name', 'email'],
+    ),
   ),
   opposedReviewersReason: opposedReasonValidator('opposedReviewers'),
 }

--- a/packages/component-submission/client/utils/ValidationSchemas.test.js
+++ b/packages/component-submission/client/utils/ValidationSchemas.test.js
@@ -41,7 +41,7 @@ describe('Editors Schema', () => {
       opposedReviewingEditors: [{ id: 1 }, { id: 2 }, { id: 3 }],
       opposedReviewingEditorsReason: '',
       suggestedReviewers: [{ name: '', email: 'bloop' }],
-      opposedReviewers: [{ name: 'Jane Doe', email: 'jane@doe.com' }],
+      opposedReviewers: [{ name: '', email: 'boop' }],
       opposedReviewersReason: '',
     }
 
@@ -57,6 +57,9 @@ describe('Editors Schema', () => {
       opposedReviewingEditorsReason: 'Please provide a reason for exclusion',
       opposedSeniorEditorsReason: 'Please provide a reason for exclusion',
       suggestedReviewers: [
+        { email: 'Must be a valid email', name: 'Name is required' },
+      ],
+      opposedReviewers: [
         { email: 'Must be a valid email', name: 'Name is required' },
       ],
       suggestedReviewingEditors: 'Please suggest at least 2 editors',
@@ -92,6 +95,36 @@ describe('Editors Schema', () => {
 
     expect(errors).toEqual({
       suggestedReviewers: [{ email: 'Email is required' }],
+    })
+  })
+
+  it('stops invalid opposed reviewer with no name', () => {
+    const testData = { ...validEditorData }
+    testData.opposedReviewers = [{ name: '', email: 'email@email.com' }]
+    let errors
+    try {
+      schema.validateSync(testData, { abortEarly: false })
+    } catch (e) {
+      errors = yupToFormErrors(e)
+    }
+
+    expect(errors).toEqual({
+      opposedReviewers: [{ name: 'Name is required' }],
+    })
+  })
+
+  it('stops invalid opposed reviewer with no email', () => {
+    const testData = { ...validEditorData }
+    testData.opposedReviewers = [{ name: 'Name', email: '' }]
+    let errors
+    try {
+      schema.validateSync(testData, { abortEarly: false })
+    } catch (e) {
+      errors = yupToFormErrors(e)
+    }
+
+    expect(errors).toEqual({
+      opposedReviewers: [{ email: 'Email is required' }],
     })
   })
 })


### PR DESCRIPTION
#### Background

Copies the validation for the suggested reviewers for the opposed reviewers, these should now be identical and display the same messages.

#### Any relevant tickets

Closes #2005 

#### How has this been tested?
- [x] Unit / Integration tests
