### PR TITLE
2003 - add @pubsweet/models and implement within  resolvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
   "dependencies": {
     "@elifesciences/elife-theme": "^1.0.0",
     "@pubsweet/component-send-email": "^0.2.13",
+    "@pubsweet/models": "^0.2.7",
     "@pubsweet/ui": "^9.0.3",
     "@pubsweet/ui-toolkit": "^2.0.3",
     "@rebass/grid": "^6.0.0-7",

--- a/packages/component-dashboard/server/resolvers.js
+++ b/packages/component-dashboard/server/resolvers.js
@@ -1,14 +1,12 @@
 const logger = require('@pubsweet/logger')
 const { S3Storage } = require('@elifesciences/component-service-s3')
-const User = require('@elifesciences/component-model-user').model
-const Manuscript = require('@elifesciences/component-model-manuscript').model
-const File = require('@elifesciences/component-model-file').model
+const models = require('@pubsweet/models')
 
 const resolvers = {
   Query: {
     async manuscripts(_, vars, { user }) {
-      const userUuid = await User.getUuidForProfile(user)
-      return Manuscript.all(userUuid)
+      const userUuid = await models.User.getUuidForProfile(user)
+      return models.Manuscript.all(userUuid)
     },
   },
 
@@ -17,16 +15,16 @@ const resolvers = {
       if (!user) {
         throw new Error('Not logged in')
       }
-      const userUuid = await User.getUuidForProfile(user)
-      const manuscript = Manuscript.makeInitial({ createdBy: userUuid })
+      const userUuid = await models.User.getUuidForProfile(user)
+      const manuscript = models.Manuscript.makeInitial({ createdBy: userUuid })
       manuscript.setDefaults()
       return manuscript.save()
     },
 
     async deleteManuscript(_, { id }, { user }) {
-      const userUuid = await User.getUuidForProfile(user)
-      const manuscript = await Manuscript.find(id, userUuid)
-      const files = await File.findByManuscriptId(id)
+      const userUuid = await models.User.getUuidForProfile(user)
+      const manuscript = await models.Manuscript.find(id, userUuid)
+      const files = await models.File.findByManuscriptId(id)
       if (files) {
         try {
           await files.forEach(file => {

--- a/packages/component-model-semantic-extraction/index.js
+++ b/packages/component-model-semantic-extraction/index.js
@@ -1,3 +1,6 @@
 const SemanticExtraction = require('./entities/semanticExtraction')
 
-module.exports = SemanticExtraction
+module.exports = {
+  model: SemanticExtraction,
+  modelName: 'SemanticExtraction',
+}

--- a/packages/component-submission/server/resolvers/index.js
+++ b/packages/component-submission/server/resolvers/index.js
@@ -1,14 +1,12 @@
 const config = require('config')
 const logger = require('@pubsweet/logger')
-const User = require('@elifesciences/component-model-user').model
-const ManuscriptModel = require('@elifesciences/component-model-manuscript')
-  .model
-const FileModel = require('@elifesciences/component-model-file').model
+const models = require('@pubsweet/models')
+
 const { S3Storage } = require('@elifesciences/component-service-s3')
 const elifeApi = require('@elifesciences/component-model-user/entities/user/helpers/elife-api')
 const {
   getPubsub,
-  asyncIterators,
+  asyncIterators: { ON_UPLOAD_PROGRESS },
 } = require('pubsweet-server/src/graphql/pubsub')
 
 const removeUploadedManuscript = require('./removeUploadedManuscript')
@@ -21,17 +19,12 @@ const removeSupportingFiles = require('./removeSupportingFiles')
 const { Manuscript, getSubmissionUseCase } = require('../use-cases')
 const { Submission } = require('../aggregates')
 
-const { ON_UPLOAD_PROGRESS } = asyncIterators
-
 const resolvers = {
   Query: {
     async manuscript(_, { id }, { user }) {
-      const userUuid = await User.getUuidForProfile(user)
+      const userUuid = await models.User.getUuidForProfile(user)
       const submission = new Submission({
-        models: {
-          Manuscript: ManuscriptModel,
-          File: FileModel,
-        },
+        models,
         services: {
           Storage: S3Storage,
         },
@@ -60,8 +53,8 @@ const resolvers = {
     removeSupportingFiles,
 
     async savePage(_, vars, { user }) {
-      const userUuid = await User.getUuidForProfile(user)
-      const manuscriptModel = await ManuscriptModel.find(vars.id, userUuid)
+      const userUuid = await models.User.getUuidForProfile(user)
+      const manuscriptModel = await models.Manuscript.find(vars.id, userUuid)
       const manuscript = new Manuscript(config, userUuid, S3Storage)
 
       manuscriptModel.lastStepVisited = vars.url

--- a/packages/component-submission/server/use-cases/helpers/files.js
+++ b/packages/component-submission/server/use-cases/helpers/files.js
@@ -1,6 +1,7 @@
 const logger = require('@pubsweet/logger')
 const FileModel = require('@elifesciences/component-model-file').model
 const SemanticExtractionModel = require('@elifesciences/component-model-semantic-extraction')
+  .model
 
 const cleanOldManuscript = async fileList => {
   const oldFileIndex = fileList.findIndex(

--- a/packages/component-submission/server/use-cases/helpers/files.test.js
+++ b/packages/component-submission/server/use-cases/helpers/files.test.js
@@ -4,6 +4,7 @@ const stream = require('stream')
 const { createTables } = require('@elifesciences/component-model')
 const logger = require('@pubsweet/logger')
 const SemanticExtraction = require('@elifesciences/component-model-semantic-extraction')
+  .model
 const ManuscriptModel = require('@elifesciences/component-model-manuscript')
   .model
 const FilesHelper = require('./files')

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,6 +424,15 @@
     joi "^14.3.0"
     lodash "^4.17.4"
 
+"@pubsweet/logger@^0.2.20":
+  version "0.2.20"
+  resolved "https://registry.yarnpkg.com/@pubsweet/logger/-/logger-0.2.20.tgz#7e4d575ede19e6f6e2ce9b8cf9ad9fe088e662b4"
+  integrity sha512-J1sV5PE/68Wf6mhMxkj81ZpySLaWMjwd1AIhfNOsWWD8aUGyiu/u+GjUZvGcodo78NVybIGpdwAipKcvnjIVjQ==
+  dependencies:
+    config "^3.0.1"
+    joi "^14.3.0"
+    lodash "^4.17.4"
+
 "@pubsweet/logger@^0.2.8":
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/@pubsweet/logger/-/logger-0.2.8.tgz#3e178d9c7ab0f181df00d1abc655a097f5d8fea9"
@@ -440,6 +449,13 @@
   dependencies:
     objection "^1.5.3"
     pubsweet-server "^13.2.0"
+
+"@pubsweet/models@^0.2.7":
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/@pubsweet/models/-/models-0.2.7.tgz#0a0cf77138112e29b49bbf8eec7b8810e9db85b4"
+  integrity sha512-bYhse3dyrZ4J34nJVxU28auuJ/pbKPQgZzfcy0p43Zh7gIxFq0ChPzLSNBib8ot8Q4b1GHpQfw3G+cbTdzCeCw==
+  dependencies:
+    "@pubsweet/logger" "^0.2.20"
 
 "@pubsweet/ui-toolkit@^2.0.1", "@pubsweet/ui-toolkit@^2.0.3":
   version "2.0.3"


### PR DESCRIPTION
#### Background

Adds `@pubsweet/models` and use models export in resolver files.

Bring `SemanticExtraction`'s export file inline with other models.

#### Any relevant tickets

closes #2003 
