### PR TITLE
decoupled the add supporting files messages from the manuscript state

### DIFF
--- a/packages/component-submission/client/components/SupportingUpload.js
+++ b/packages/component-submission/client/components/SupportingUpload.js
@@ -284,14 +284,14 @@ class SupportingUpload extends React.Component {
             </FileBlock>
           ))}
         </StyledDropzone>
-        {hasManuscript &&
+        {(hasManuscript || successfullyUploadedFiles.length > 0) &&
           !this.state.uploading && (
             <React.Fragment>
               <Flex>
                 {successfullyUploadedFiles.length < MAX_SUPPORTING_FILES && (
                   <React.Fragment>
-                    <UploadControl>
-                      Add more{' '}
+                    <UploadControl data-test-id="supporting-files-upload-control">
+                      Add {successfullyUploadedFiles.length > 0 && 'more'}{' '}
                       <UploadLink
                         data-test-id="supportingFilesLink"
                         onClick={() => dropzoneRef.open()}
@@ -319,12 +319,11 @@ class SupportingUpload extends React.Component {
               </Flex>
             </React.Fragment>
           )}
-        {hasManuscript &&
-          successfullyUploadedFiles.length > 9 && (
-            <ValidationText>
-              Maximum {MAX_SUPPORTING_FILES} supporting files
-            </ValidationText>
-          )}
+        {successfullyUploadedFiles.length > MAX_SUPPORTING_FILES - 1 && (
+          <ValidationText data-test-id="supporting-files-validation-text">
+            Maximum {MAX_SUPPORTING_FILES} supporting files
+          </ValidationText>
+        )}
       </React.Fragment>
     )
   }

--- a/packages/component-submission/client/components/SupportingUpload.test.js
+++ b/packages/component-submission/client/components/SupportingUpload.test.js
@@ -3,35 +3,92 @@ import { mount } from 'enzyme'
 import { MemoryRouter } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import theme from '@elifesciences/elife-theme'
+import { range } from 'lodash'
 import SupportingUpload from './SupportingUpload'
 
 const WrappedComponent = props => (
   <ThemeProvider theme={theme}>
     <MemoryRouter>
-      <SupportingUpload onDrop={jest.fn()} {...props} />
+      <SupportingUpload
+        data-test-id="test-supporting-upload"
+        onDrop={jest.fn()}
+        {...props}
+      />
     </MemoryRouter>
   </ThemeProvider>
 )
 
 const makeWrapper = props => mount(<WrappedComponent {...props} />)
+const createFiles = count =>
+  range(count).map(num => ({
+    filename: `foo${num}.png`,
+    type: 'SUPPORTING_FILE',
+  }))
 
 describe('SupportingUpload', () => {
+  it('shows no text for "add" when no supporting files or manuscrip are uploaded', () => {
+    const wrapper = makeWrapper({
+      hasManuscript: false,
+      files: [],
+    })
+    expect(
+      wrapper.find('[data-test-id="supporting-files-upload-control"] > div'),
+    ).toHaveLength(0)
+  })
+
   it('Shows existing files from manuscript value', () => {
     const wrapper = makeWrapper({
       hasManuscript: true,
-      files: [
-        {
-          filename: 'Foo.png',
-          type: 'SUPPORTING_FILE',
-        },
-        {
-          filename: 'Bar.png',
-          type: 'SUPPORTING_FILE',
-        },
-      ],
+      files: createFiles(2),
     })
     expect(wrapper.find('[data-test-id="file-block-name"] span')).toHaveLength(
       2,
     )
+  })
+
+  it('shows the correct text for add (more) when supporting files exist', () => {
+    let wrapper = makeWrapper({
+      hasManuscript: true,
+      files: [],
+    })
+    expect(
+      wrapper
+        .find('[data-test-id="supporting-files-upload-control"] > div')
+        .text(),
+    ).toEqual('Add  supporting files (optional)')
+
+    wrapper = makeWrapper({
+      hasManuscript: true,
+      files: createFiles(1),
+    })
+    expect(
+      wrapper
+        .find('[data-test-id="supporting-files-upload-control"] > div')
+        .text(),
+    ).toEqual('Add more supporting files (optional)')
+  })
+
+  it('shows the correct validation text when more than 9 files are added', () => {
+    const wrapper = makeWrapper({
+      hasManuscript: true,
+      files: createFiles(10),
+    })
+    expect(
+      wrapper
+        .find('[data-test-id="supporting-files-validation-text"] > div')
+        .text(),
+    ).toEqual('Maximum 10 supporting files')
+  })
+
+  it('Shows the "Add more supporting files (optional)" message when there are files but no manuscript', () => {
+    const wrapper = makeWrapper({
+      hasManuscript: false,
+      files: createFiles(2),
+    })
+    expect(
+      wrapper
+        .find('[data-test-id="supporting-files-upload-control"] > div')
+        .text(),
+    ).toEqual('Add more supporting files (optional)')
   })
 })

--- a/packages/component-submission/client/components/SupportingUpload.test.js
+++ b/packages/component-submission/client/components/SupportingUpload.test.js
@@ -9,11 +9,7 @@ import SupportingUpload from './SupportingUpload'
 const WrappedComponent = props => (
   <ThemeProvider theme={theme}>
     <MemoryRouter>
-      <SupportingUpload
-        data-test-id="test-supporting-upload"
-        onDrop={jest.fn()}
-        {...props}
-      />
+      <SupportingUpload onDrop={jest.fn()} {...props} />
     </MemoryRouter>
   </ThemeProvider>
 )


### PR DESCRIPTION
#### Background

decouples the add supporting files messages from the manuscript state:

- no manuscript && no supporting files => no messages
- manuscript && no supporting files => "add supporting..." message
- no manuscript && some supporting files => "add more..." message
- 10 supporting files => "Max 10...." message

#### Any relevant tickets

Closes #2000 

#### How has this been tested?
- [x] Unit / Integration tests
