### PR TITLE
2016 - add optional flag to Subject Area label when article type is feature

### DIFF
--- a/packages/component-submission/client/components/SubjectAreaDropdown.js
+++ b/packages/component-submission/client/components/SubjectAreaDropdown.js
@@ -171,7 +171,7 @@ class SubjectAreaDropdown extends React.Component {
 
   render() {
     const { selectedOptions, hasReachedMultiselectLimit } = this.state
-    const { label, name, onBlur, theme } = this.props
+    const { label, name, onBlur, theme, isOptional } = this.props
 
     const TagRemovalIcon = props => (
       <components.MultiValueRemove {...props}>
@@ -202,7 +202,10 @@ class SubjectAreaDropdown extends React.Component {
       <Root>
         {/* htmlFor matches with react-select's inputId, which applies the correct id to the internal sub-component */}
         {/* eslint-disable-next-line jsx-a11y/label-has-for */}
-        <Label htmlFor="subject-area-select">{label}</Label>
+        <Label htmlFor="subject-area-select">
+          {label}
+          {isOptional && ' (optional)'}
+        </Label>
         {!hasReachedMultiselectLimit && <Select {...selectChildProps} />}
         {hasReachedMultiselectLimit && (
           <div>

--- a/packages/component-submission/client/components/SubjectAreaDropdown.test.js
+++ b/packages/component-submission/client/components/SubjectAreaDropdown.test.js
@@ -25,6 +25,36 @@ describe('SubjectAreaDropdown component', () => {
     expect(wrapper.find('[inputId="subject-area-select"]').exists()).toBe(true)
     expect(wrapper.text()).not.toContain('No more than two subject areas')
   })
+  it('has optional in label if isOptional is passed', () => {
+    const wrapper = mount(
+      <SubjectAreaDropdown
+        isOptional
+        label="My label"
+        name="My name"
+        onBlur={handleBlur}
+        onChange={handleChange}
+        savedValues={[]}
+        theme={theme}
+      />,
+    )
+
+    expect(wrapper.find('label').text()).toBe('My label (optional)')
+  })
+
+  it('only outputs label if isOptional is not passed', () => {
+    const wrapper = mount(
+      <SubjectAreaDropdown
+        label="My label"
+        name="My name"
+        onBlur={handleBlur}
+        onChange={handleChange}
+        savedValues={[]}
+        theme={theme}
+      />,
+    )
+
+    expect(wrapper.find('label').text()).toBe('My label')
+  })
 
   describe('Integration with react-select', () => {
     let wrapper, selectWrapper, selectInput

--- a/packages/component-submission/client/pages/SubmissionPage.js
+++ b/packages/component-submission/client/pages/SubmissionPage.js
@@ -49,6 +49,7 @@ const SubmissionPage = ({ values, setFieldValue, setFieldTouched }) => (
     <Box mb={3}>
       <ValidatedField
         component={SubjectAreaDropdown}
+        isOptional={values.meta.articleType === 'feature'}
         label="Subject areas"
         name="meta.subjects"
         onBlur={e => setFieldTouched('meta.subjects', true)}


### PR DESCRIPTION
#### Background

Adds an (optional) flag to the Subject Area label when the Article Type is `feature`

#### Any relevant tickets

Closes #2016

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
