### PR TITLE
2020 - rediect to a given config url on logout

### DIFF
--- a/config/__tests__/__snapshots__/config.ci.test.js.snap
+++ b/config/__tests__/__snapshots__/config.ci.test.js.snap
@@ -45,6 +45,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "logout.isPublic",
   "mailer.from",
   "mailer.path",
   "aws.credentials.region",

--- a/config/__tests__/__snapshots__/config.default.test.js.snap
+++ b/config/__tests__/__snapshots__/config.default.test.js.snap
@@ -45,6 +45,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "logout.isPublic",
   "mailer.from",
   "mailer.path",
   "aws.credentials.region",

--- a/config/__tests__/__snapshots__/config.development.test.js.snap
+++ b/config/__tests__/__snapshots__/config.development.test.js.snap
@@ -48,6 +48,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "logout.isPublic",
   "mailer.from",
   "mailer.path",
   "aws.credentials.region",

--- a/config/__tests__/__snapshots__/config.end2end.test.js.snap
+++ b/config/__tests__/__snapshots__/config.end2end.test.js.snap
@@ -45,6 +45,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "logout.isPublic",
   "mailer.from",
   "mailer.path",
   "aws.credentials.region",

--- a/config/__tests__/__snapshots__/config.prod.test.js.snap
+++ b/config/__tests__/__snapshots__/config.prod.test.js.snap
@@ -45,6 +45,8 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "logout.isPublic",
+  "logout.redirectUrl",
   "mailer.from",
   "mailer.path",
   "aws.credentials.region",

--- a/config/__tests__/__snapshots__/config.staging.test.js.snap
+++ b/config/__tests__/__snapshots__/config.staging.test.js.snap
@@ -45,6 +45,8 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "logout.isPublic",
+  "logout.redirectUrl",
   "mailer.from",
   "mailer.path",
   "aws.credentials.region",

--- a/config/__tests__/__snapshots__/config.test.test.js.snap
+++ b/config/__tests__/__snapshots__/config.test.test.js.snap
@@ -46,6 +46,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "logout.isPublic",
   "mailer.from",
   "mailer.path",
   "mailer.transport.sendmail",

--- a/config/default.js
+++ b/config/default.js
@@ -92,6 +92,9 @@ module.exports = {
     signupUrl: 'https://orcid.org/register',
     legacySubmissionUrl: 'https://submit.elifesciences.org',
   },
+  logout: {
+    isPublic: true,
+  },
   mailer: {
     from: 'dev@example.com',
     path: `${__dirname}/non-serializable/fake-mailer`,

--- a/config/development.js
+++ b/config/development.js
@@ -23,7 +23,6 @@ module.exports = {
     url: '/mock-token-exchange/ewwboc7m',
     enableMock: true,
   },
-
   forever: {
     watchDirectory: path.resolve(__dirname, '..', 'packages'),
   },

--- a/config/prod.js
+++ b/config/prod.js
@@ -14,6 +14,9 @@ module.exports = {
     url: 'https://elifesciences.org/submit',
     enableMock: false,
   },
+  logout: {
+    redirectUrl: 'https://elifesciences.org/log-out',
+  },
   meca: {
     email: {
       recipient: 'xpub-tech-alerts@elifesciences.org',

--- a/config/staging.js
+++ b/config/staging.js
@@ -14,6 +14,9 @@ module.exports = {
     url: 'https://continuumtest--cdn-journal.elifesciences.org/submit',
     enableMock: false,
   },
+  logout: {
+    redirectUrl: 'https://continuumtest--cdn-journal.elifesciences.org/log-out',
+  },
   mailer: {
     from: 'editorial-staging@elifesciences.org',
     path: `${__dirname}/non-serializable/mailer`,

--- a/packages/component-login/client/pages/LogoutPage.js
+++ b/packages/component-login/client/pages/LogoutPage.js
@@ -1,12 +1,17 @@
 import React from 'react'
 import { Redirect } from 'react-router-dom'
 import { withApollo } from 'react-apollo'
+import config from 'config'
 
 class LogoutPage extends React.Component {
   constructor(props) {
     super(props)
     window.localStorage.removeItem('token')
     this.props.client.resetStore()
+
+    if (config.logout.redirectUrl) {
+      window.location = config.logout.redirectUrl
+    }
   }
 
   render() {


### PR DESCRIPTION
#### Background

The user should be signed out of the journal and be redirected back to the journals home page if they log out of reviewer. This PR adds this redirect based on a config value after clearing the local apollo store and removing the reviewer session storage token.

#### Any relevant tickets

closes #2020 

