### PR TITLE
2039: don't use Manuscript model

### DIFF
--- a/packages/component-submission/server/resolvers/removeSupportingFiles.test.js
+++ b/packages/component-submission/server/resolvers/removeSupportingFiles.test.js
@@ -12,6 +12,7 @@ const dummyStorage = {
   deleteContent: async () => ({
     promise: Promise.resolve(true),
   }),
+  getDownloadLink: jest.fn(),
 }
 
 const expectRemoveSupportingFilesDoesNothing = async (manuscriptIn, userId) => {

--- a/packages/component-submission/server/use-cases/supportingFiles.js
+++ b/packages/component-submission/server/use-cases/supportingFiles.js
@@ -1,5 +1,7 @@
 const config = require('config')
 const FileModel = require('@elifesciences/component-model-file').model
+const ManuscriptModel = require('@elifesciences/component-model-manuscript')
+  .model
 const logger = require('@pubsweet/logger')
 const Manuscript = require('./manuscript')
 
@@ -50,10 +52,8 @@ class SupportingFiles {
   async removeAll() {
     const manuscript = new Manuscript(config, this.userId, this.storage)
 
-    // let manuscript = await ManuscriptModel.find(this.manuscriptId, this.userId)
-    // const filesWithoutSupporting = manuscript.files.filter(
-    //   file => file.type !== 'SUPPORTING_FILE',
-    // )
+    // we need to do a find to make sure the user has access
+    await ManuscriptModel.find(this.manuscriptId, this.userId)
 
     const files = await FileModel.findByManuscriptId(this.manuscriptId)
 
@@ -73,10 +73,6 @@ class SupportingFiles {
             }
           }),
       )
-      // if (modified) {
-      //   manuscript.files = filesWithoutSupporting
-      //   manuscript = await manuscript.save()
-      // }
     }
 
     return manuscript.getView(this.manuscriptId)

--- a/packages/component-submission/server/use-cases/supportingFiles.js
+++ b/packages/component-submission/server/use-cases/supportingFiles.js
@@ -58,13 +58,11 @@ class SupportingFiles {
     const files = await FileModel.findByManuscriptId(this.manuscriptId)
 
     if (files && files.length > 0) {
-      // let modified = false
       await Promise.all(
         files
           .filter(file => file.type === 'SUPPORTING_FILE')
           .map(async file => {
             try {
-              // modified = true
               await file.updateStatus('CANCELLED')
               await this.storage.deleteContent(file)
               await file.delete()

--- a/packages/component-submission/server/use-cases/supportingFiles.js
+++ b/packages/component-submission/server/use-cases/supportingFiles.js
@@ -1,7 +1,7 @@
-const ManuscriptModel = require('@elifesciences/component-model-manuscript')
-  .model
+const config = require('config')
 const FileModel = require('@elifesciences/component-model-file').model
 const logger = require('@pubsweet/logger')
+const Manuscript = require('./manuscript')
 
 class SupportingFiles {
   constructor(storage, manuscriptId, userId) {
@@ -48,21 +48,23 @@ class SupportingFiles {
   }
 
   async removeAll() {
-    let manuscript = await ManuscriptModel.find(this.manuscriptId, this.userId)
-    const filesWithoutSupporting = manuscript.files.filter(
-      file => file.type !== 'SUPPORTING_FILE',
-    )
+    const manuscript = new Manuscript(config, this.userId, this.storage)
+
+    // let manuscript = await ManuscriptModel.find(this.manuscriptId, this.userId)
+    // const filesWithoutSupporting = manuscript.files.filter(
+    //   file => file.type !== 'SUPPORTING_FILE',
+    // )
 
     const files = await FileModel.findByManuscriptId(this.manuscriptId)
 
     if (files && files.length > 0) {
-      let modified = false
+      // let modified = false
       await Promise.all(
         files
           .filter(file => file.type === 'SUPPORTING_FILE')
           .map(async file => {
             try {
-              modified = true
+              // modified = true
               await file.updateStatus('CANCELLED')
               await this.storage.deleteContent(file)
               await file.delete()
@@ -71,13 +73,13 @@ class SupportingFiles {
             }
           }),
       )
-      if (modified) {
-        manuscript.files = filesWithoutSupporting
-        manuscript = await manuscript.save()
-      }
+      // if (modified) {
+      //   manuscript.files = filesWithoutSupporting
+      //   manuscript = await manuscript.save()
+      // }
     }
 
-    return manuscript
+    return manuscript.getView(this.manuscriptId)
   }
 }
 


### PR DESCRIPTION
#### Background

Changes the removeSupportingFiles resolver underlying logic so that the Manuscript model's save method isn't called. This should reduce the amount of browser test failures

#### Any relevant tickets

Closes #2039 


