### PR TITLE
2104 - fix null last step

### DIFF
--- a/packages/component-dashboard/client/components/DashboardListItem.js
+++ b/packages/component-dashboard/client/components/DashboardListItem.js
@@ -170,7 +170,11 @@ const DashboardListItem = ({ manuscript, onDelete }) => {
             <Fragment>
               <DashboardLink
                 data-test-id="continue-submission"
-                to={`${manuscript.lastStepVisited}`}
+                to={
+                  manuscript.lastStepVisited
+                    ? `${manuscript.lastStepVisited}`
+                    : `/submit/${manuscript.id}/author`
+                }
               >
                 <DashboardListItemContent
                   manuscript={manuscript}

--- a/packages/component-dashboard/client/components/DashboardListItem.test.js
+++ b/packages/component-dashboard/client/components/DashboardListItem.test.js
@@ -1,12 +1,28 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import { subDays } from 'date-fns'
+
+import { ThemeProvider } from 'styled-components'
+import { MemoryRouter } from 'react-router-dom'
+import { MockedProvider } from 'react-apollo/test-utils'
+import theme from '@elifesciences/elife-theme'
 
 import DashboardListItem, {
   dashboardDateText,
   DashboardListItemContent,
 } from './DashboardListItem'
 import ManuscriptStatus from './ManuscriptStatus'
+
+const makeMountedWrapper = (props = {}) =>
+  mount(
+    <ThemeProvider theme={theme}>
+      <MemoryRouter>
+        <MockedProvider>
+          <DashboardListItem {...props} />,
+        </MockedProvider>
+      </MemoryRouter>
+    </ThemeProvider>,
+  )
 
 describe('DashboardListItem', () => {
   describe('dashboardDateText', () => {
@@ -85,6 +101,42 @@ describe('DashboardListItem', () => {
       )
 
       expect(wrapper.find('ModalHistoryState')).toHaveLength(0)
+    })
+    it('links to author step when lastStepVisited is null', () => {
+      const dummyManuscript = {
+        id: 'foo',
+        meta: {
+          title: 'MockTitle',
+        },
+        lastStepVisited: null,
+        clientStatus: 'CONTINUE_SUBMISSION',
+        updated: '2019-04-03T15:24:07.190Z',
+      }
+
+      const wrapper = makeMountedWrapper({
+        manuscript: dummyManuscript,
+        onDelete: () => {},
+      })
+
+      expect(wrapper.find('Link').prop('to')).toBe('/submit/foo/author')
+    })
+
+    it('links to the lastStepVisited if present on manuscript', () => {
+      const dummyManuscript = {
+        id: 'foo',
+        meta: {
+          title: 'MockTitle',
+        },
+        lastStepVisited: '/submit/foo/files',
+        clientStatus: 'CONTINUE_SUBMISSION',
+        updated: '2019-04-03T15:24:07.190Z',
+      }
+
+      const wrapper = makeMountedWrapper({
+        manuscript: dummyManuscript,
+        onDelete: () => {},
+      })
+      expect(wrapper.find('Link').prop('to')).toBe('/submit/foo/files')
     })
   })
 })

--- a/packages/component-dashboard/server/resolvers.js
+++ b/packages/component-dashboard/server/resolvers.js
@@ -19,7 +19,7 @@ const resolvers = {
       const manuscript = models.Manuscript.makeInitial({ createdBy: userUuid })
       manuscript.setDefaults()
       await manuscript.save()
-      //id generated on $beforeInsert so need to save before setting lastStepVisited
+      // id generated on $beforeInsert so need to save before setting lastStepVisited
       manuscript.lastStepVisited = `/submit/${manuscript.id}/author`
       return manuscript.save()
     },

--- a/packages/component-dashboard/server/resolvers.js
+++ b/packages/component-dashboard/server/resolvers.js
@@ -19,6 +19,7 @@ const resolvers = {
       const manuscript = models.Manuscript.makeInitial({ createdBy: userUuid })
       manuscript.setDefaults()
       await manuscript.save()
+      //id generated on $beforeInsert so need to save before setting lastStepVisited
       manuscript.lastStepVisited = `/submit/${manuscript.id}/author`
       return manuscript.save()
     },

--- a/packages/component-dashboard/server/resolvers.js
+++ b/packages/component-dashboard/server/resolvers.js
@@ -18,6 +18,8 @@ const resolvers = {
       const userUuid = await models.User.getUuidForProfile(user)
       const manuscript = models.Manuscript.makeInitial({ createdBy: userUuid })
       manuscript.setDefaults()
+      await manuscript.save()
+      manuscript.lastStepVisited = `/submit/${manuscript.id}/author`
       return manuscript.save()
     },
 

--- a/packages/component-dashboard/server/resolvers.test.js
+++ b/packages/component-dashboard/server/resolvers.test.js
@@ -67,5 +67,15 @@ describe('component-dashboard resolvers', () => {
       expect(manuscripts.length).toBeGreaterThan(0)
       expect(manuscripts[0].id).toBe(manuscript.id)
     })
+
+    it('adds new manuscript to the db for current user with correct lastStepVisited', async () => {
+      await Mutation.createManuscript({}, {}, { user: profileId })
+
+      const manuscripts = await Manuscript.findByStatus('INITIAL', userId)
+      expect(manuscripts.length).toBeGreaterThan(0)
+      expect(manuscripts[0].lastStepVisited).toBe(
+        `/submit/${manuscripts[0].id}/author`,
+      )
+    })
   })
 })


### PR DESCRIPTION
#### Background

Gives a new submission an initial `lastStepVisited`  value of `/submit/${id}/author` when it is created to prevent the `null` link if the user navigates away before auto save. Also adds protections into the `DashboardListItem` to link to author step if `lastStepVisited` is `null`.

#### Any relevant tickets

closes #2104

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
