### PR TITLE
2105: restructure submitManuscript tests to test export functionality seperately

### DIFF
--- a/packages/component-submission/server/resolvers/__snapshots__/submitManuscript.test.js.snap
+++ b/packages/component-submission/server/resolvers/__snapshots__/submitManuscript.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Manuscripts submitManuscript sends a confirmation email to the submitter 1`] = `
+exports[`Manuscripts submitManuscript runExport sends a confirmation email to the submitter 1`] = `
 "Dear Firstname,
 
 You have just submitted your work, \\"My manuscript\\", to eLife using our brand new submission interface. Our aim is to create an application that makes the process of publishing your research faster and simpler. It is a work in progress and we welcome any feedback you may have on your experience.
@@ -19,7 +19,7 @@ eLife Sciences Publications, Ltd is a limited liability non-profit non-stock cor
 You are receiving this email because you have been identified as the corresponding author of a submission to eLife. If this isn't you please contact editorial@elifesciences.org."
 `;
 
-exports[`Manuscripts submitManuscript sends a confirmation email to the submitter 2`] = `
+exports[`Manuscripts submitManuscript runExport sends a confirmation email to the submitter 2`] = `
 "<p>Dear Firstname,</p><p>You have just submitted your work, \\"My manuscript\\", to eLife using our brand new submission interface. Our aim is to create an application that makes the process of publishing your research faster and simpler. It is a work in progress and we welcome any feedback you may have on your experience.</p><p>You will hear from us again shortly once your submission has undergone our quality check process and been assigned to a Senior Editor for initial evaluation. You may be asked to continue your submission using our legacy system.</p><p>Best wishes,</p><p>Susanna</p><p>Susanna Richmond</p><p>Senior Editorial Assistant, eLife
 eLife Sciences Publications, Ltd is a limited liability non-profit non-stock corporation incorporated in the State of Delaware, USA, with company number 5030732, and is registered in the UK with company number FC030576 and branch number BR015634 at the address, Westbrook Centre, Milton Road, Cambridge CB4 1YG.</p><p>You are receiving this email because you have been identified as the corresponding author of a submission to eLife. If this isn't you please contact editorial@elifesciences.org</p>"
 `;

--- a/packages/component-submission/server/resolvers/submitManuscript.test.js
+++ b/packages/component-submission/server/resolvers/submitManuscript.test.js
@@ -4,6 +4,7 @@ jest.mock('@elifesciences/component-meca', () => ({
 }))
 
 const lodash = require('lodash')
+const flushPromises = require('flush-promises')
 const logger = require('@pubsweet/logger')
 const { createTables } = require('@elifesciences/component-model')
 const mailer = require('@pubsweet/component-send-email')
@@ -37,6 +38,7 @@ describe('Manuscripts', () => {
 
   beforeEach(async () => {
     replaySetup('success')
+    await flushPromises()
     await createTables(true)
     const [user] = await Promise.all([
       User.createWithIdentity(profileId),

--- a/packages/component-submission/server/resolvers/submitManuscript.test.js
+++ b/packages/component-submission/server/resolvers/submitManuscript.test.js
@@ -4,7 +4,6 @@ jest.mock('@elifesciences/component-meca', () => ({
 }))
 
 const lodash = require('lodash')
-const flushPromises = require('flush-promises')
 const logger = require('@pubsweet/logger')
 const { createTables } = require('@elifesciences/component-model')
 const mailer = require('@pubsweet/component-send-email')
@@ -12,9 +11,8 @@ const { mecaExport } = require('@elifesciences/component-meca')
 const User = require('@elifesciences/component-model-user').model
 const Manuscript = require('@elifesciences/component-model-manuscript').model
 const { S3Storage } = require('@elifesciences/component-service-s3')
-const { submitManuscript } = require('./submitManuscript')
+const { submitManuscript, runExport } = require('./submitManuscript')
 
-const { Mutation } = require('.')
 const {
   userData,
   badUserData,
@@ -38,9 +36,6 @@ describe('Manuscripts', () => {
 
   beforeEach(async () => {
     replaySetup('success')
-    // flush promises to prevent deadlock, this can happen when we are not mocking the
-    // runExport method for the submitManuscript mutation
-    await flushPromises()
     await createTables(true)
     const [user] = await Promise.all([
       User.createWithIdentity(profileId),
@@ -108,6 +103,8 @@ describe('Manuscripts', () => {
 
     it('throws error if manuscript fileStatus is not READY', async () => {
       let manuscript = await Manuscript.find(id, userId)
+      const mockedExportFn = jest.fn(() => Promise.resolve())
+
       manuscript.files.push({
         url: 'fake-path.pdf',
         filename: 'FakeManuscript.pdf',
@@ -116,11 +113,11 @@ describe('Manuscripts', () => {
       })
       manuscript = await manuscript.save()
 
-      expect.assertions(4)
+      expect.assertions(3)
       expect(manuscript.files).toHaveLength(2)
       expect(manuscript.fileStatus).toBe('CHANGING')
       await expect(
-        Mutation.submitManuscript(
+        submitManuscript(mockedExportFn)(
           {},
           { data: { ...manuscriptInput, id } },
           { user: profileId },
@@ -130,41 +127,20 @@ describe('Manuscripts', () => {
           manuscriptId: manuscript.id,
         }),
       )
-      const NUM_EMAILS = 0
-      await waitforEmails(NUM_EMAILS)
-      expect(mailer.getMails()).toHaveLength(NUM_EMAILS)
-    })
-
-    it('sends a confirmation email to the submitter', async () => {
-      await Mutation.submitManuscript(
-        {},
-        { data: { ...manuscriptInput, id } },
-        { user: profileId },
-      )
-      const NUM_EMAILS = 1
-      await waitforEmails(NUM_EMAILS)
-      const allEmails = mailer.getMails()
-
-      expect(allEmails).toHaveLength(NUM_EMAILS)
-      expect(allEmails[0]).toMatchObject({
-        subject: 'Your eLife submission',
-        to: 'mymail@mail.com',
-        from: 'editorial@elifesciences.org',
-      })
-      expect(allEmails[0].text).toMatchSnapshot()
-      expect(allEmails[0].html).toMatchSnapshot()
     })
 
     it('calls meca export with correct arguments', async () => {
       const ip = '1.2.3.4'
-      await Mutation.submitManuscript(
+      const mockedExportFn = jest.fn(() => Promise.resolve())
+
+      await submitManuscript(mockedExportFn)(
         {},
         { data: { ...manuscriptInput, id } },
         { user: profileId, ip },
       )
 
-      expect(mecaExport).toHaveBeenCalled()
-      const [actualManuscript, , actualIp] = mecaExport.mock.calls[0]
+      expect(mockedExportFn).toHaveBeenCalled()
+      const [actualManuscript, , actualIp] = mockedExportFn.mock.calls[0]
 
       expect(actualManuscript.id).toBe(id)
       expect(actualIp).toBe(ip)
@@ -172,6 +148,8 @@ describe('Manuscripts', () => {
 
     it('removes blank optional reviewer rows', async () => {
       const input = lodash.cloneDeep(manuscriptInput)
+      const mockedExportFn = jest.fn(() => Promise.resolve())
+
       input.id = id
       input.suggestedReviewers = [
         { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
@@ -181,7 +159,11 @@ describe('Manuscripts', () => {
         { name: 'Reviewer 4', email: 'reviewer4@mail.com' },
         { name: '', email: '' },
       ]
-      await Mutation.submitManuscript({}, { data: input }, { user: profileId })
+      await submitManuscript(mockedExportFn)(
+        {},
+        { data: input },
+        { user: profileId },
+      )
 
       const manuscript = await Manuscript.find(id, userId)
       const team = manuscript.teams.find(t => t.role === 'suggestedReviewer')
@@ -196,8 +178,10 @@ describe('Manuscripts', () => {
     it("fails if manuscript doesn't belong to user", async () => {
       const blankManuscript = Manuscript.makeInitial({ createdBy: userId })
       const manuscript = await blankManuscript.save()
+      const mockedExportFn = jest.fn(() => Promise.resolve())
+
       await expect(
-        Mutation.submitManuscript(
+        submitManuscript(mockedExportFn)(
           {},
           { data: { id: manuscript.id } },
           { user: badProfileId },
@@ -211,8 +195,10 @@ describe('Manuscripts', () => {
         status: Manuscript.statuses.MECA_EXPORT_PENDING,
       })
       const manuscript = await blankManuscript.save()
+      const mockedExportFn = jest.fn(() => Promise.resolve())
+
       await expect(
-        Mutation.submitManuscript(
+        submitManuscript(mockedExportFn)(
           {},
           { data: { id: manuscript.id } },
           { user: profileId },
@@ -228,8 +214,10 @@ describe('Manuscripts', () => {
         id,
         title: 'Some Title',
       }
+      const mockedExportFn = jest.fn(() => Promise.resolve())
+
       await expect(
-        Mutation.submitManuscript(
+        submitManuscript(mockedExportFn)(
           {},
           { data: badManuscript },
           { user: profileId },
@@ -239,13 +227,15 @@ describe('Manuscripts', () => {
 
     it('fails when manuscript has bad data types', async () => {
       const badManuscript = lodash.cloneDeep(manuscriptInput)
+      const mockedExportFn = jest.fn(() => Promise.resolve())
+
       lodash.merge(badManuscript, {
         id,
         title: 100,
         manuscriptType: {},
       })
       await expect(
-        Mutation.submitManuscript(
+        submitManuscript(mockedExportFn)(
           {},
           { data: badManuscript },
           { user: profileId },
@@ -255,24 +245,20 @@ describe('Manuscripts', () => {
       )
     })
 
-    describe('when export fails', () => {
+    describe('runExport', () => {
       let manuscript
 
-      beforeEach(() => {
-        jest.spyOn(logger, 'error').mockImplementationOnce(() => {})
-        mecaExport.mockImplementationOnce(() =>
-          Promise.reject(new Error('Borked')),
-        )
-        manuscript = lodash.cloneDeep(manuscriptInput)
-        manuscript.id = id
-      })
+      it('sends a confirmation email to the submitter', async () => {
+        const mockedExportFn = jest.fn(() => Promise.resolve())
 
-      it('sends email alert on failure', async () => {
-        await Mutation.submitManuscript(
+        await submitManuscript(mockedExportFn)(
           {},
-          { data: manuscript },
+          { data: { ...manuscriptInput, id } },
           { user: profileId },
         )
+
+        const updatedManuscript = await Manuscript.find(id, userId)
+        await runExport(updatedManuscript, userId, '1.2.3.4')
 
         const NUM_EMAILS = 1
         await waitforEmails(NUM_EMAILS)
@@ -280,36 +266,79 @@ describe('Manuscripts', () => {
 
         expect(allEmails).toHaveLength(NUM_EMAILS)
         expect(allEmails[0]).toMatchObject({
-          to: 'test@example.com',
-          subject: 'MECA export failed',
+          subject: 'Your eLife submission',
+          to: 'mymail@mail.com',
+          from: 'editorial@elifesciences.org',
         })
+        expect(allEmails[0].text).toMatchSnapshot()
+        expect(allEmails[0].html).toMatchSnapshot()
       })
 
-      it('updated status to MECA_EXPORT_FAILED', async done => {
-        await Mutation.submitManuscript(
-          {},
-          { data: manuscript },
-          { user: profileId },
-        )
-        setTimeout(async () => {
+      describe('export failure', () => {
+        beforeEach(() => {
+          jest.spyOn(logger, 'error').mockImplementationOnce(() => {})
+          mecaExport.mockImplementationOnce(() =>
+            Promise.reject(new Error('Borked')),
+          )
+          manuscript = lodash.cloneDeep(manuscriptInput)
+          manuscript.id = id
+        })
+
+        it('sends email alert on failure', async () => {
+          const mockedExportFn = jest.fn(() => Promise.resolve())
+          await submitManuscript(mockedExportFn)(
+            {},
+            { data: manuscript },
+            { user: profileId },
+          )
+
           const updatedManuscript = await Manuscript.find(manuscript.id, userId)
+          await runExport(updatedManuscript, userId, '1.2.3.4')
+
+          const NUM_EMAILS = 1
+          await waitforEmails(NUM_EMAILS)
+          const allEmails = mailer.getMails()
+
+          expect(allEmails).toHaveLength(NUM_EMAILS)
+          expect(allEmails[0]).toMatchObject({
+            to: 'test@example.com',
+            subject: 'MECA export failed',
+          })
+        })
+
+        it('updated status to MECA_EXPORT_FAILED', async () => {
+          const mockedExportFn = jest.fn(() => Promise.resolve())
+          await submitManuscript(mockedExportFn)(
+            {},
+            { data: manuscript },
+            { user: profileId },
+          )
+
+          let updatedManuscript = await Manuscript.find(manuscript.id, userId)
+          await runExport(updatedManuscript, userId, '1.2.3.4')
+
+          updatedManuscript = await Manuscript.find(manuscript.id, userId)
           expect(updatedManuscript.status).toBe(
             Manuscript.statuses.MECA_EXPORT_FAILED,
           )
-          done()
-        }, 3000)
-      })
+        })
 
-      it('should log an error', async () => {
-        await Mutation.submitManuscript(
-          {},
-          { data: manuscript },
-          { user: profileId },
-        )
-        expect(logger.error).toHaveBeenCalledWith(
-          'MECA export failed',
-          expect.any(Error),
-        )
+        it('should log an error', async () => {
+          const mockedExportFn = jest.fn(() => Promise.resolve())
+          await submitManuscript(mockedExportFn)(
+            {},
+            { data: manuscript },
+            { user: profileId },
+          )
+
+          const updatedManuscript = await Manuscript.find(manuscript.id, userId)
+          await runExport(updatedManuscript, userId, '1.2.3.4')
+
+          expect(logger.error).toHaveBeenCalledWith(
+            'MECA export failed',
+            expect.any(Error),
+          )
+        })
       })
     })
   })

--- a/packages/component-submission/server/resolvers/submitManuscript.test.js
+++ b/packages/component-submission/server/resolvers/submitManuscript.test.js
@@ -38,6 +38,8 @@ describe('Manuscripts', () => {
 
   beforeEach(async () => {
     replaySetup('success')
+    // flush promises to prevent deadlock, this can happen when we are not mocking the
+    // runExport method for the submitManuscript mutation
     await flushPromises()
     await createTables(true)
     const [user] = await Promise.all([


### PR DESCRIPTION
#### Background

Adds a call to flushPromises in submitManuscript tests to prevent deadlocks

#### Any relevant tickets

Closes #2105 
