### PR TITLE
add wait in lastPageVisisted browser test 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "app:browser": "NODE_CONFIG_ENV=test NODE_ENV=production pubsweet migrate; pubsweet server",
+    "app:browser": "NODE_CONFIG_ENV=test NODE_ENV=production pubsweet migrate; NODE_CONFIG_ENV=test NODE_ENV=production pubsweet server",
     "build": "NODE_ENV=production pubsweet build",
     "build:styleguide": "styleguidist build",
     "clean": "find . -type d -name node_modules -exec rm -rf {} \\;",

--- a/test/lastStepVisited.browser.js
+++ b/test/lastStepVisited.browser.js
@@ -39,7 +39,7 @@ test('Interrupt and resume Submission', async t => {
     .typeText(author.emailField, 'example@example.org')
     .click(wizardStep.next)
 
-  // wait 5 seconds to ensure autosave hasn't interupted the navigation save
+  // wait 5 seconds to ensure autosave hasn't interrupted the navigation save
   navigationHelper.wait(5000)
 
   // navigate back to the dashboard page and continue submission

--- a/test/lastStepVisited.browser.js
+++ b/test/lastStepVisited.browser.js
@@ -39,6 +39,9 @@ test('Interrupt and resume Submission', async t => {
     .typeText(author.emailField, 'example@example.org')
     .click(wizardStep.next)
 
+  // wait 5 seconds to ensure autosave hasn't interupted the navigation save
+  navigationHelper.wait(5000)
+
   // navigate back to the dashboard page and continue submission
   await t
     .navigateTo(`${config.get('pubsweet-server.baseUrl')}`)


### PR DESCRIPTION
#### Background

Potential for autosave to interrupt navigation save. This adds . 5 second wait to ensure the `lastStepVisited` is sent before the dashboard navigation assertion.

#### Any relevant tickets

closes #2113 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
