### PR TITLE
2149 - Filestatus ready on failure

### DIFF
--- a/packages/component-submission/client/pages/FilesStepPage.js
+++ b/packages/component-submission/client/pages/FilesStepPage.js
@@ -95,6 +95,25 @@ export class FilesStepPageComponent extends React.Component {
     })
   }
 
+  onSupportingFileUpload = file => {
+    const { setFieldValue, values, uploadSupportingFile } = this.props
+
+    return new Promise((resolve, reject) => {
+      setFieldValue('fileStatus', 'CHANGING')
+      uploadSupportingFile({
+        variables: { file, id: values.id },
+      })
+        .then(data => {
+          setFieldValue('fileStatus', data.data.uploadSupportingFile.fileStatus)
+          resolve(data)
+        })
+        .catch(err => {
+          setFieldValue('fileStatus', 'READY')
+          reject(err)
+        })
+    })
+  }
+
   render() {
     const {
       setFieldValue,
@@ -102,7 +121,6 @@ export class FilesStepPageComponent extends React.Component {
       touched,
       values,
       manuscriptUploadProgress = 0,
-      uploadSupportingFile,
       deleteSupportingFiles,
     } = this.props
 
@@ -179,25 +197,7 @@ export class FilesStepPageComponent extends React.Component {
                 variables: { id: values.id },
               })
             }
-            uploadFile={file =>
-              new Promise((resolve, reject) => {
-                setFieldValue('fileStatus', 'CHANGING')
-                return uploadSupportingFile({
-                  variables: { file, id: values.id },
-                })
-                  .then(data => {
-                    setFieldValue(
-                      'fileStatus',
-                      data.data.uploadSupportingFile.fileStatus,
-                    )
-                    resolve(data)
-                  })
-                  .catch(err => {
-                    setFieldValue('fileStatus', 'READY')
-                    reject(err)
-                  })
-              })
-            }
+            uploadFile={this.onSupportingFileUpload}
           />
         </Box>
         <ValidatedField

--- a/packages/component-submission/client/pages/FilesStepPage.js
+++ b/packages/component-submission/client/pages/FilesStepPage.js
@@ -192,7 +192,10 @@ export class FilesStepPageComponent extends React.Component {
                     )
                     resolve(data)
                   })
-                  .catch(err => reject(err))
+                  .catch(err => {
+                    setFieldValue('fileStatus', 'READY')
+                    reject(err)
+                  })
               })
             }
           />

--- a/packages/component-submission/client/pages/FilesStepPage.js
+++ b/packages/component-submission/client/pages/FilesStepPage.js
@@ -78,6 +78,30 @@ export class FilesStepPageComponent extends React.Component {
       })
   }
 
+  onSupportingFileUpload = file => {
+    const {
+      uploadSupportingFile,
+      setFieldValue,
+      isUploading,
+      values,
+    } = this.props
+    return new Promise((resolve, reject) => {
+      setFieldValue('fileStatus', 'CHANGING')
+      uploadSupportingFile({
+        variables: { file, id: values.id },
+      })
+        .then(data => {
+          setFieldValue('files', data.data.uploadSupportingFile.files)
+          setFieldValue('fileStatus', data.data.uploadSupportingFile.fileStatus)
+          resolve(data)
+        })
+        .catch(err => {
+          setFieldValue('fileStatus', isUploading ? 'CHANGING' : 'READY')
+          reject(err)
+        })
+    })
+  }
+
   onUploadValidationError = errorMessage => {
     const {
       setFieldError,
@@ -92,25 +116,6 @@ export class FilesStepPageComponent extends React.Component {
       variables: { id: manuscriptId },
     }).then(({ data }) => {
       setFieldValue('files', data.removeUploadedManuscript.files)
-    })
-  }
-
-  onSupportingFileUpload = file => {
-    const { setFieldValue, values, uploadSupportingFile } = this.props
-
-    return new Promise((resolve, reject) => {
-      setFieldValue('fileStatus', 'CHANGING')
-      uploadSupportingFile({
-        variables: { file, id: values.id },
-      })
-        .then(data => {
-          setFieldValue('fileStatus', data.data.uploadSupportingFile.fileStatus)
-          resolve(data)
-        })
-        .catch(err => {
-          setFieldValue('fileStatus', 'READY')
-          reject(err)
-        })
     })
   }
 

--- a/packages/component-submission/client/pages/FilesStepPage.test.js
+++ b/packages/component-submission/client/pages/FilesStepPage.test.js
@@ -147,4 +147,24 @@ describe('FileStepPage', () => {
     wrapper.instance().onFileDrop([])
     expect(mockUploadManuscriptFile).toBeCalledTimes(0)
   })
+
+  it('sets fileStatus to CHANGING on supporting upload start', () => {
+    const mockSetFieldValue = jest.fn()
+    const wrapper = createWrapper({}, { setFieldValue: mockSetFieldValue })
+    wrapper.instance().onSupportingFileUpload([])
+    expect(mockSetFieldValue.mock.calls[0]).toBeCalledWith(
+      'fileStatus',
+      'CHANGING',
+    )
+  })
+
+  it('sets fileStatus to READY on supporting upload success,', async () => {
+    const mockSetFieldValue = jest.fn()
+    const wrapper = createWrapper({}, { setFieldValue: mockSetFieldValue })
+    await wrapper.instance().onSupportingFileUpload([])
+    expect(mockSetFieldValue.mock.calls[1]).toBeCalledWith(
+      'fileStatus',
+      'READY',
+    )
+  })
 })

--- a/packages/component-submission/client/pages/FilesStepPage.test.js
+++ b/packages/component-submission/client/pages/FilesStepPage.test.js
@@ -49,6 +49,13 @@ function createWrapper(valueOverrides, propOverrides) {
           () => new Promise(resolve => resolve(deleteResponse)),
         ),
         uploadManuscriptFile: jest.fn(async () => uploadResponse),
+        uploadSupportingFile: jest.fn(() =>
+          Promise.resolve({
+            data: {
+              uploadSupportingFile: { files: [], fileStatus: 'READY' },
+            },
+          }),
+        ),
         ...propOverrides,
       }}
     />,
@@ -148,23 +155,92 @@ describe('FileStepPage', () => {
     expect(mockUploadManuscriptFile).toBeCalledTimes(0)
   })
 
-  it('sets fileStatus to CHANGING on supporting upload start', () => {
+  it('upload supporting file sets the formik value for files on success', async () => {
     const mockSetFieldValue = jest.fn()
-    const wrapper = createWrapper({}, { setFieldValue: mockSetFieldValue })
-    wrapper.instance().onSupportingFileUpload([])
-    expect(mockSetFieldValue.mock.calls[0]).toBeCalledWith(
-      'fileStatus',
-      'CHANGING',
+    const wrapper = createWrapper(
+      {},
+      {
+        uploadSupportingFile: jest.fn(() =>
+          Promise.resolve({
+            data: {
+              uploadSupportingFile: { files: ['foo'], fileStatus: 'READY' },
+            },
+          }),
+        ),
+        setFieldValue: mockSetFieldValue,
+      },
     )
+
+    await wrapper.instance().onSupportingFileUpload([{}])
+
+    expect(mockSetFieldValue).toBeCalledTimes(3)
+    expect(mockSetFieldValue.mock.calls[0]).toEqual(['fileStatus', 'CHANGING'])
+    expect(mockSetFieldValue.mock.calls[1]).toEqual(['files', ['foo']])
+    expect(mockSetFieldValue.mock.calls[2]).toEqual(['fileStatus', 'READY'])
   })
 
-  it('sets fileStatus to READY on supporting upload success,', async () => {
+  it('sets fileStatus to CHANGING on supporting upload start', async () => {
     const mockSetFieldValue = jest.fn()
-    const wrapper = createWrapper({}, { setFieldValue: mockSetFieldValue })
-    await wrapper.instance().onSupportingFileUpload([])
-    expect(mockSetFieldValue.mock.calls[1]).toBeCalledWith(
-      'fileStatus',
-      'READY',
+    const wrapper = createWrapper(
+      {},
+      {
+        setFieldValue: mockSetFieldValue,
+      },
     )
+
+    await wrapper.instance().onSupportingFileUpload([{}])
+    expect(mockSetFieldValue.mock.calls[0]).toEqual(['fileStatus', 'CHANGING'])
+  })
+
+  it('sets fileStatus to the returned fileStatus value on supporting upload success', async () => {
+    const mockSetFieldValue = jest.fn()
+    const options = {
+      setFieldValue: mockSetFieldValue,
+    }
+    let wrapper = createWrapper({}, options)
+
+    await wrapper.instance().onSupportingFileUpload([{}])
+    expect(mockSetFieldValue).toBeCalledTimes(3)
+    expect(mockSetFieldValue.mock.calls[0]).toEqual(['fileStatus', 'CHANGING'])
+    expect(mockSetFieldValue.mock.calls[2]).toEqual(['fileStatus', 'READY'])
+    mockSetFieldValue.mockReset()
+
+    options.uploadSupportingFile = jest.fn(() =>
+      Promise.resolve({
+        data: {
+          uploadSupportingFile: { files: ['foo'], fileStatus: 'CHANGING' },
+        },
+      }),
+    )
+    wrapper = createWrapper({}, options)
+
+    await wrapper.instance().onSupportingFileUpload([{}])
+    expect(mockSetFieldValue.mock.calls[0]).toEqual(['fileStatus', 'CHANGING'])
+    expect(mockSetFieldValue.mock.calls[2]).toEqual(['fileStatus', 'CHANGING'])
+  })
+
+  it('set fileStatus to READY if uploading supporting file fails and no manuscript is uploading', async () => {
+    const mockSetFieldValue = jest.fn()
+    const errorToThrow = new Error('error')
+    const wrapper = createWrapper(
+      {},
+      {
+        isUploading: false,
+        uploadSupportingFile: jest.fn(() => Promise.reject(errorToThrow)),
+        setFieldValue: mockSetFieldValue,
+      },
+    )
+    expect.assertions(4)
+    try {
+      await wrapper.instance().onSupportingFileUpload([{}])
+    } catch (error) {
+      expect(error).toBe(errorToThrow)
+      expect(mockSetFieldValue).toBeCalledTimes(2)
+      expect(mockSetFieldValue.mock.calls[0]).toEqual([
+        'fileStatus',
+        'CHANGING',
+      ])
+      expect(mockSetFieldValue.mock.calls[1]).toEqual(['fileStatus', 'READY'])
+    }
   })
 })


### PR DESCRIPTION
#### Background

Previously if a supporting file upload failed the client `fileStatus` is left in a `CHANGING` state causing the form to be in an invalid state until another file was uploaded or the user navigated back to the dashboard and into the submission again.

This PR resets the `fileStatus` to `READY` if there are no other uploads happening or leaves in `CHANGING` if the manuscript upload is in progress.

#### Any relevant tickets

closes #2149
