### PR TITLE
2156 - disclosure validation

### DIFF
--- a/packages/component-submission/client/components/WizardSubmit.js
+++ b/packages/component-submission/client/components/WizardSubmit.js
@@ -6,7 +6,7 @@ import {
 } from '@elifesciences/component-elife-ui/client/molecules'
 
 const WizardSubmit = ({
-  setTouched,
+  touchAllErrorFields,
   submitForm,
   validateForm,
   setSubmissionAttempted,
@@ -22,6 +22,7 @@ const WizardSubmit = ({
               if (!Object.keys(errors).length) {
                 showModal()
               }
+              touchAllErrorFields()
             })
           }}
           primary

--- a/packages/component-submission/client/components/WizardSubmit.js
+++ b/packages/component-submission/client/components/WizardSubmit.js
@@ -22,7 +22,7 @@ const WizardSubmit = ({
               if (!Object.keys(errors).length) {
                 showModal()
               }
-              touchAllErrorFields()
+              touchAllErrorFields(errors)
             })
           }}
           primary

--- a/packages/component-submission/client/pages/SubmissionWizard.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.js
@@ -92,151 +92,147 @@ export const SubmissionWizard = ({
     <Formik
       initialValues={initialValues}
       onSubmit={handleSubmit}
-      render={formikProps => (
-        <Form data-test-id="submission-wizard-form">
-          <SubmissionSave
-            disabled={formikProps.isSubmitting}
-            handleSave={handleSave}
-            values={{
-              ...formikProps.values,
-              lastStepVisited: history.location.pathname,
-            }}
-          />
-          <Flex>
-            <BoxNoMinWidth flex="1 1 100%" mx={[0, 0, 0, '16.666%']}>
-              <Box my={5}>
-                <ProgressBar currentStep={currentStep} />
-              </Box>
-              <FormH2>{STEP_NAMES[currentStep]}</FormH2>
-              <Switch>
-                <TrackedRoute
-                  path={`${match.path}/author`}
-                  render={() => <AuthorStep {...formikProps} />}
-                />
-                <TrackedRoute
-                  path={`${match.path}/files`}
-                  render={() => (
-                    <FilesStep
-                      {...formikProps}
-                      isUploading={isUploading}
-                      setIsUploading={setIsUploading}
-                    />
-                  )}
-                />
-                <TrackedRoute
-                  path={`${match.path}/details`}
-                  render={() => (
-                    <DetailsStep
-                      initialTitle={initialValues.meta.title}
-                      {...formikProps}
-                    />
-                  )}
-                />
-                <TrackedRoute
-                  path={`${match.path}/editors`}
-                  render={() => <EditorStep {...formikProps} />}
-                />
-                <TrackedRoute
-                  path={`${match.path}/disclosure`}
-                  render={() => (
-                    <DisclosureStep
-                      isSubmissionAttempted={submissionAttempted}
-                      {...formikProps}
-                    />
-                  )}
-                />
-                <Redirect
-                  from="/submit/:id"
-                  to={`/submit/${match.params.id}/author`}
-                />
-                <ErrorPage error="404: page not found" />
-              </Switch>
-              {!!Object.keys(formikProps.errors).length &&
-                submissionAttempted &&
-                isLastStep() && (
-                  <ErrorMessage data-test-id="test-error-message">
-                    We&apos;re sorry but there appears to be one or more errors
-                    in your submission that require attention before you can
-                    submit. Please use the back button to review the{' '}
-                    {convertArrayToReadableList(
-                      getErrorStepsFromErrors(formikProps.errors),
-                    )}{' '}
-                    steps before trying again.
-                  </ErrorMessage>
-                )}
-              <Flex mt={6}>
-                <Box mr={3}>
-                  <Button
-                    data-test-id="back"
-                    disabled={currentStep === 0}
-                    onClick={() => {
-                      setCurrentStep(currentStep - 1)
-                      history.push(
-                        `${match.url}/${STEP_NAMES[
-                          currentStep - 1
-                        ].toLowerCase()}`,
-                      )
-                    }}
-                  >
-                    Back
-                  </Button>
-                </Box>
-                <Box>
-                  {currentStep === STEP_NAMES.length - 1 ? (
-                    <WizardSubmit
-                      setSubmissionAttempted={setsubmissionAttempted}
-                      setTouched={formikProps.setTouched}
-                      submitForm={formikProps.submitForm}
-                      validateForm={formikProps.validateForm}
-                    />
-                  ) : (
-                    <Button
-                      data-test-id="next"
-                      onClick={() => {
-                        formikProps.validateForm().then(errors => {
-                          if (!Object.keys(errors).length) {
-                            setCurrentStep(currentStep + 1)
-                            history.push(
-                              `${match.url}/${STEP_NAMES[
-                                currentStep + 1
-                              ].toLowerCase()}`,
-                            )
-                          }
+      render={formikProps => {
+        const touchAllErrorFields = () => {
+          Object.keys(formikProps.errors).forEach(errorField => {
+            if (typeof formikProps.errors[errorField] === 'object') {
+              const flattenedSubfields = flattenObject(
+                formikProps.errors[errorField],
+              )
+              Object.keys(flattenedSubfields).forEach(subField => {
+                formikProps.setFieldTouched(`${errorField}.${subField}`, true)
+              })
+            } else {
+              formikProps.setFieldTouched(errorField, true, false)
+            }
+          })
+        }
 
-                          Object.keys(errors).forEach(errorField => {
-                            if (typeof errors[errorField] === 'object') {
-                              const flattenedSubfields = flattenObject(
-                                errors[errorField],
-                              )
-                              Object.keys(flattenedSubfields).forEach(
-                                subField => {
-                                  formikProps.setFieldTouched(
-                                    `${errorField}.${subField}`,
-                                    true,
-                                  )
-                                },
-                              )
-                            } else {
-                              formikProps.setFieldTouched(
-                                errorField,
-                                true,
-                                false,
+        return (
+          <Form data-test-id="submission-wizard-form">
+            <SubmissionSave
+              disabled={formikProps.isSubmitting}
+              handleSave={handleSave}
+              values={{
+                ...formikProps.values,
+                lastStepVisited: history.location.pathname,
+              }}
+            />
+            <Flex>
+              <BoxNoMinWidth flex="1 1 100%" mx={[0, 0, 0, '16.666%']}>
+                <Box my={5}>
+                  <ProgressBar currentStep={currentStep} />
+                </Box>
+                <FormH2>{STEP_NAMES[currentStep]}</FormH2>
+                <Switch>
+                  <TrackedRoute
+                    path={`${match.path}/author`}
+                    render={() => <AuthorStep {...formikProps} />}
+                  />
+                  <TrackedRoute
+                    path={`${match.path}/files`}
+                    render={() => (
+                      <FilesStep
+                        {...formikProps}
+                        isUploading={isUploading}
+                        setIsUploading={setIsUploading}
+                      />
+                    )}
+                  />
+                  <TrackedRoute
+                    path={`${match.path}/details`}
+                    render={() => (
+                      <DetailsStep
+                        initialTitle={initialValues.meta.title}
+                        {...formikProps}
+                      />
+                    )}
+                  />
+                  <TrackedRoute
+                    path={`${match.path}/editors`}
+                    render={() => <EditorStep {...formikProps} />}
+                  />
+                  <TrackedRoute
+                    path={`${match.path}/disclosure`}
+                    render={() => (
+                      <DisclosureStep
+                        isSubmissionAttempted={submissionAttempted}
+                        {...formikProps}
+                      />
+                    )}
+                  />
+                  <Redirect
+                    from="/submit/:id"
+                    to={`/submit/${match.params.id}/author`}
+                  />
+                  <ErrorPage error="404: page not found" />
+                </Switch>
+                {!!Object.keys(formikProps.errors).length &&
+                  submissionAttempted &&
+                  isLastStep() && (
+                    <ErrorMessage data-test-id="test-error-message">
+                      We&apos;re sorry but there appears to be one or more
+                      errors in your submission that require attention before
+                      you can submit. Please use the back button to review the{' '}
+                      {convertArrayToReadableList(
+                        getErrorStepsFromErrors(formikProps.errors),
+                      )}{' '}
+                      steps before trying again.
+                    </ErrorMessage>
+                  )}
+                <Flex mt={6}>
+                  <Box mr={3}>
+                    <Button
+                      data-test-id="back"
+                      disabled={currentStep === 0}
+                      onClick={() => {
+                        setCurrentStep(currentStep - 1)
+                        history.push(
+                          `${match.url}/${STEP_NAMES[
+                            currentStep - 1
+                          ].toLowerCase()}`,
+                        )
+                      }}
+                    >
+                      Back
+                    </Button>
+                  </Box>
+                  <Box>
+                    {currentStep === STEP_NAMES.length - 1 ? (
+                      <WizardSubmit
+                        setSubmissionAttempted={setsubmissionAttempted}
+                        submitForm={formikProps.submitForm}
+                        touchAllErrorFields={touchAllErrorFields}
+                        validateForm={formikProps.validateForm}
+                      />
+                    ) : (
+                      <Button
+                        data-test-id="next"
+                        onClick={() => {
+                          formikProps.validateForm().then(errors => {
+                            if (!Object.keys(errors).length) {
+                              setCurrentStep(currentStep + 1)
+                              history.push(
+                                `${match.url}/${STEP_NAMES[
+                                  currentStep + 1
+                                ].toLowerCase()}`,
                               )
                             }
+                            touchAllErrorFields()
                           })
-                        })
-                      }}
-                      primary
-                    >
-                      Next
-                    </Button>
-                  )}
-                </Box>
-              </Flex>
-            </BoxNoMinWidth>
-          </Flex>
-        </Form>
-      )}
+                        }}
+                        primary
+                      >
+                        Next
+                      </Button>
+                    )}
+                  </Box>
+                </Flex>
+              </BoxNoMinWidth>
+            </Flex>
+          </Form>
+        )
+      }}
       validationSchema={yup.object().shape(stepValidation[currentStep])}
     />
   )

--- a/packages/component-submission/client/pages/SubmissionWizard.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.js
@@ -93,12 +93,10 @@ export const SubmissionWizard = ({
       initialValues={initialValues}
       onSubmit={handleSubmit}
       render={formikProps => {
-        const touchAllErrorFields = () => {
-          Object.keys(formikProps.errors).forEach(errorField => {
-            if (typeof formikProps.errors[errorField] === 'object') {
-              const flattenedSubfields = flattenObject(
-                formikProps.errors[errorField],
-              )
+        const touchAllErrorFields = errors => {
+          Object.keys(errors).forEach(errorField => {
+            if (typeof errors[errorField] === 'object') {
+              const flattenedSubfields = flattenObject(errors[errorField])
               Object.keys(flattenedSubfields).forEach(subField => {
                 formikProps.setFieldTouched(`${errorField}.${subField}`, true)
               })
@@ -218,7 +216,7 @@ export const SubmissionWizard = ({
                                 ].toLowerCase()}`,
                               )
                             }
-                            touchAllErrorFields()
+                            touchAllErrorFields(errors)
                           })
                         }}
                         primary

--- a/test/pageObjects/disclosure.js
+++ b/test/pageObjects/disclosure.js
@@ -9,7 +9,10 @@ const disclosure = {
   consentCheckbox: Selector('[name="disclosureConsent"]').parent(),
   title: Selector('[data-test-id=disclosure-title]'),
   name: Selector('[data-test-id=disclosure-name]'),
-  validationWarning: Selector('[data-test-id=test-error-message]'),
+  validationWarning: Selector('[data-test-id="test-error-message"]'),
+  consentValidationWarning: Selector(
+    '[data-test-id="error-disclosureConsent"]',
+  ),
 }
 
 export default disclosure

--- a/test/submission.browser.js
+++ b/test/submission.browser.js
@@ -235,8 +235,9 @@ test('Ability to progress through the wizard is tied to validation', async t => 
       disclosure.url,
       'Validation errors prevent progress to the next page',
     )
+
   await t
-    .expect((await disclosure.validationWarning.textContent).length)
+    .expect((await disclosure.consentValidationWarning.textContent).length)
     .gt(0, 'is visible')
 
   navigationHelper.consentDisclosure()


### PR DESCRIPTION
#### Background

Moves inline logic for touching all error fields into a function called `touchAllErrorFields`. Calls this function on the submit button press as well as the next button.

#### Any relevant tickets

closes #2156 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
