### PR TITLE
Remove sudo from helm and kubectl commands

### DIFF
--- a/scripts/helm_deploy.sh
+++ b/scripts/helm_deploy.sh
@@ -11,4 +11,4 @@ fi
 release_name="elife-xpub--${1}"
 image_tag="${2}"
 
-sudo -u elife -H helm upgrade --install "$release_name" --set image.tag="${image_tag}" alfred/elife-xpub
+helm upgrade --install "$release_name" --set image.tag="${image_tag}" alfred/elife-xpub

--- a/scripts/helm_url.sh
+++ b/scripts/helm_url.sh
@@ -9,6 +9,6 @@ if [ "$#" -ne 1 ]; then
 fi
 
 release_name="elife-xpub--${1}"
-first_node_address=$(sudo -u elife -H kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="ExternalDNS").address')
-node_port=$(sudo -u elife -H kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services "$release_name")
+first_node_address=$(kubectl get nodes -o json | jq -r '.items[0].status.addresses[] | select(.type=="ExternalDNS").address')
+node_port=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services "$release_name")
 echo "http://$first_node_address:$node_port"


### PR DESCRIPTION
These commands can now run as the `jenkins` user so `sudo` should be unnecessary.