### PR TITLE
array of strings on save options

### DIFF
--- a/packages/component-submission/server/aggregates/Submission.js
+++ b/packages/component-submission/server/aggregates/Submission.js
@@ -65,7 +65,7 @@ class Submission {
   async _saveTeams() {
     this.manuscript.teams = this.teams
 
-    await this.manuscript.save({ noUpdate: '[files]' })
+    await this.manuscript.save({ noUpdate: ['files'] })
 
     this.teams = this.manuscript.teams
   }


### PR DESCRIPTION
#### Background

Objection seems to have two different formats of taking arrays of properties as function params, for `$loadRelated` it takes a string which holds an array `'[foo]'`. For save options, it requires an array of strings `['foo']`. We were passing the wrong one to the save options in save teams which resulted in us not saving teams. This fixes that!