### PR TITLE
2171 - wizard step titles

### DIFF
--- a/packages/component-submission/client/pages/FilesStepPage.js
+++ b/packages/component-submission/client/pages/FilesStepPage.js
@@ -142,7 +142,6 @@ export class FilesStepPageComponent extends React.Component {
     return (
       <React.Fragment>
         <Box mb={3} width={1}>
-          <FormH2>Your cover letter</FormH2>
           <Paragraph.Small secondary>
             Please enter or paste in your cover letter below. To help with the
             initial evaluation of your submission, you should aim to answer the

--- a/packages/component-submission/client/pages/SubmissionWizard.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.js
@@ -35,7 +35,7 @@ import {
   getErrorStepsFromErrors,
   convertArrayToReadableList,
 } from '../utils'
-import { STEP_NAMES } from '../utils/constants'
+import { STEP_NAMES, STEP_TITLES } from '../utils/constants'
 
 import wizardSchema, {
   authorSchema,
@@ -121,7 +121,7 @@ export const SubmissionWizard = ({
                 <Box my={5}>
                   <ProgressBar currentStep={currentStep} />
                 </Box>
-                <FormH2>{STEP_NAMES[currentStep]}</FormH2>
+                <FormH2>{STEP_TITLES[currentStep]}</FormH2>
                 <Switch>
                   <TrackedRoute
                     path={`${match.path}/author`}

--- a/packages/component-submission/client/pages/SubmissionWizard.test.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.test.js
@@ -170,14 +170,14 @@ describe('SubmissionWizard', async () => {
     it('displays correct title on Editors step', () => {
       expect(
         renderWithPath('/submit/id/editors').getByText(
-          'Who should review your work',
+          'Who should review your work?',
         ),
       ).toBeInTheDocument()
     })
     it('displays correct title on Disclosure step', () => {
       expect(
         renderWithPath('/submit/id/disclosure').getByText(
-          'Disclosure of data to Editors',
+          'Disclosure of data to editors',
         ),
       ).toBeInTheDocument()
     })

--- a/packages/component-submission/client/pages/SubmissionWizard.test.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.test.js
@@ -148,4 +148,38 @@ describe('SubmissionWizard', async () => {
       console.error = consoleError
     })
   })
+
+  describe('Step titles', () => {
+    it('displays correct title on Author step', () => {
+      expect(
+        renderWithPath('/submit/id/author').getByText('Your details'),
+      ).toBeInTheDocument()
+    })
+    it('displays correct title on Files step', () => {
+      expect(
+        renderWithPath('/submit/id/files').getByText('Your cover letter'),
+      ).toBeInTheDocument()
+    })
+    it('displays correct title on Details step', () => {
+      expect(
+        renderWithPath('/submit/id/details').getByText(
+          'Help us get your work seen by the right people',
+        ),
+      ).toBeInTheDocument()
+    })
+    it('displays correct title on Editors step', () => {
+      expect(
+        renderWithPath('/submit/id/editors').getByText(
+          'Who should review your work',
+        ),
+      ).toBeInTheDocument()
+    })
+    it('displays correct title on Disclosure step', () => {
+      expect(
+        renderWithPath('/submit/id/disclosure').getByText(
+          'Disclosure of data to Editors',
+        ),
+      ).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/component-submission/client/utils/constants.js
+++ b/packages/component-submission/client/utils/constants.js
@@ -33,6 +33,14 @@ export const STEP_NAMES = [
   'Disclosure',
 ]
 
+export const STEP_TITLES = [
+  'Your details',
+  'Your cover letter',
+  'Help us get your work seen by the right people',
+  'Who should review your work',
+  'Disclosure of data to Editors',
+]
+
 export const FIELD_TO_STEP_MAP = {
   author: STEP_NAMES[0],
   cosubmission: STEP_NAMES[2],

--- a/packages/component-submission/client/utils/constants.js
+++ b/packages/component-submission/client/utils/constants.js
@@ -37,8 +37,8 @@ export const STEP_TITLES = [
   'Your details',
   'Your cover letter',
   'Help us get your work seen by the right people',
-  'Who should review your work',
-  'Disclosure of data to Editors',
+  'Who should review your work?',
+  'Disclosure of data to editors',
 ]
 
 export const FIELD_TO_STEP_MAP = {


### PR DESCRIPTION
#### Background

We were using the same string values for the progress bar labels as wizard step titles, this needed changing to make the titles more descriptive. This adds a new constant value of `STEP_TITLES` which hold the title strings and adds unit tests for checking the correct titles are present on each step.

#### Any relevant tickets

closes #2171 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
