### PR TITLE
2189 - Scroll to top of form on navigating next or back

### DIFF
--- a/packages/component-submission/client/pages/SubmissionWizard.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.js
@@ -109,6 +109,15 @@ export const SubmissionWizard = ({
       )
       .then(() => history.push(`/thankyou/${match.params.id}`))
 
+  const navigateToStep = step => {
+    setCurrentStep(step)
+
+    history.push(`${match.url}/${STEP_NAMES[step].toLowerCase()}`)
+
+    // scroll to top
+    window.scrollTo(0, 0)
+  }
+
   return (
     <Formik
       initialValues={initialValues}
@@ -205,12 +214,7 @@ export const SubmissionWizard = ({
                       data-test-id="back"
                       disabled={currentStep === 0}
                       onClick={() => {
-                        setCurrentStep(currentStep - 1)
-                        history.push(
-                          `${match.url}/${STEP_NAMES[
-                            currentStep - 1
-                          ].toLowerCase()}`,
-                        )
+                        navigateToStep(currentStep - 1)
                       }}
                     >
                       Back
@@ -230,12 +234,7 @@ export const SubmissionWizard = ({
                         onClick={() => {
                           formikProps.validateForm().then(errors => {
                             if (!Object.keys(errors).length) {
-                              setCurrentStep(currentStep + 1)
-                              history.push(
-                                `${match.url}/${STEP_NAMES[
-                                  currentStep + 1
-                                ].toLowerCase()}`,
-                              )
+                              navigateToStep(currentStep + 1)
                             }
                             touchAllErrorFields(errors)
                           })

--- a/packages/component-submission/client/pages/SubmissionWizard.test.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.test.js
@@ -94,6 +94,7 @@ describe('SubmissionWizard', async () => {
     // eslint-disable-next-line no-console
     const consoleError = console.error
     const pushHistory = jest.fn()
+    const scrollSpy = jest.spyOn(window, 'scrollTo')
 
     const testStepNavigation = async (currentPath, nextStep, buttonId) => {
       const opts = renderWithPath(currentPath, pushHistory)
@@ -141,6 +142,34 @@ describe('SubmissionWizard', async () => {
       await testStepNavigation('/submit/id/details', '/files', 'back')
       await testStepNavigation('/submit/id/editors', '/details', 'back')
       await testStepNavigation('/submit/id/disclosure', '/editors', 'back')
+    })
+
+    it('scrolls to top on next', async () => {
+      const { getByTestId } = renderWithPath('/submit/id/author', pushHistory)
+
+      expect(scrollSpy).toBeCalledTimes(0)
+
+      fireEvent.click(getByTestId('next'))
+      await flushPromises()
+
+      expect(scrollSpy).toBeCalledTimes(1)
+      expect(scrollSpy).toBeCalledWith(0, 0)
+    })
+
+    it('scrolls to top on back', async () => {
+      const { getByTestId } = renderWithPath('/submit/id/files', pushHistory)
+
+      expect(scrollSpy).toBeCalledTimes(0)
+
+      fireEvent.click(getByTestId('back'))
+      await flushPromises()
+
+      expect(scrollSpy).toBeCalledTimes(1)
+      expect(scrollSpy).toBeCalledWith(0, 0)
+    })
+
+    afterEach(() => {
+      scrollSpy.mockClear()
     })
 
     afterAll(() => {


### PR DESCRIPTION
#### Background

When navigating through the wizard steps the user should be taken to the top of the current step when using the 'Next' or 'Back' buttons. 

#### Any relevant tickets

closes #2189

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
