### PR TITLE
[WIP] 2199 - fix excessive re-renders caused by Apollo passed function props

### DIFF
--- a/packages/component-submission/client/graphql/authorWithGQL.js
+++ b/packages/component-submission/client/graphql/authorWithGQL.js
@@ -2,5 +2,9 @@ import { graphql } from 'react-apollo'
 import { compose } from 'recompose'
 
 import { CURRENT_USER } from '@elifesciences/component-elife-app/client/graphql/queries'
+import graphqlMemoWrapper from './graphqlMemoWrapper'
 
-export default compose(graphql(CURRENT_USER))
+export default compose(
+  graphql(CURRENT_USER),
+  graphqlMemoWrapper,
+)

--- a/packages/component-submission/client/graphql/editorsWithGQL.js
+++ b/packages/component-submission/client/graphql/editorsWithGQL.js
@@ -3,6 +3,8 @@ import { compose } from 'recompose'
 
 import { EDITOR_LIST_QUERY } from './queries'
 
+import graphqlMemoWrapper from './graphqlMemoWrapper'
+
 export default compose(
   graphql(EDITOR_LIST_QUERY, {
     name: 'reviewingEditors',
@@ -12,4 +14,5 @@ export default compose(
     name: 'seniorEditors',
     options: () => ({ variables: { role: 'senior-editor,leadership' } }),
   }),
+  graphqlMemoWrapper,
 )

--- a/packages/component-submission/client/graphql/filesWithGQL.js
+++ b/packages/component-submission/client/graphql/filesWithGQL.js
@@ -9,6 +9,8 @@ import {
 
 import { ON_UPLOAD_PROGRESS } from './subscriptions'
 
+import graphqlMemoWrapper from './graphqlMemoWrapper'
+
 export default compose(
   graphql(UPLOAD_MANUSCRIPT_FILE, {
     name: 'uploadManuscriptFile',
@@ -26,4 +28,5 @@ export default compose(
     name: 'uploadProgress',
     options: props => ({ variables: { id: props.initialValues.id } }),
   }),
+  graphqlMemoWrapper,
 )

--- a/packages/component-submission/client/graphql/graphqlMemoWrapper.js
+++ b/packages/component-submission/client/graphql/graphqlMemoWrapper.js
@@ -1,0 +1,11 @@
+import { memo } from 'react'
+import { isEqual } from 'lodash'
+
+// Apollo passes a data prop with some function properties as well as the query data and any errors that might
+// have been thrown. React is diffing these and evaluating the functions as changed props which is
+// triggering unwanted re-renders. Using isEqual within a React memo solves this.
+export default Component =>
+  memo(
+    Component,
+    (prevProps, currentProps) => !isEqual(prevProps, currentProps),
+  )


### PR DESCRIPTION
#### Background

Apollo passes down a data prop that contains functions for things like refetching. These were not evaluating as unchanged between lifecycle events so were causing whole step components to be re-rendered unnecessarily. The fix was to memoize the components and do a manual diff using `isEqual` which correctly diffs the functions (or maybe doesn't diff them at all, either way we have the intended result).

#### Any relevant tickets

closes #2199 

relates to closed issue #2088 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
