### PR TITLE
2194: Fixed issue with PersonPod components being needlessly re-rendered

### DIFF
--- a/packages/component-submission/client/components/PeoplePicker/PersonPod.js
+++ b/packages/component-submission/client/components/PeoplePicker/PersonPod.js
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
 import { Action } from '@pubsweet/ui'
 import { Flex, Box } from '@rebass/grid'
+import { isEqual, pick } from 'lodash'
 import {
   Icon,
   ButtonAsIconWrapper,
@@ -64,13 +65,30 @@ class PersonPod extends React.Component {
     }
   }
 
+  shouldComponentUpdate(nextProps) {
+    const compareProps = [
+      'isSelectButtonClickable',
+      'isSelected',
+      'selectButtonType',
+      'institution',
+      'focuses',
+      'expertises',
+      'name',
+    ]
+
+    return !isEqual(
+      pick(nextProps, compareProps),
+      pick(this.props, compareProps),
+    )
+  }
+
   openModal = () => {
     this.setState({ isModalOpen: true })
   }
 
-  acceptModal = person => {
+  acceptModal = () => {
     this.setState({ isModalOpen: false })
-    this.props.togglePersonSelection(person)
+    this.props.togglePersonSelection()
   }
 
   cancelModal = () => {

--- a/packages/component-submission/client/components/PeoplePicker/PersonPod.js
+++ b/packages/component-submission/client/components/PeoplePicker/PersonPod.js
@@ -65,7 +65,7 @@ class PersonPod extends React.Component {
     }
   }
 
-  shouldComponentUpdate(nextProps) {
+  shouldComponentUpdate(nextProps, nextState) {
     const compareProps = [
       'isSelectButtonClickable',
       'isSelected',
@@ -76,9 +76,9 @@ class PersonPod extends React.Component {
       'name',
     ]
 
-    return !isEqual(
-      pick(nextProps, compareProps),
-      pick(this.props, compareProps),
+    return (
+      !isEqual(pick(nextProps, compareProps), pick(this.props, compareProps)) ||
+      !isEqual(this.state, nextState)
     )
   }
 


### PR DESCRIPTION
The root cause was inside the PersonPodGrid component's render method, where it was passing
an anonymous method to each PersonPod component that calls the toggleSelection method passed
down from the PeoplePickerLogic component. This led to a prop change being detected to a new
anonymous method being created on PersonPodGrid re render.

The fix involves adding a shouldComponentUpdate method to check whether relevant props have been modified.

Additionally, the `acceptModal` method passed to PersonInfoModal component doesn't accept a `person` parameter anymore as it wasn't actually needed (and was actually given a click event value).

#### Background

Every time a Person was selected or unselected, PersonPod components were being re rendered, which caused degraded performance with a large number of items.

#### Any relevant tickets

Closes #2194 

#### How has this been tested?
This has been tested locally by using the live api service instead of the dummy one to get the bigger number of items. When the fix was implemented, the console log stopped throwing violations (except when reaching the maximum limit of items).

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
