### PR TITLE
Re-enable introspection in apollo for testing

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -14,6 +14,9 @@ module.exports = {
     uploads: 'test/temp/uploads',
     secret: 'test',
     logger,
+    apollo: {
+      introspection: true,
+    },
   },
   login: {
     url: '/mock-token-exchange/ewwboc7m',

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "omit-deep-lodash": "^1.1.2",
     "pre-commit": "^1.0.0",
     "prop-types": "^15.6.2",
-    "pubsweet": "^4.0.4",
+    "pubsweet": "^4.1.9",
     "pubsweet-client": "^8.0.0",
     "pubsweet-server": "^13.5.0",
     "pug": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "prop-types": "^15.6.2",
     "pubsweet": "^4.0.4",
     "pubsweet-client": "^8.0.0",
-    "pubsweet-server": "^13.4.5",
+    "pubsweet-server": "^13.5.0",
     "pug": "^2.0.3",
     "react": "^16.8.6",
     "react-apollo": "^2.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -558,19 +558,19 @@
   dependencies:
     "@pubsweet/logger" "^0.2.22"
 
-"@pubsweet/models@^0.2.12", "@pubsweet/models@^0.2.7":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@pubsweet/models/-/models-0.2.12.tgz#214d8df2d5905340af3b9f058010637cfcafbde2"
-  integrity sha512-GiUVogtzf4hf2so/Mt1htezpMDf3aNrdydGoBjHwTJgkoGuhlYLNzK3DqEZmeJhzxHm1Sx4DWCt09QrVcfVkfA==
-  dependencies:
-    "@pubsweet/logger" "^0.2.25"
-
 "@pubsweet/models@^0.2.14":
   version "0.2.14"
   resolved "https://registry.yarnpkg.com/@pubsweet/models/-/models-0.2.14.tgz#006a50fb01576d0d213069520fba5594c8f2f111"
   integrity sha512-jiYbIbxd/6CVRWkhLAVGYyhVWvVXnjcCabIOKuY5uCw0KLi7X7t2vyD9DRulsj9UoyezZldKNFO+Ft9MDW38Ug==
   dependencies:
     "@pubsweet/logger" "^0.2.27"
+
+"@pubsweet/models@^0.2.7":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@pubsweet/models/-/models-0.2.12.tgz#214d8df2d5905340af3b9f058010637cfcafbde2"
+  integrity sha512-GiUVogtzf4hf2so/Mt1htezpMDf3aNrdydGoBjHwTJgkoGuhlYLNzK3DqEZmeJhzxHm1Sx4DWCt09QrVcfVkfA==
+  dependencies:
+    "@pubsweet/logger" "^0.2.25"
 
 "@pubsweet/ui-toolkit@^2.0.1", "@pubsweet/ui-toolkit@^2.0.3":
   version "2.0.3"
@@ -12281,7 +12281,7 @@ promisify-event@^1.0.0:
   dependencies:
     pinkie-promise "^2.0.0"
 
-prompt@^1.0.0, prompt@flatiron/prompt#1c95d1d8d333b5fbc13fa5f0619f3dcf0d514f87:
+prompt@^1.0.0, "prompt@github:flatiron/prompt#1c95d1d8d333b5fbc13fa5f0619f3dcf0d514f87":
   version "1.0.0"
   resolved "https://codeload.github.com/flatiron/prompt/tar.gz/1c95d1d8d333b5fbc13fa5f0619f3dcf0d514f87"
   dependencies:
@@ -12537,51 +12537,6 @@ pubsweet-client@^8.0.0:
     styled-normalize "^8.0.4"
     subscriptions-transport-ws "^0.9.12"
 
-pubsweet-server@^13.4.6:
-  version "13.4.6"
-  resolved "https://registry.yarnpkg.com/pubsweet-server/-/pubsweet-server-13.4.6.tgz#a5063ec4aff9ce216b52943f0cab3da6a3f28a58"
-  integrity sha512-X5nSyyNSRdPhoZWj32lyRnUFuoKE3gmnpzjFoaQFn9tVQ20AMi/nH+mSLLfoSLOSaoCYQXAVG7k5gN46L9MciA==
-  dependencies:
-    "@pubsweet/db-manager" "^3.0.11"
-    "@pubsweet/errors" "^2.0.15"
-    "@pubsweet/logger" "^0.2.25"
-    "@pubsweet/models" "^0.2.12"
-    apollo-server-express "^2.4.8"
-    authsome "^0.1.0"
-    bluebird "^3.5.1"
-    body-parser "^1.15.2"
-    colors "^1.1.2"
-    config "^3.0.1"
-    cookie-parser "^1.4.3"
-    dotenv "^4.0.0"
-    express "^4.16.1"
-    fs-extra "^7.0.1"
-    graphql "^14.2.1"
-    graphql-postgres-subscriptions "^1.0.4"
-    graphql-tools "^4.0.4"
-    helmet "^3.8.1"
-    http-status-codes "^1.0.6"
-    joi "^14.3.0"
-    jsonwebtoken "^8.4.0"
-    lodash "^4.0.0"
-    minimist "^1.2.0"
-    morgan "^1.8.2"
-    multer "^1.1.0"
-    objection "^1.5.3"
-    passport "^0.4.0"
-    passport-anonymous "^1.0.1"
-    passport-http-bearer "^1.0.1"
-    passport-local "^1.0.0"
-    pg "^7.4.1"
-    pg-boss "^3.1.2"
-    promise-queue "^2.2.3"
-    prompt "^1.0.0"
-    pubsweet-sse "^1.0.19"
-    subscriptions-transport-ws "^0.9.12"
-    uuid "^3.0.1"
-    waait "^1.0.2"
-    winston "^2.2.0"
-
 pubsweet-server@^13.5.0:
   version "13.5.0"
   resolved "https://registry.yarnpkg.com/pubsweet-server/-/pubsweet-server-13.5.0.tgz#c22233d0a23744d8aec6458010b7c23b79db80e1"
@@ -12627,23 +12582,18 @@ pubsweet-server@^13.5.0:
     waait "^1.0.2"
     winston "^2.2.0"
 
-pubsweet-sse@^1.0.19:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/pubsweet-sse/-/pubsweet-sse-1.0.19.tgz#57270fef555f9ccff3ad086cc62aef3d802f834b"
-  integrity sha512-8YNl6nXnXfWgt183iDH2TgqswQjj2qcZwt+7plVhoyNVZeJiPdwc7I24eT0mnHiovN9lntGMeCAtkpELn34zqw==
-
 pubsweet-sse@^1.0.21:
   version "1.0.21"
   resolved "https://registry.yarnpkg.com/pubsweet-sse/-/pubsweet-sse-1.0.21.tgz#06f3c9b254e4fb721b789da6ffe25d9f57d917ae"
   integrity sha512-ilxC0QAAjCJ5zuqsgUoSmMOJ9whRMnzT10RF5OsSuShZxCZ2ZijqK4dMFRPTgRzhbSYy28kaijC898yxxQ2vZw==
 
-pubsweet@^4.0.4:
-  version "4.1.7"
-  resolved "https://registry.yarnpkg.com/pubsweet/-/pubsweet-4.1.7.tgz#36c4d9776ade7fb96e6deb23e3c12c02ad87ba97"
-  integrity sha512-D9nSpz5j0ChEa7WfneO0Z/TPkxKD0/P4YNC0uzlY647N4O7dtATYaVu/+h5+oxipaHE+gr7YoAflu9WoVqN5cw==
+pubsweet@^4.1.9:
+  version "4.1.9"
+  resolved "https://registry.yarnpkg.com/pubsweet/-/pubsweet-4.1.9.tgz#22a7be68a776ecaa48799ee6bd3552f6051ee877"
+  integrity sha512-IuZiIsn1B1u8yG5igqqp0Vbz1ZxR0aOP4gcd1VwuEtL6EfP9Gsh8FERrr+B+nKLHuxuiL+iQx+nY7eZNJBPl2w==
   dependencies:
-    "@pubsweet/db-manager" "^3.0.11"
-    "@pubsweet/logger" "^0.2.25"
+    "@pubsweet/db-manager" "^3.0.13"
+    "@pubsweet/logger" "^0.2.27"
     bluebird "^3.5.0"
     colors "^1.1.2"
     commander "^2.20.0"
@@ -12654,7 +12604,7 @@ pubsweet@^4.0.4:
     inflection "^1.12.0"
     lodash "^4.17.11"
     prompt flatiron/prompt#1c95d1d8d333b5fbc13fa5f0619f3dcf0d514f87
-    pubsweet-server "^13.4.6"
+    pubsweet-server "^13.5.0"
     uuid "^3.0.1"
     webpack "^4.29.5"
     webpack-dev-middleware "^3.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,22 @@
     tmp-promise "^1.0.5"
     umzug "^2.1.0"
 
+"@pubsweet/db-manager@^3.0.13":
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/@pubsweet/db-manager/-/db-manager-3.0.13.tgz#d97b809731499ced4b2380b26b63dbdc01a8fb3b"
+  integrity sha512-QeMTJw6bZA33jOxpz2Jv/qcg2GWuNJzF2k9KVWxyrPxaAEPoTpMauQtEZkOf/tGjFBv3Y7VDDXm9o2JDFB/pEQ==
+  dependencies:
+    "@pubsweet/logger" "^0.2.27"
+    fs-extra "^4.0.2"
+    isomorphic-fetch "^2.2.1"
+    joi "^14.3.0"
+    knex "^0.16.3"
+    lodash "^4.17.11"
+    objection "^1.5.3"
+    pg "^7.8.0"
+    tmp-promise "^1.0.5"
+    umzug "^2.1.0"
+
 "@pubsweet/errors@2.0.12":
   version "2.0.12"
   resolved "https://registry.yarnpkg.com/@pubsweet/errors/-/errors-2.0.12.tgz#0891ff5fbb7a5e8d2cbad5390f56e99a54ee9e90"
@@ -498,6 +514,13 @@
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/@pubsweet/errors/-/errors-2.0.15.tgz#dfd8ee97679983f2489dc729866063fcb29fa70e"
   integrity sha512-XDlypimBkFCISB5bDO4hRc/UXr2if2XAHVgEb+SMfmND13vmYVW+3BQaSZQM/YVJjooN79ubNNupwCLs/GyrJg==
+  dependencies:
+    http-status-codes "^1.3.0"
+
+"@pubsweet/errors@^2.0.17":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@pubsweet/errors/-/errors-2.0.17.tgz#4307efa7fec396eed287c5e0e7f35d3b627be57e"
+  integrity sha512-XIso1VydH5s713+A3N9EHlxDNlN79pQ993T4ElIfmJiOwnjYYvXms2e3r39ah77OcrujhHYvsxlTaDaNytp7TQ==
   dependencies:
     http-status-codes "^1.3.0"
 
@@ -519,6 +542,15 @@
     joi "^14.3.0"
     lodash "^4.17.4"
 
+"@pubsweet/logger@^0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@pubsweet/logger/-/logger-0.2.27.tgz#470272f725418c16c8444c6985b63d8188cd2124"
+  integrity sha512-Sz7GX0r/PmrYFdAaEyLLKhgOzJ7hxnUab8ITLqvYhUNh4dMXRCsafiO94Jtx+3xzbrQkTBVkW+Z5Q4PTUxs4mA==
+  dependencies:
+    config "^3.0.1"
+    joi "^14.3.0"
+    lodash "^4.17.4"
+
 "@pubsweet/models@0.2.9":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@pubsweet/models/-/models-0.2.9.tgz#c9184f99bdda174e82eca2187cbe0cd4da7603f2"
@@ -532,6 +564,13 @@
   integrity sha512-GiUVogtzf4hf2so/Mt1htezpMDf3aNrdydGoBjHwTJgkoGuhlYLNzK3DqEZmeJhzxHm1Sx4DWCt09QrVcfVkfA==
   dependencies:
     "@pubsweet/logger" "^0.2.25"
+
+"@pubsweet/models@^0.2.14":
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/@pubsweet/models/-/models-0.2.14.tgz#006a50fb01576d0d213069520fba5594c8f2f111"
+  integrity sha512-jiYbIbxd/6CVRWkhLAVGYyhVWvVXnjcCabIOKuY5uCw0KLi7X7t2vyD9DRulsj9UoyezZldKNFO+Ft9MDW38Ug==
+  dependencies:
+    "@pubsweet/logger" "^0.2.27"
 
 "@pubsweet/ui-toolkit@^2.0.1", "@pubsweet/ui-toolkit@^2.0.3":
   version "2.0.3"
@@ -12498,7 +12537,7 @@ pubsweet-client@^8.0.0:
     styled-normalize "^8.0.4"
     subscriptions-transport-ws "^0.9.12"
 
-pubsweet-server@^13.4.5, pubsweet-server@^13.4.6:
+pubsweet-server@^13.4.6:
   version "13.4.6"
   resolved "https://registry.yarnpkg.com/pubsweet-server/-/pubsweet-server-13.4.6.tgz#a5063ec4aff9ce216b52943f0cab3da6a3f28a58"
   integrity sha512-X5nSyyNSRdPhoZWj32lyRnUFuoKE3gmnpzjFoaQFn9tVQ20AMi/nH+mSLLfoSLOSaoCYQXAVG7k5gN46L9MciA==
@@ -12543,10 +12582,60 @@ pubsweet-server@^13.4.5, pubsweet-server@^13.4.6:
     waait "^1.0.2"
     winston "^2.2.0"
 
+pubsweet-server@^13.5.0:
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/pubsweet-server/-/pubsweet-server-13.5.0.tgz#c22233d0a23744d8aec6458010b7c23b79db80e1"
+  integrity sha512-FX/dzNiKBA80hBn0w23K8Z2mZooLULExtTWDgtLHvJ1UkM4bsDhts2oO8rq/frJESOdvaI1QLQ8xo73vvyB0/g==
+  dependencies:
+    "@pubsweet/db-manager" "^3.0.13"
+    "@pubsweet/errors" "^2.0.17"
+    "@pubsweet/logger" "^0.2.27"
+    "@pubsweet/models" "^0.2.14"
+    apollo-server-express "^2.4.8"
+    authsome "^0.1.0"
+    bluebird "^3.5.1"
+    body-parser "^1.15.2"
+    colors "^1.1.2"
+    config "^3.0.1"
+    cookie-parser "^1.4.3"
+    dotenv "^4.0.0"
+    express "^4.16.1"
+    fs-extra "^7.0.1"
+    graphql "^14.2.1"
+    graphql-postgres-subscriptions "^1.0.4"
+    graphql-tools "^4.0.4"
+    helmet "^3.8.1"
+    http-status-codes "^1.0.6"
+    joi "^14.3.0"
+    jsonwebtoken "^8.4.0"
+    lodash "^4.0.0"
+    minimist "^1.2.0"
+    morgan "^1.8.2"
+    multer "^1.1.0"
+    objection "^1.5.3"
+    passport "^0.4.0"
+    passport-anonymous "^1.0.1"
+    passport-http-bearer "^1.0.1"
+    passport-local "^1.0.0"
+    pg "^7.4.1"
+    pg-boss "^3.1.2"
+    promise-queue "^2.2.3"
+    prompt "^1.0.0"
+    pubsweet-sse "^1.0.21"
+    subscriptions-transport-ws "^0.9.12"
+    uuid "^3.0.1"
+    waait "^1.0.2"
+    winston "^2.2.0"
+
 pubsweet-sse@^1.0.19:
   version "1.0.19"
   resolved "https://registry.yarnpkg.com/pubsweet-sse/-/pubsweet-sse-1.0.19.tgz#57270fef555f9ccff3ad086cc62aef3d802f834b"
   integrity sha512-8YNl6nXnXfWgt183iDH2TgqswQjj2qcZwt+7plVhoyNVZeJiPdwc7I24eT0mnHiovN9lntGMeCAtkpELn34zqw==
+
+pubsweet-sse@^1.0.21:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/pubsweet-sse/-/pubsweet-sse-1.0.21.tgz#06f3c9b254e4fb721b789da6ffe25d9f57d917ae"
+  integrity sha512-ilxC0QAAjCJ5zuqsgUoSmMOJ9whRMnzT10RF5OsSuShZxCZ2ZijqK4dMFRPTgRzhbSYy28kaijC898yxxQ2vZw==
 
 pubsweet@^4.0.4:
   version "4.1.7"


### PR DESCRIPTION
#### Background
Re-enables introspection in apollo, should fix errors in the api-tests. This is blocked by a new pubsweet version (see https://gitlab.coko.foundation/pubsweet/pubsweet/merge_requests/562)

#### Any relevant tickets

Please use the phrase 'Closes' if it will fully complete the ticket.

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
