### PR TITLE
2249 - Add graphql resolution for pubsweet-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
     "secretcheck"
   ],
   "resolutions": {
-    "lodash": ">=4.17.11",
-    "pubsweet-client/graphql": "^14.2.1"
+    "graphql": "^14.2.1",
+    "lodash": ">=4.17.11"
   },
   "workspaces": [
     "client/*",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "secretcheck"
   ],
   "resolutions": {
-    "lodash": ">=4.17.11"
+    "lodash": ">=4.17.11",
+    "pubsweet-client/graphql": "^14.2.1"
   },
   "workspaces": [
     "client/*",
@@ -113,6 +114,7 @@
     "config": "^3.0.1",
     "date-fns": "^1.29.0",
     "formik": "1.5.7",
+    "graphql": "^14.2.1",
     "graphql-tag": "^2.8.0",
     "history": "^4.7.2",
     "html-pdf": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7063,14 +7063,7 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.2"
     object-path "^0.11.4"
 
-graphql@^14.0.2:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
-  integrity sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==
-  dependencies:
-    iterall "^1.2.2"
-
-graphql@^14.2.1:
+graphql@^14.0.2, graphql@^14.2.1:
   version "14.3.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.3.1.tgz#b3aa50e61a841ada3c1f9ccda101c483f8e8c807"
   integrity sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==


### PR DESCRIPTION
#### Background

We were having multiple graphql dependency issues when using subscriptions on the client side. This was caused by two different versions of `graphql` being depended upon by the project, `14.0.2` and `14.3.1`. 

Long term fix for this is to upgrade to the latest `pubsweet-client` which has the same dependency version of `graphql` as the `pubsweet-server` version we are using. This is being addressed as part of #2239.

Short term fix is to set a resolution for `pubsweet-client` to put `graphql` at the same version as 

#### Any relevant tickets

Closes #2249 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
