### PR TITLE
Add survey submission mutation (without useCase)

### DIFF
--- a/packages/component-submission/server/resolvers/index.js
+++ b/packages/component-submission/server/resolvers/index.js
@@ -12,6 +12,7 @@ const { submitManuscript } = require('./submitManuscript')
 const uploadManuscript = require('./uploadManuscript')
 const uploadSupportingFile = require('./uploadSupportingFile')
 const removeSupportingFiles = require('./removeSupportingFiles')
+const submitSurvey = require('./submitSurvey')
 
 const {
   getSubmissionUseCase,
@@ -64,6 +65,8 @@ const resolvers = {
     removeUploadedManuscript,
 
     removeSupportingFiles,
+
+    submitSurvey,
   },
 
   Subscription: {

--- a/packages/component-submission/server/resolvers/submitSurvey.js
+++ b/packages/component-submission/server/resolvers/submitSurvey.js
@@ -1,0 +1,22 @@
+// submit survey resolver -- calls the usecase
+const { submitSurveyUseCase } = require('../use-cases')
+const config = require('config')
+
+async function submitSurvey(_, data, { user }) {
+  const { surveyId, submissionId, answers } = data
+
+  console.log(surveyId, submissionId, answers)
+
+  try {
+    // submitSurvey
+    return submitSurveyUseCase(null, { surveyId, submissionId, answers, user })
+  } catch (e) {
+    throw e
+  }
+}
+
+module.exports =
+  config.has('features.demographicSurvey') &&
+  config.get('features.demographicSurvey')
+    ? submitSurvey
+    : async () => false

--- a/packages/component-submission/server/resolvers/submitSurvey.js
+++ b/packages/component-submission/server/resolvers/submitSurvey.js
@@ -1,15 +1,18 @@
-// submit survey resolver -- calls the usecase
 const { submitSurveyUseCase } = require('../use-cases')
 const config = require('config')
 
-async function submitSurvey(_, data, { user }) {
+async function submitSurvey(_, { data }, { user: userId }) {
   const { surveyId, submissionId, answers } = data
 
-  console.log(surveyId, submissionId, answers)
+  console.log(surveyId, submissionId, answers, userId)
 
   try {
-    // submitSurvey
-    return submitSurveyUseCase(null, { surveyId, submissionId, answers, user })
+    return submitSurveyUseCase(null, {
+      surveyId,
+      submissionId,
+      answers,
+      userId,
+    })
   } catch (e) {
     throw e
   }

--- a/packages/component-submission/server/typeDefs.graphqls
+++ b/packages/component-submission/server/typeDefs.graphqls
@@ -9,6 +9,7 @@ extend type Mutation {
   removeSupportingFiles(id: ID!): Manuscript
   removeUploadedManuscript(id: ID!): Manuscript!
   submitManuscript(data: ManuscriptInput!): Manuscript!
+  submitSurvey(data: SurveySubmission!): Boolean!
 }
 
 extend type Subscription {
@@ -51,3 +52,14 @@ input OpposedReviewerInput {
   email: String
 }
 
+input SurveySubmission {
+  surveyId: String!
+  answers: [SurveyAnswer!]!
+  submissionId: String!
+}
+
+input SurveyAnswer {
+  questionId: String!,
+  text: String!,
+  answer: String!,
+}

--- a/packages/component-submission/server/use-cases/index.js
+++ b/packages/component-submission/server/use-cases/index.js
@@ -3,10 +3,12 @@ const Manuscript = require('./manuscript')
 
 const getSubmissionUseCase = require('./getSubmissionUseCase')
 const updateSubmissionUseCase = require('./updateSubmissionUseCase')
+const submitSurveyUseCase = require('./submitSurveyUseCase')
 
 module.exports = {
   getSubmissionUseCase,
   updateSubmissionUseCase,
   SupportingFiles,
+  submitSurveyUseCase,
   Manuscript,
 }

--- a/packages/component-submission/server/use-cases/submitSurveyUseCase.js
+++ b/packages/component-submission/server/use-cases/submitSurveyUseCase.js
@@ -1,6 +1,5 @@
 // Export a stub use case for submit survey
 
-module.exports = (dbManager, { surveyId, answers, submissionId, user }) => 
+module.exports = (dbManager, { surveyId, answers, submissionId, userId }) =>
   // Do some stuff eventually
-   false
-
+  false

--- a/packages/component-submission/server/use-cases/submitSurveyUseCase.js
+++ b/packages/component-submission/server/use-cases/submitSurveyUseCase.js
@@ -1,0 +1,6 @@
+// Export a stub use case for submit survey
+
+module.exports = (dbManager, { surveyId, answers, submissionId, user }) => 
+  // Do some stuff eventually
+   false
+


### PR DESCRIPTION
#### Background

This PR includes scope for the following:
- [x] GraphQL type definitions for `submitSurvey`
- [x] A resolver for the `submitSurveyUseCase`
- [x] A stub use-case so it builds
- [x] feature flags - will be enabled by #2281 
- [ ] Does this need unit tests?

What does this PR do?
Closes #2277

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [ ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide