### PR TITLE
2298: move redirect to confirm button

### DIFF
--- a/config/unit-test.js
+++ b/config/unit-test.js
@@ -62,4 +62,8 @@ module.exports = {
       },
     },
   },
+  features: {
+    isPublic: true,
+    demographicSurvey: false,
+  },
 }

--- a/config/unit-test.js
+++ b/config/unit-test.js
@@ -63,7 +63,6 @@ module.exports = {
     },
   },
   features: {
-    isPublic: true,
     demographicSurvey: false,
   },
 }

--- a/packages/component-submission/client/pages/SubmissionWizard.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.js
@@ -10,6 +10,7 @@ import styled from 'styled-components'
 import { th } from '@pubsweet/ui-toolkit'
 import { Formik, Form } from 'formik'
 import * as yup from 'yup'
+import config from 'config'
 import {
   ErrorPage,
   TrackedRoute,
@@ -107,7 +108,13 @@ export const SubmissionWizard = ({
           variables: { data: parseFormToOutputData(formValues) },
         }),
       )
-      .then(() => history.push(`/thankyou/${match.params.id}`))
+      .then(() =>
+        history.push(
+          config.features && config.features.demographicSurvey
+            ? `/survey/${match.params.id}`
+            : `/thankyou/${match.params.id}`,
+        ),
+      )
 
   const navigateToStep = step => {
     setCurrentStep(step)

--- a/packages/component-submission/client/pages/SubmissionWizard.test.js
+++ b/packages/component-submission/client/pages/SubmissionWizard.test.js
@@ -10,7 +10,6 @@ import { MemoryRouter } from 'react-router-dom'
 import { MockedProvider } from 'react-apollo/test-utils'
 import { SubmissionWizard } from './SubmissionWizard'
 
-jest.mock('config')
 jest.mock('react-ga')
 jest.mock('./AuthorStepPage', () => () => 'AuthorStepPage')
 jest.mock('./FilesStepPage', () => () => 'FilesStepPage')
@@ -99,8 +98,10 @@ describe('SubmissionWizard', async () => {
       const path = '/submit/id/disclosure'
       const submitManuscript = jest.fn()
       const pushHistory = jest.fn()
+      const originalFeatures = { ...config.features }
 
-      beforeEach(() => {
+      afterEach(() => {
+        config.features = originalFeatures
         submitManuscript.mockReset()
         pushHistory.mockReset()
       })
@@ -120,8 +121,6 @@ describe('SubmissionWizard', async () => {
         expect(submitManuscript).toHaveBeenCalledTimes(1)
         expect(pushHistory).toHaveBeenCalledTimes(1)
         expect(pushHistory).toHaveBeenCalledWith('/thankyou/id')
-
-        config.features.demographicSurvey = true
       })
 
       it('should redirect to survey page if survey flag is on', async () => {
@@ -139,8 +138,6 @@ describe('SubmissionWizard', async () => {
         expect(submitManuscript).toHaveBeenCalledTimes(1)
         expect(pushHistory).toHaveBeenCalledTimes(1)
         expect(pushHistory).toHaveBeenCalledWith('/survey/id')
-
-        config.features.demographicSurvey = false
       })
     })
   })

--- a/packages/component-submission/client/pages/ThankYouPage.js
+++ b/packages/component-submission/client/pages/ThankYouPage.js
@@ -48,15 +48,7 @@ export class ThankYouPageComponent extends React.Component {
           submission.
           <BookmarkLink href="/">elifesciences.org/submissions</BookmarkLink>
         </Paragraph.Small>
-        <ButtonLink
-          data-test-id="finish"
-          primary
-          to={
-            config.features && config.features.demographicSurvey
-              ? `/survey/${data.manuscript.id}`
-              : '/'
-          }
-        >
+        <ButtonLink data-test-id="finish" primary to="/">
           Finish
         </ButtonLink>
       </CenteredContent>


### PR DESCRIPTION
#### Background

Moves the functionality to redirect to either the thank you page or survey page depending on the feature flag

#### Any relevant tickets

Closes #2298 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
