### PR TITLE
ensure people pod keys are unique to prevent errors throwing

### DIFF
--- a/packages/component-submission/client/components/PeoplePicker/PersonInfoModal.js
+++ b/packages/component-submission/client/components/PeoplePicker/PersonInfoModal.js
@@ -66,13 +66,14 @@ PersonInfoModal.propTypes = {
   open: PropTypes.bool.isRequired,
   maxSelection: PropTypes.number,
   name: personNamePropType.isRequired,
-  institution: affiliationPropType.isRequired,
+  institution: affiliationPropType,
   focuses: focusesPropType.isRequired,
   expertises: expertisesPropType.isRequired,
 }
 
 PersonInfoModal.defaultProps = {
   maxSelection: Infinity,
+  institution: '',
 }
 
 export default PersonInfoModal

--- a/packages/component-submission/client/components/PeoplePicker/PersonPod.js
+++ b/packages/component-submission/client/components/PeoplePicker/PersonPod.js
@@ -113,20 +113,21 @@ class PersonPod extends React.Component {
     } = this.props
 
     let keywordList
+    /* eslint-disable react/no-array-index-key */
     const keywords = [].concat(focuses).concat(expertises)
     if (isKeywordClickable) {
-      keywordList = keywords.map(keyword => (
+      keywordList = keywords.map((keyword, index) => (
         <SmallAction
           data-test-id="clickable-keyword"
-          key={keyword}
+          key={`${keyword}-${index}`}
           onClick={() => onKeywordClick(keyword)}
         >
           {keyword}
         </SmallAction>
       ))
     } else {
-      keywordList = keywords.map(keyword => (
-        <span data-test-id="non-clickable-keyword" key={keyword}>
+      keywordList = keywords.map((keyword, index) => (
+        <span data-test-id="non-clickable-keyword" key={`${keyword}-${index}`}>
           {keyword}
         </span>
       ))

--- a/packages/component-submission/client/components/PeoplePicker/PersonPod.js
+++ b/packages/component-submission/client/components/PeoplePicker/PersonPod.js
@@ -113,12 +113,12 @@ class PersonPod extends React.Component {
     } = this.props
 
     let keywordList
-    /* eslint-disable react/no-array-index-key */
-    const keywords = [].concat(focuses).concat(expertises)
+    const keywords = [...focuses, ...expertises]
     if (isKeywordClickable) {
       keywordList = keywords.map((keyword, index) => (
         <SmallAction
           data-test-id="clickable-keyword"
+          /* eslint-disable-next-line react/no-array-index-key */
           key={`${keyword}-${index}`}
           onClick={() => onKeywordClick(keyword)}
         >
@@ -127,6 +127,7 @@ class PersonPod extends React.Component {
       ))
     } else {
       keywordList = keywords.map((keyword, index) => (
+        /* eslint-disable-next-line react/no-array-index-key */
         <span data-test-id="non-clickable-keyword" key={`${keyword}-${index}`}>
           {keyword}
         </span>


### PR DESCRIPTION
This should fix the console errors being thrown when opening people picker in a development environment.