### PR TITLE
Use lock file in api tests

### DIFF
--- a/tools/api-tests/Dockerfile
+++ b/tools/api-tests/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /opt
 
 MAINTAINER Peter East <petereast+pgp@pm.me>
 
-COPY package.json .
-RUN ["npm", "i"]
+COPY package.json yarn.lock ./
+RUN ["yarn", "install"]
 
 COPY tsconfig.json .
 COPY codegen-docker.yml .

--- a/tools/api-tests/package.json
+++ b/tools/api-tests/package.json
@@ -34,7 +34,7 @@
     "ci": "npm run graphql:codegen:docker && npm run compile && npm start"
   },
   "resolutions": {
-    "lodash.merge": "^5.6.2",
+    "lodash.merge": "^4.6.2",
     "lodash": "^4.17.13"
   },
   "devDependencies": {


### PR DESCRIPTION
`@graphql-codegen/cli` has got up to [1.5.0](https://github.com/dotansimha/graphql-code-generator/releases) possibly having incompatibilities with the current setup.