### PR TITLE
Fix for #2345: filter out opposed reviewers

### DIFF
--- a/packages/component-model-manuscript/entities/manuscript/index.js
+++ b/packages/component-model-manuscript/entities/manuscript/index.js
@@ -319,10 +319,18 @@ class Manuscript extends BaseModel {
   // would mean applying the input to the manuscript first
   static removeOptionalBlankReviewers(input) {
     const itemIsBlank = item => item.name + item.email === ''
-    const filteredReviewers = input.suggestedReviewers.filter(
+    const filteredSuggestedReviewers = input.suggestedReviewers.filter(
       item => !itemIsBlank(item),
     )
-    return { ...input, suggestedReviewers: filteredReviewers }
+    const filteredOpposedReviewers = input.opposedReviewers.filter(
+      item => !itemIsBlank(item),
+    )
+
+    return {
+      ...input,
+      suggestedReviewers: filteredSuggestedReviewers,
+      opposedReviewers: filteredOpposedReviewers,
+    }
   }
 
   getAuthor() {

--- a/packages/component-submission/server/resolvers/submitManuscript.test.js
+++ b/packages/component-submission/server/resolvers/submitManuscript.test.js
@@ -159,6 +159,13 @@ describe('Manuscripts', () => {
         { name: 'Reviewer 4', email: 'reviewer4@mail.com' },
         { name: '', email: '' },
       ]
+      input.opposedReviewers = [
+        { name: 'Reviewer 5', email: 'reviewer5@mail.com' },
+        { name: '', email: '' },
+        { name: 'Reviewer 6', email: 'reviewer6@mail.com' },
+        { name: '', email: '' },
+      ]
+
       await submitManuscript(mockedExportFn)(
         {},
         { data: input },
@@ -166,12 +173,24 @@ describe('Manuscripts', () => {
       )
 
       const manuscript = await Manuscript.find(id, userId)
-      const team = manuscript.teams.find(t => t.role === 'suggestedReviewer')
-      expect(team.teamMembers.map(member => member.meta)).toEqual([
-        { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
-        { name: 'Reviewer 2', email: 'reviewer2@mail.com' },
-        { name: 'Reviewer 3', email: 'reviewer3@mail.com' },
-        { name: 'Reviewer 4', email: 'reviewer4@mail.com' },
+      const suggestedReviewers = manuscript.teams.find(
+        t => t.role === 'suggestedReviewer',
+      )
+      expect(suggestedReviewers.teamMembers.map(member => member.meta)).toEqual(
+        [
+          { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
+          { name: 'Reviewer 2', email: 'reviewer2@mail.com' },
+          { name: 'Reviewer 3', email: 'reviewer3@mail.com' },
+          { name: 'Reviewer 4', email: 'reviewer4@mail.com' },
+        ],
+      )
+
+      const opposedReviewers = manuscript.teams.find(
+        t => t.role === 'opposedReviewer',
+      )
+      expect(opposedReviewers.teamMembers.map(member => member.meta)).toEqual([
+        { name: 'Reviewer 5', email: 'reviewer5@mail.com' },
+        { name: 'Reviewer 6', email: 'reviewer6@mail.com' },
       ])
     })
 


### PR DESCRIPTION
#### Background

Fixes bug when empty opposed reviewer name and email data are empty string are erroneously rejected by joi validation. The fix is to filter out any empty entries as was done currently for suggested reviewers

#### Any relevant tickets

Contributes to #2354 

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

