### PR TITLE
frontend fix for #2354: prevent client from sending empty reviewer data

### DIFF
--- a/packages/component-submission/client/utils/parseFormToOutputData.js
+++ b/packages/component-submission/client/utils/parseFormToOutputData.js
@@ -50,9 +50,9 @@ export function parseReviewersData({ suggestedReviewers, opposedReviewers }) {
 
 function parseFormToOutputData(formValues) {
   return {
+    ...parseReviewersData(formValues),
     ...omitDeep(formValues, FORM_FIELDS_TO_OMIT),
     ...parseCosubmissionFormData(formValues),
-    ...parseReviewersData(formValues),
     ...parseEditorSuggestionsData(formValues),
   }
 }

--- a/packages/component-submission/client/utils/parseFormToOutputData.js
+++ b/packages/component-submission/client/utils/parseFormToOutputData.js
@@ -33,10 +33,26 @@ export function parseEditorSuggestionsData(values) {
   return returnObject
 }
 
+export function parseReviewersData({ suggestedReviewers, opposedReviewers }) {
+  const itemNotBlank = item => item.name + item.email !== ''
+  const filtered = {}
+
+  if (suggestedReviewers !== undefined) {
+    filtered.suggestedReviewers = suggestedReviewers.filter(itemNotBlank)
+  }
+
+  if (opposedReviewers !== undefined) {
+    filtered.opposedReviewers = opposedReviewers.filter(itemNotBlank)
+  }
+
+  return filtered
+}
+
 function parseFormToOutputData(formValues) {
   return {
     ...omitDeep(formValues, FORM_FIELDS_TO_OMIT),
     ...parseCosubmissionFormData(formValues),
+    ...parseReviewersData(formValues),
     ...parseEditorSuggestionsData(formValues),
   }
 }

--- a/packages/component-submission/client/utils/parseFormToOutputData.test.js
+++ b/packages/component-submission/client/utils/parseFormToOutputData.test.js
@@ -1,5 +1,6 @@
 import parseFormToOutputData, {
   parseCosubmissionFormData,
+  parseReviewersData,
   parseEditorSuggestionsData,
 } from './parseFormToOutputData'
 
@@ -36,6 +37,38 @@ describe('parseCosubmissionFormData', () => {
     expect(cosubmission).toHaveLength(2)
     expect(cosubmission[0]).toEqual('bar')
     expect(cosubmission[1]).toEqual('foo')
+  })
+})
+
+describe('parseReviewersData', () => {
+  it('removes empty suggested reviewers', () => {
+    const values = {
+      suggestedReviewers: [
+        { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
+        { name: '', email: '' },
+        { name: 'Reviewer 2', email: 'reviewer2@mail.com' },
+      ],
+    }
+
+    expect(parseReviewersData(values).suggestedReviewers).toEqual([
+      { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
+      { name: 'Reviewer 2', email: 'reviewer2@mail.com' },
+    ])
+  })
+
+  it('removes empty opposed reviewers', () => {
+    const values = {
+      opposedReviewers: [
+        { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
+        { name: '', email: '' },
+        { name: 'Reviewer 2', email: 'reviewer2@mail.com' },
+      ],
+    }
+
+    expect(parseReviewersData(values).opposedReviewers).toEqual([
+      { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
+      { name: 'Reviewer 2', email: 'reviewer2@mail.com' },
+    ])
   })
 })
 

--- a/packages/component-submission/client/utils/parseInputToFormData.js
+++ b/packages/component-submission/client/utils/parseInputToFormData.js
@@ -10,10 +10,21 @@ export function parseCosubmissionInput(cosubmissionValues = []) {
   }
 }
 
+export function parseSuggestedReviewers({ suggestedReviewers }) {
+  if (suggestedReviewers !== undefined) {
+    return suggestedReviewers.length === 0
+      ? { suggestedReviewers: [{ name: '', email: '' }] }
+      : suggestedReviewers
+  }
+
+  return {}
+}
+
 // This basically sets the initial values
 function parseInputToFormData(values) {
   return {
     ...cloneDeep(values),
+    ...parseSuggestedReviewers(values),
     ...parseCosubmissionInput(values.cosubmission),
   }
 }

--- a/packages/component-submission/client/utils/parseInputToFormData.js
+++ b/packages/component-submission/client/utils/parseInputToFormData.js
@@ -14,7 +14,7 @@ export function parseSuggestedReviewers({ suggestedReviewers }) {
   if (suggestedReviewers !== undefined) {
     return suggestedReviewers.length === 0
       ? { suggestedReviewers: [{ name: '', email: '' }] }
-      : suggestedReviewers
+      : { suggestedReviewers }
   }
 
   return {}

--- a/packages/component-submission/client/utils/parseInputToFormData.test.js
+++ b/packages/component-submission/client/utils/parseInputToFormData.test.js
@@ -61,4 +61,24 @@ describe('parseInputToFormData', () => {
       secondCosubmissionTitle: 'e',
     })
   })
+
+  it('adds an empty suggested reviewer if empty', () => {
+    const mockInput = {
+      suggestedReviewers: [],
+    }
+
+    expect(parseInputToFormData(mockInput).suggestedReviewers).toEqual([
+      { name: '', email: '' },
+    ])
+  })
+
+  it("doesn't add an empty suggested reviewer if empty", () => {
+    const mockInput = {
+      suggestedReviewers: [{ name: 'Reviewer 1', email: 'reviewer1@mail.com' }],
+    }
+
+    expect(parseInputToFormData(mockInput).suggestedReviewers).toEqual([
+      { name: 'Reviewer 1', email: 'reviewer1@mail.com' },
+    ])
+  })
 })


### PR DESCRIPTION
#### Background

Adds a further fix for #2354 so that front end doesn't send empty reviewer data

#### Any relevant tickets

Closes #2354 

#### How has this been tested?

- [x ] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

