### PR TITLE
Add caching to eLife API

### DIFF
--- a/packages/component-model-user/entities/user/helpers/api-cache.js
+++ b/packages/component-model-user/entities/user/helpers/api-cache.js
@@ -21,6 +21,7 @@ class ApiCache {
       result,
       time: Date.now(),
     }
+    return hash
   }
 
   _isExpired(hash) {

--- a/packages/component-model-user/entities/user/helpers/api-cache.js
+++ b/packages/component-model-user/entities/user/helpers/api-cache.js
@@ -1,0 +1,61 @@
+const crypto = require('crypto')
+
+class ApiCache {
+  constructor(ttl) {
+    this.ttl = ttl
+    this.clear()
+  }
+
+  clear() {
+    this._cache = {}
+  }
+
+  static md5(s) {
+    return crypto
+      .createHash('md5')
+      .update(s)
+      .digest('hex')
+  }
+
+  addEntry(hash, result) {
+    this._cache[hash] = {
+      result,
+      time: Date.now(),
+    }
+  }
+
+  static makeHash(uri, req) {
+    const rString = uri + JSON.stringify(req)
+    const result = ApiCache.md5(rString)
+    return result
+  }
+
+  isExpired(hash) {
+    let result = true
+    if (this.hasEntry(hash)) {
+      const elapsed = this._cache[hash].time - Date.now()
+      result = elapsed > this.ttl
+    }
+    return result
+  }
+
+  hasEntry(hash) {
+    return hash in this._cache
+  }
+
+  getResult(hash) {
+    let result = null
+
+    if (this.hasEntry(hash)) {
+      result = this._cache[hash].result
+    }
+
+    return result
+  }
+
+  getLength() {
+    return Object.keys(this._cache).length
+  }
+}
+
+module.exports = ApiCache

--- a/packages/component-model-user/entities/user/helpers/api-cache.test.js
+++ b/packages/component-model-user/entities/user/helpers/api-cache.test.js
@@ -1,0 +1,12 @@
+const ApiCache = require('./api-cache')
+
+describe('eLife API Cache tests', () => {
+  let cache
+
+  beforeEach(() => {
+    cache = new ApiCache(1)
+  })
+  it('Cache adds entries', async () => {
+    expect(cache.getLength()).toBe(0)
+  })
+})

--- a/packages/component-model-user/entities/user/helpers/api-cache.test.js
+++ b/packages/component-model-user/entities/user/helpers/api-cache.test.js
@@ -1,12 +1,73 @@
 const ApiCache = require('./api-cache')
 
-describe('eLife API Cache tests', () => {
-  let cache
+describe('API Cache tests', () => {
+  let cache, key, key2, ttl
 
   beforeEach(() => {
-    cache = new ApiCache(1)
+    ttl = 600
+    cache = new ApiCache(ttl)
+    key = 'front door'
+    key2 = 'back door'
   })
+
+  it('Cache produces different hashes', async () => {
+    const hash1 = cache.addEntry(key, { a: 1 })
+    const hash2 = cache.addEntry(key2, { a: 1 })
+    expect(hash1).not.toEqual(hash2)
+    expect(hash1).toHaveLength(32)
+    expect(hash2).toHaveLength(32)
+  })
+
+  it('Cache returns null if entry does not exist', async () => {
+    expect(cache.getLength()).toBe(0)
+    expect(cache.getResult(key)).toBeNull()
+  })
+
   it('Cache adds entries', async () => {
     expect(cache.getLength()).toBe(0)
+    cache.addEntry(key, { a: 1 })
+    expect(cache.getLength()).toBe(1)
+  })
+
+  it('Cache can be cleared', async () => {
+    expect(cache.getLength()).toBe(0)
+    cache.addEntry(key, { a: 1 })
+    cache.addEntry(key2, { a: 2 })
+    expect(cache.getLength()).toBe(2)
+    cache.clear()
+    expect(cache.getLength()).toBe(0)
+  })
+
+  it('Cache updates entries', async () => {
+    expect(cache.getLength()).toBe(0)
+    cache.addEntry(key, { a: 1 })
+    expect(cache.getLength()).toBe(1)
+    cache.addEntry(key, { a: 2 })
+    expect(cache.getLength()).toBe(1)
+    expect(cache.getResult(key)).toEqual({ a: 2 })
+  })
+
+  it('Cache respects ttl', async () => {
+    const originalDate = Date
+
+    cache.addEntry(key, { a: 1 })
+    const now = Date.now()
+    expect(cache.getLength()).toBe(1)
+    expect(cache.hasEntry(key)).toBe(true)
+    expect(cache.hasLiveEntry(key)).toBe(true)
+
+    // sometime later but not exceeding TTL
+    global.Date.now = jest.fn(() => now + ttl / 2)
+    expect(cache.hasEntry(key)).toBe(true)
+    expect(cache.hasLiveEntry(key)).toBe(true)
+
+    // Exceeded TTL
+    global.Date.now = jest.fn(() => now + ttl + 1)
+    expect(cache.hasEntry(key)).toBe(true)
+    expect(cache.hasLiveEntry(key)).toBe(false)
+    expect(cache.getResult(key)).toEqual({ a: 1 })
+
+    // restore global Date object
+    global.Date = originalDate
   })
 })

--- a/packages/component-model-user/entities/user/helpers/cached-request.js
+++ b/packages/component-model-user/entities/user/helpers/cached-request.js
@@ -1,0 +1,20 @@
+const superagent = require('superagent')
+const config = require('config')
+const logger = require('@pubsweet/logger')
+
+const apiRoot = config.get('server.api.url')
+
+const request = (endpoint, query = {}) => {
+  const req = superagent.get(apiRoot + endpoint)
+
+  // only had the header if its defined in config
+  const secret = config.get('server.api.secret')
+  if (secret) {
+    req.header.Authorization = secret
+  }
+  return req.query(query).catch(err => {
+    logger.error('Failed to fetch from eLife API:', err.message, err.stack)
+    throw err
+  })
+}
+module.exports = request

--- a/packages/component-model-user/entities/user/helpers/cached-request.js
+++ b/packages/component-model-user/entities/user/helpers/cached-request.js
@@ -6,19 +6,20 @@ const ApiCache = require('./api-cache')
 const apiRoot = config.get('server.api.url')
 const elifeCache = new ApiCache(600)
 
+const getKeyFromRequest = (root, endpoint, query, req) => root + endpoint + query + JSON.stringify(req)
 //
 // cachedRequest() is meant to be a drop in replacement for superagent.request
 //
 const cachedRequest = async (endpoint, query = {}) => {
-  const uri = apiRoot + endpoint
-  const req = superagent.get(uri)
-  const key = uri + query + JSON.stringify(req)
+  const req = superagent.get(apiRoot + endpoint)
 
   // only had the header if its defined in config
   const secret = config.get('server.api.secret')
   if (secret) {
     req.header.Authorization = secret
   }
+
+  const key = getKeyFromRequest(apiRoot, endpoint, query, req)
   const found = elifeCache.hasLiveEntry(key)
 
   let result = null
@@ -46,4 +47,5 @@ const cachedRequest = async (endpoint, query = {}) => {
 module.exports = {
   cachedRequest,
   elifeCache,
+  getKeyFromRequest,
 }

--- a/packages/component-model-user/entities/user/helpers/cached-request.js
+++ b/packages/component-model-user/entities/user/helpers/cached-request.js
@@ -1,20 +1,104 @@
 const superagent = require('superagent')
-const config = require('config')
 const logger = require('@pubsweet/logger')
+const config = require('config')
+const crypto = require('crypto')
 
 const apiRoot = config.get('server.api.url')
 
-const request = (endpoint, query = {}) => {
-  const req = superagent.get(apiRoot + endpoint)
+class ApiCache {
+  constructor(maxSeconds) {
+    this.maxSeconds = maxSeconds
+    this.clear()
+  }
+
+  clear() {
+    this._cache = {}
+  }
+
+  static md5(s) {
+    return crypto
+      .createHash('md5')
+      .update(s)
+      .digest('hex')
+  }
+
+  addEntry(hash, result) {
+    this._cache[hash] = {
+      result,
+      time: Date.now(),
+    }
+  }
+
+  static makeHash(uri, req) {
+    const rString = uri + JSON.stringify(req)
+    const result = ApiCache.md5(rString)
+    return result
+  }
+
+  isExpired(hash) {
+    let result = true
+    if (this.hasEntry(hash)) {
+      const elapsed = this._cache[hash].time - Date.now()
+      result = elapsed > this.maxSeconds
+    }
+    return result
+  }
+
+  hasEntry(hash) {
+    return hash in this._cache
+  }
+
+  getResult(hash) {
+    let result = null
+
+    if (this.hasEntry(hash)) {
+      result = this._cache[hash].result
+    }
+
+    return result
+  }
+
+  getLength() {
+    return Object.keys(this._cache).length
+  }
+}
+
+const elifeCache = new ApiCache()
+
+const request = async (endpoint, query = {}) => {
+  const uri = apiRoot + endpoint
+  const req = superagent.get(uri)
 
   // only had the header if its defined in config
   const secret = config.get('server.api.secret')
   if (secret) {
     req.header.Authorization = secret
   }
-  return req.query(query).catch(err => {
+  const hash = ApiCache.makeHash(uri + query, req)
+  const found = elifeCache.hasEntry(hash)
+  const expired = elifeCache.isExpired(hash)
+  let result = null
+  try {
+    if (found && !expired) {
+      result = elifeCache.getResult(hash)
+    } else {
+      // if we are here then the cache is expired or stale
+      result = await req.query(query)
+      elifeCache.addEntry(hash, result)
+    }
+  } catch (err) {
     logger.error('Failed to fetch from eLife API:', err.message, err.stack)
-    throw err
-  })
+    // last resort return stale data
+    if (found) {
+      result = elifeCache.getResult(hash)
+    } else {
+      throw err
+    }
+  }
+  return result
 }
-module.exports = request
+
+module.exports = {
+  request,
+  elifeCache,
+}

--- a/packages/component-model-user/entities/user/helpers/cached-request.js
+++ b/packages/component-model-user/entities/user/helpers/cached-request.js
@@ -1,71 +1,12 @@
 const superagent = require('superagent')
 const logger = require('@pubsweet/logger')
 const config = require('config')
-const crypto = require('crypto')
+const ApiCache = require('./api-cache')
 
 const apiRoot = config.get('server.api.url')
+const elifeCache = new ApiCache(600)
 
-class ApiCache {
-  constructor(maxSeconds) {
-    this.maxSeconds = maxSeconds
-    this.clear()
-  }
-
-  clear() {
-    this._cache = {}
-  }
-
-  static md5(s) {
-    return crypto
-      .createHash('md5')
-      .update(s)
-      .digest('hex')
-  }
-
-  addEntry(hash, result) {
-    this._cache[hash] = {
-      result,
-      time: Date.now(),
-    }
-  }
-
-  static makeHash(uri, req) {
-    const rString = uri + JSON.stringify(req)
-    const result = ApiCache.md5(rString)
-    return result
-  }
-
-  isExpired(hash) {
-    let result = true
-    if (this.hasEntry(hash)) {
-      const elapsed = this._cache[hash].time - Date.now()
-      result = elapsed > this.maxSeconds
-    }
-    return result
-  }
-
-  hasEntry(hash) {
-    return hash in this._cache
-  }
-
-  getResult(hash) {
-    let result = null
-
-    if (this.hasEntry(hash)) {
-      result = this._cache[hash].result
-    }
-
-    return result
-  }
-
-  getLength() {
-    return Object.keys(this._cache).length
-  }
-}
-
-const elifeCache = new ApiCache()
-
-const request = async (endpoint, query = {}) => {
+const cachedRequest = async (endpoint, query = {}) => {
   const uri = apiRoot + endpoint
   const req = superagent.get(uri)
 
@@ -77,6 +18,7 @@ const request = async (endpoint, query = {}) => {
   const hash = ApiCache.makeHash(uri + query, req)
   const found = elifeCache.hasEntry(hash)
   const expired = elifeCache.isExpired(hash)
+
   let result = null
   try {
     if (found && !expired) {
@@ -88,10 +30,11 @@ const request = async (endpoint, query = {}) => {
     }
   } catch (err) {
     logger.error('Failed to fetch from eLife API:', err.message, err.stack)
-    // last resort return stale data
     if (found) {
+      // error doing query - last resort return stale data
       result = elifeCache.getResult(hash)
     } else {
+      // error doing query and nothing in cache - so error
       throw err
     }
   }
@@ -99,6 +42,6 @@ const request = async (endpoint, query = {}) => {
 }
 
 module.exports = {
-  request,
+  cachedRequest,
   elifeCache,
 }

--- a/packages/component-model-user/entities/user/helpers/cached-request.test.js
+++ b/packages/component-model-user/entities/user/helpers/cached-request.test.js
@@ -7,13 +7,17 @@ jest.mock('superagent', () => ({
   },
 }))
 
+const request = require('superagent')
+const {
+  elifeCache,
+  cachedRequest,
+  getKeyFromRequest,
+} = require('./cached-request')
+
 const makeGetResponse = response => () => ({
   header: request.header,
   query: response,
 })
-
-const request = require('superagent')
-const { elifeCache, cachedRequest } = require('./cached-request')
 
 const doQuery = async query => {
   request.get.mockImplementation(makeGetResponse(query))
@@ -22,14 +26,49 @@ const doQuery = async query => {
 }
 
 describe('eLife API Cache tests', () => {
-  let responseContent, goodQuery, badQuery
+  let responseContent, goodQuery, badQuery, reqWithAuth, reqNoAuth
 
   beforeEach(() => {
     elifeCache.clear()
     responseContent = { body: 'this is the body of the request' }
     goodQuery = jest.fn(() => Promise.resolve(responseContent))
     badQuery = jest.fn(() => Promise.reject(new Error('Bad')))
+    reqWithAuth = { header: { Authorization: 'let me in' } }
+    reqNoAuth = { header: { Authorization: 'keep me out' } }
   })
+
+  it('Key generation alters given root', async () => {
+    const key1 = getKeyFromRequest('root1', 'ep1', 'query1', reqWithAuth)
+    const key2 = getKeyFromRequest('root2', 'ep1', 'query1', reqWithAuth)
+    expect(key1).not.toEqual(key2)
+    expect(key1.length).toBeGreaterThan(0)
+    expect(key2.length).toBeGreaterThan(0)
+  })
+
+  it('Key generation alters given endpoint', async () => {
+    const key1 = getKeyFromRequest('root1', 'ep1', 'query1', reqWithAuth)
+    const key2 = getKeyFromRequest('root1', 'ep2', 'query1', reqWithAuth)
+    expect(key1).not.toEqual(key2)
+    expect(key1.length).toBeGreaterThan(0)
+    expect(key2.length).toBeGreaterThan(0)
+  })
+
+  it('Key generation alters given query', async () => {
+    const key1 = getKeyFromRequest('root1', 'ep1', 'query1', reqWithAuth)
+    const key2 = getKeyFromRequest('root1', 'ep1', 'query2', reqWithAuth)
+    expect(key1).not.toEqual(key2)
+    expect(key1.length).toBeGreaterThan(0)
+    expect(key2.length).toBeGreaterThan(0)
+  })
+
+  it('Key generation alters given request headers', async () => {
+    const key1 = getKeyFromRequest('root1', 'ep1', 'query1', reqWithAuth)
+    const key2 = getKeyFromRequest('root1', 'ep1', 'query1', reqNoAuth)
+    expect(key1).not.toEqual(key2)
+    expect(key1.length).toBeGreaterThan(0)
+    expect(key2.length).toBeGreaterThan(0)
+  })
+
   it("Cache adds entry and doesn't re-query for it", async () => {
     let response, query
     ;({ response, query } = await doQuery(goodQuery))
@@ -45,6 +84,7 @@ describe('eLife API Cache tests', () => {
     expect(query).toHaveBeenCalledTimes(1)
     expect(response).toBe(responseContent)
   })
+
   it('Cache is returned if query fails', async () => {
     let response, query
     ;({ response, query } = await doQuery(goodQuery))

--- a/packages/component-model-user/entities/user/helpers/cached-request.test.js
+++ b/packages/component-model-user/entities/user/helpers/cached-request.test.js
@@ -1,0 +1,63 @@
+jest.mock('superagent', () => ({
+  header: {},
+  url: '',
+  get: jest.fn(),
+  getHeader() {
+    return this.header
+  },
+}))
+
+const makeGetResponse = response => () => ({
+  header: request.header,
+  query: response,
+})
+
+const request = require('superagent')
+const { elifeCache, cachedRequest } = require('./cached-request')
+
+const doQuery = async query => {
+  request.get.mockImplementation(makeGetResponse(query))
+  const response = await cachedRequest('/endpoint', 'order=asc')
+  return { response, query }
+}
+
+describe('eLife API Cache tests', () => {
+  let responseContent, goodQuery, badQuery
+
+  beforeEach(() => {
+    elifeCache.clear()
+    responseContent = { body: 'this is the body of the request' }
+    goodQuery = jest.fn(() => Promise.resolve(responseContent))
+    badQuery = jest.fn(() => Promise.reject(new Error('Bad')))
+  })
+  it("Cache adds entry and doesn't re-query for it", async () => {
+    let response, query
+    ;({ response, query } = await doQuery(goodQuery))
+
+    expect(elifeCache.getLength()).toBe(1)
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(response).toBe(responseContent)
+
+    // Now repeat the query and expect the cache not to call the response
+    ;({ response, query } = await doQuery(goodQuery))
+
+    expect(elifeCache.getLength()).toBe(1)
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(response).toBe(responseContent)
+  })
+  it('Cache is returned if query fails', async () => {
+    let response, query
+    ;({ response, query } = await doQuery(goodQuery))
+
+    expect(elifeCache.getLength()).toBe(1)
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(response).toBe(responseContent)
+
+    // Now repeat the query and expect the cache not to call the response
+    ;({ response, query } = await doQuery(badQuery))
+
+    expect(elifeCache.getLength()).toBe(1)
+    expect(query).toHaveBeenCalledTimes(0)
+    expect(response).toBe(responseContent)
+  })
+})

--- a/packages/component-model-user/entities/user/helpers/elife-api.js
+++ b/packages/component-model-user/entities/user/helpers/elife-api.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 const config = require('config')
 const logger = require('@pubsweet/logger')
-const request = require('./cached-request')
+const { request } = require('./cached-request')
 
 // Taken from journal-cms:
 // sync/field.storage.node.field_person_type.yml
@@ -57,7 +57,9 @@ const people = async role => {
     if (role) {
       role.split(',').forEach(r => {
         if (!isValidRole(r)) {
-          throw new TypeError(`Invalid Role Querying the eLife API: ${r}`)
+          const msg = `Invalid Role Querying the eLife API: ${r}`
+          logger.error(msg)
+          throw new TypeError(msg)
         }
         query += `&type[]=${r}`
       })

--- a/packages/component-model-user/entities/user/helpers/elife-api.js
+++ b/packages/component-model-user/entities/user/helpers/elife-api.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-await-in-loop */
-const superagent = require('superagent')
 const config = require('config')
 const logger = require('@pubsweet/logger')
-
-const apiRoot = config.get('server.api.url')
+const request = require('./cached-request')
 
 // Taken from journal-cms:
 // sync/field.storage.node.field_person_type.yml
@@ -17,20 +15,6 @@ const validRoles = [
 ]
 
 const isValidRole = role => validRoles.indexOf(role) > 1
-
-const request = (endpoint, query = {}) => {
-  const req = superagent.get(apiRoot + endpoint)
-
-  // only had the header if its defined in config
-  const secret = config.get('server.api.secret')
-  if (secret) {
-    req.header.Authorization = secret
-  }
-  return req.query(query).catch(err => {
-    logger.error('Failed to fetch from eLife API:', err.message, err.stack)
-    throw err
-  })
-}
 
 const convertPerson = apiPerson => {
   const { id, name, research = {}, emailAddresses, affiliations } = apiPerson

--- a/packages/component-model-user/entities/user/helpers/elife-api.js
+++ b/packages/component-model-user/entities/user/helpers/elife-api.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 const config = require('config')
 const logger = require('@pubsweet/logger')
-const { request } = require('./cached-request')
+const { cachedRequest } = require('./cached-request')
 
 // Taken from journal-cms:
 // sync/field.storage.node.field_person_type.yml
@@ -65,7 +65,7 @@ const people = async role => {
       })
     }
 
-    response = await request('people', query)
+    response = await cachedRequest('people', query)
     if (response.body.items) {
       items = items.concat(response.body.items)
     }
@@ -76,7 +76,7 @@ const people = async role => {
 
 const person = async id => {
   logger.debug('Fetching editor from /people', { id })
-  const response = await request(`people/${id}`)
+  const response = await cachedRequest(`people/${id}`)
   return convertPerson(response.body)
 }
 
@@ -87,7 +87,7 @@ const getEditorsByPersonId = async editorIds =>
 
 const profile = async id => {
   logger.debug('Fetching profile with ID', id, 'from public API')
-  return request(`profiles/${id}`)
+  return cachedRequest(`profiles/${id}`)
 }
 
 module.exports = {

--- a/packages/component-model-user/entities/user/helpers/elife-api.test.js
+++ b/packages/component-model-user/entities/user/helpers/elife-api.test.js
@@ -36,6 +36,7 @@ const makeGetResponse = examplePerson => () => ({
 const logger = require('@pubsweet/logger')
 const request = require('superagent')
 const api = require('./elife-api')
+const { elifeCache } = require('./cached-request')
 const person = require('./elife-api.test.person')
 
 describe('eLife API tests', () => {
@@ -93,6 +94,7 @@ describe('eLife API tests', () => {
   })
 
   it('logs on error', async () => {
+    elifeCache.clear()
     request.get.mockImplementationOnce(() => ({
       header: request.header,
       query: jest.fn(() => Promise.reject(new Error('Forbidden'))),
@@ -106,6 +108,5 @@ describe('eLife API tests', () => {
     await expect(api.people('dogs,cats')).rejects.toThrow(
       'Invalid Role Querying the eLife API: dogs',
     )
-    expect(logger.error).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
#### Background

Adds a caching layer to the eLife API to decouple.

#### Any relevant tickets

Closes https://github.com/libero/reviewer/issues/356

#### How has this been tested?
New tests added. Also tested on latest PR deployment - looks to behave fine.