### PR TITLE
Use the CDN for caching

### DIFF
--- a/config/prod.js
+++ b/config/prod.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   server: {
     api: {
-      url: 'http://prod--gateway.elife.internal/',
+      url: 'https://prod--cdn-gateway.elifesciences.org/',
     },
   },
   login: {


### PR DESCRIPTION
#### Background

Changes the endpoint for the elife API to use the one backed by the CDN to ensure we have caching.

#### Any relevant tickets

Closes https://github.com/libero/reviewer/issues/356

## Not Tested