### PR TITLE
2389 client session redirect

### DIFF
--- a/config/__tests__/__snapshots__/config.ci.test.js.snap
+++ b/config/__tests__/__snapshots__/config.ci.test.js.snap
@@ -45,6 +45,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "login.sessionTTL",
   "logout.isPublic",
   "mailer.from",
   "mailer.path",

--- a/config/__tests__/__snapshots__/config.default.test.js.snap
+++ b/config/__tests__/__snapshots__/config.default.test.js.snap
@@ -45,6 +45,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "login.sessionTTL",
   "logout.isPublic",
   "mailer.from",
   "mailer.path",

--- a/config/__tests__/__snapshots__/config.development.test.js.snap
+++ b/config/__tests__/__snapshots__/config.development.test.js.snap
@@ -48,6 +48,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "login.sessionTTL",
   "logout.isPublic",
   "mailer.from",
   "mailer.path",

--- a/config/__tests__/__snapshots__/config.end2end.test.js.snap
+++ b/config/__tests__/__snapshots__/config.end2end.test.js.snap
@@ -45,6 +45,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "login.sessionTTL",
   "logout.isPublic",
   "mailer.from",
   "mailer.path",

--- a/config/__tests__/__snapshots__/config.prod.test.js.snap
+++ b/config/__tests__/__snapshots__/config.prod.test.js.snap
@@ -45,6 +45,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "login.sessionTTL",
   "logout.isPublic",
   "logout.redirectUrl",
   "mailer.from",

--- a/config/__tests__/__snapshots__/config.staging.test.js.snap
+++ b/config/__tests__/__snapshots__/config.staging.test.js.snap
@@ -45,6 +45,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "login.sessionTTL",
   "logout.isPublic",
   "logout.redirectUrl",
   "mailer.from",

--- a/config/__tests__/__snapshots__/config.test.test.js.snap
+++ b/config/__tests__/__snapshots__/config.test.test.js.snap
@@ -47,6 +47,7 @@ Array [
   "login.enableMock",
   "login.signupUrl",
   "login.legacySubmissionUrl",
+  "login.sessionTTL",
   "logout.isPublic",
   "mailer.from",
   "mailer.path",

--- a/config/ci.js
+++ b/config/ci.js
@@ -7,6 +7,9 @@ module.exports = {
       endpoint: new AWS.Endpoint('http://localhost:4569'),
     },
   },
+  login: {
+    sessionTTL: 300000,
+  },
   meca: {
     sftp: {
       disableUpload: true,

--- a/config/default.js
+++ b/config/default.js
@@ -91,6 +91,7 @@ module.exports = {
     enableMock: true,
     signupUrl: 'https://orcid.org/register',
     legacySubmissionUrl: 'https://submit.elifesciences.org',
+    sessionTtl: 86400000,
   },
   logout: {
     isPublic: true,

--- a/config/default.js
+++ b/config/default.js
@@ -91,7 +91,7 @@ module.exports = {
     enableMock: true,
     signupUrl: 'https://orcid.org/register',
     legacySubmissionUrl: 'https://submit.elifesciences.org',
-    sessionTtl: 86400000,
+    sessionTTL: 86400000,
   },
   logout: {
     isPublic: true,

--- a/config/staging.js
+++ b/config/staging.js
@@ -13,6 +13,7 @@ module.exports = {
   login: {
     url: 'https://continuumtest--cdn-journal.elifesciences.org/submit',
     enableMock: false,
+    sessionTTL: 300000,
   },
   logout: {
     redirectUrl: 'https://continuumtest--cdn-journal.elifesciences.org/log-out',

--- a/packages/component-login/client/pages/LoginPage.js
+++ b/packages/component-login/client/pages/LoginPage.js
@@ -79,7 +79,7 @@ class LoginPage extends React.Component {
     // force user to signin page once session expires
     setTimeout(() => {
       history.push('/logout')
-    }, config.login.sessionTtl)
+    }, config.login.sessionTTL)
     window.localStorage.setItem('token', token)
   }
 

--- a/packages/component-login/client/pages/LoginPage.js
+++ b/packages/component-login/client/pages/LoginPage.js
@@ -53,7 +53,7 @@ class LoginPage extends React.Component {
     // save JWT to local storage if present
     const token = this.getToken()
     if (token) {
-      LoginPage.setToken(token)
+      LoginPage.setToken(token, this.props.history)
       this.exchangeToken(token)
     }
   }
@@ -64,17 +64,22 @@ class LoginPage extends React.Component {
         mutation: EXCHANGE_TOKEN_MUTATION,
         variables: { token },
       })
-      .then(({ data }) => LoginPage.setToken(data.exchangeJournalToken))
+      .then(({ data }) =>
+        LoginPage.setToken(data.exchangeJournalToken, this.props.history),
+      )
       .catch(err => {
-        LoginPage.setToken(null)
         // TODO expose this error once we have a UI to do so
-        this.props.history.push('/login', { error: err.message })
+        this.props.history.push('/logout', { error: err.message })
         // eslint-disable-next-line no-console
         console.error(err)
       })
   }
 
-  static setToken(token) {
+  static setToken(token, history) {
+    // force user to signin page once session expires
+    setTimeout(() => {
+      history.push('/logout')
+    }, config.login.sessionTtl)
     window.localStorage.setItem('token', token)
   }
 

--- a/packages/component-login/client/pages/LoginPage.test.js
+++ b/packages/component-login/client/pages/LoginPage.test.js
@@ -61,8 +61,16 @@ describe('LoginPage component', () => {
     makeWrapper({ client: clientMock, history: historyMock })
 
     await new Promise(resolve => setTimeout(resolve, 0))
-    expect(historyMock.push).toHaveBeenCalledWith('/login', { error: 'Nope' })
+    expect(historyMock.push).toHaveBeenCalledWith('/logout', { error: 'Nope' })
     // eslint-disable-next-line no-console
     expect(console.error).toHaveBeenCalled()
+  })
+
+  it('redirects when session expires', () => {
+    jest.useFakeTimers()
+    makeWrapper({ client: clientMock, history: historyMock })
+    expect(historyMock.push).not.toBeCalled()
+    jest.runAllTimers()
+    expect(historyMock.push).toBeCalledWith('/logout')
   })
 })


### PR DESCRIPTION
#### Background

The user needs to be taken back to the login page when their session expires as authenticated requests fail silently otherwise.

#### Any relevant tickets

closes #2389

#### How has this been tested?
**Reviewers** ensure that these test requirements are also reviewed.

Please indicate the need for this change to be tested. If not please justify, if so then at what levels. 

- [x] Unit / Integration tests
- [ ] Browser tests
- [ ] End2end tests

#### UI Changes

- [ ] Has been reviewed against Designs
- [ ] Necessary updates to styleguide
